### PR TITLE
feat: expose configurable major grid options in stat plots

### DIFF
--- a/R/CCCStatPlot.R
+++ b/R/CCCStatPlot.R
@@ -49,6 +49,11 @@
 #' @param font.size Base font size.
 #' @param theme_use Theme function used for styling.
 #' @param theme_args Arguments passed to the theme function.
+#' @param grid_major Whether to show major panel grid lines for applicable statistical panels.
+#' Default is `TRUE`.
+#' @param grid_major_colour Color of major panel grid lines.
+#' @param grid_major_linetype Linetype of major panel grid lines.
+#' @param grid_major_linewidth Line width of major panel grid lines.
 #' @param verbose Whether to print messages.
 #' @param combine Whether to combine multiple panels.
 #' @param nrow Number of rows in combined layout.
@@ -235,6 +240,10 @@ CCCStatPlot <- function(
   font.size = 10,
   theme_use = "theme_scop",
   theme_args = list(),
+  grid_major = TRUE,
+  grid_major_colour = "grey80",
+  grid_major_linetype = 2,
+  grid_major_linewidth = 0.3,
   combine = TRUE,
   nrow = NULL,
   ncol = NULL,
@@ -477,7 +486,11 @@ CCCStatPlot <- function(
       legend.direction = legend.direction,
       font.size = font.size,
       theme_use = theme_use,
-      theme_args = theme_args
+      theme_args = theme_args,
+      grid_major = grid_major,
+      grid_major_colour = grid_major_colour,
+      grid_major_linetype = grid_major_linetype,
+      grid_major_linewidth = grid_major_linewidth
     ))
   }
 
@@ -1711,9 +1724,22 @@ ccc_stat_bar_plot <- function(
   legend.direction = "vertical",
   font.size = 10,
   theme_use = "theme_scop",
-  theme_args = list()
+  theme_args = list(),
+  grid_major = TRUE,
+  grid_major_colour = "grey80",
+  grid_major_linetype = 2,
+  grid_major_linewidth = 0.3
 ) {
   check_r("thisplot", verbose = FALSE)
+  grid_major_element <- if (isTRUE(grid_major)) {
+    ggplot2::element_line(
+      colour = grid_major_colour,
+      linetype = grid_major_linetype,
+      linewidth = grid_major_linewidth
+    )
+  } else {
+    ggplot2::element_blank()
+  }
   if (identical(stat_type, "count")) {
     agg <- group_summary(
       df = df,
@@ -1772,7 +1798,11 @@ ccc_stat_bar_plot <- function(
       legend.position = legend.position,
       legend.direction = legend.direction,
       theme_use = theme_use,
-      theme_args = theme_args
+      theme_args = theme_args,
+      grid_major = grid_major,
+      grid_major_colour = grid_major_colour,
+      grid_major_linetype = grid_major_linetype,
+      grid_major_linewidth = grid_major_linewidth
     )
     return(p)
   }
@@ -1806,7 +1836,8 @@ ccc_stat_bar_plot <- function(
     theme_use = theme_use,
     theme_args = theme_args,
     font.size = font.size
-  )
+  ) +
+    ggplot2::theme(panel.grid.major = grid_major_element)
 }
 
 ccc_stat_distribution_plot <- function(

--- a/R/CellStatPlot.R
+++ b/R/CellStatPlot.R
@@ -17,6 +17,11 @@
 #' @param label.fg The foreground color of the labels.
 #' @param label.bg The background color of the labels.
 #' @param label.bg.r The radius of the rounded corners of the label background.
+#' @param grid_major Whether to show major panel grid lines.
+#' Default is `TRUE`.
+#' @param grid_major_colour Color of major panel grid lines.
+#' @param grid_major_linetype Linetype of major panel grid lines.
+#' @param grid_major_linewidth Line width of major panel grid lines.
 #'
 #' @seealso [FeatureStatPlot]
 #'
@@ -320,6 +325,10 @@ CellStatPlot <- function(
     legend.direction = "vertical",
     theme_use = "theme_scop",
     theme_args = list(),
+    grid_major = TRUE,
+    grid_major_colour = "grey80",
+    grid_major_linetype = 2,
+    grid_major_linewidth = 0.3,
     combine = TRUE,
     nrow = NULL,
     ncol = NULL,
@@ -374,6 +383,10 @@ CellStatPlot <- function(
     legend.direction = legend.direction,
     theme_use = theme_use,
     theme_args = theme_args,
+    grid_major = grid_major,
+    grid_major_colour = grid_major_colour,
+    grid_major_linetype = grid_major_linetype,
+    grid_major_linewidth = grid_major_linewidth,
     combine = combine,
     nrow = nrow,
     ncol = ncol,

--- a/R/ExpressionStatPlot.R
+++ b/R/ExpressionStatPlot.R
@@ -70,6 +70,10 @@ ExpressionStatPlot <- function(
     legend.title = NULL,
     theme_use = "theme_scop",
     theme_args = list(),
+    grid_major = TRUE,
+    grid_major_colour = "grey80",
+    grid_major_linetype = 2,
+    grid_major_linewidth = 0.3,
     force = FALSE,
     seed = 11) {
   set.seed(seed)
@@ -79,6 +83,15 @@ ExpressionStatPlot <- function(
   fill.by <- match.arg(fill.by)
   sig_label <- match.arg(sig_label)
   add_stat <- match.arg(add_stat)
+  grid_major_element <- if (isTRUE(grid_major)) {
+    element_line(
+      colour = grid_major_colour,
+      linetype = grid_major_linetype,
+      linewidth = grid_major_linewidth
+    )
+  } else {
+    element_blank()
+  }
   if (!is.null(add_line)) {
     stopifnot(is.numeric(add_line))
   }
@@ -1123,7 +1136,8 @@ ExpressionStatPlot <- function(
               aspect.ratio = aspect.ratio,
               axis.text.x = element_text(angle = 90, hjust = 1),
               strip.text.x = element_text(angle = 90),
-              panel.grid.major.x = element_line(color = "grey", linetype = 2),
+              panel.grid.major = element_blank(),
+              panel.grid.major.x = grid_major_element,
               legend.position = legend.position,
               legend.direction = legend.direction
             ) +
@@ -1135,7 +1149,8 @@ ExpressionStatPlot <- function(
               aspect.ratio = aspect.ratio,
               axis.text.x = element_text(angle = 45, hjust = 1, vjust = 1),
               strip.text.y = element_text(angle = 0),
-              panel.grid.major.x = element_line(color = "grey", linetype = 2),
+              panel.grid.major = element_blank(),
+              panel.grid.major.x = grid_major_element,
               legend.position = legend.position,
               legend.direction = legend.direction
             ) +
@@ -1148,7 +1163,8 @@ ExpressionStatPlot <- function(
             aspect.ratio = aspect.ratio,
             axis.text.x = element_text(angle = 45, hjust = 1, vjust = 1),
             strip.text.y = element_text(angle = 0),
-            panel.grid.major.y = element_line(color = "grey", linetype = 2),
+            panel.grid.major = element_blank(),
+            panel.grid.major.y = grid_major_element,
             legend.position = legend.position,
             legend.direction = legend.direction
           ) +

--- a/R/FeatureStatPlot.R
+++ b/R/FeatureStatPlot.R
@@ -122,6 +122,11 @@
 #' Default is `NULL`.
 #' @param ylab A string specifying the label of the y-axis.
 #' Default is `"Expression level"`.
+#' @param grid_major Whether to show major panel grid lines.
+#' Default is `TRUE`.
+#' @param grid_major_colour Color of major panel grid lines.
+#' @param grid_major_linetype Linetype of major panel grid lines.
+#' @param grid_major_linewidth Line width of major panel grid lines.
 #'
 #' @seealso
 #' [CellStatPlot]
@@ -473,6 +478,10 @@ FeatureStatPlot <- function(
     legend.title = NULL,
     theme_use = "theme_scop",
     theme_args = list(),
+    grid_major = TRUE,
+    grid_major_colour = "grey80",
+    grid_major_linetype = 2,
+    grid_major_linewidth = 0.3,
     combine = TRUE,
     nrow = NULL,
     ncol = NULL,
@@ -615,6 +624,10 @@ FeatureStatPlot <- function(
           legend.title = legend.title,
           theme_use = theme_use,
           theme_args = theme_args,
+          grid_major = grid_major,
+          grid_major_colour = grid_major_colour,
+          grid_major_linetype = grid_major_linetype,
+          grid_major_linewidth = grid_major_linewidth,
           force = force,
           seed = seed
         )
@@ -695,6 +708,10 @@ FeatureStatPlot <- function(
       legend.title = legend.title,
       theme_use = theme_use,
       theme_args = theme_args,
+      grid_major = grid_major,
+      grid_major_colour = grid_major_colour,
+      grid_major_linetype = grid_major_linetype,
+      grid_major_linewidth = grid_major_linewidth,
       force = force,
       seed = seed
     )

--- a/man/CCCStatPlot.Rd
+++ b/man/CCCStatPlot.Rd
@@ -46,6 +46,10 @@ CCCStatPlot(
   font.size = 10,
   theme_use = "theme_scop",
   theme_args = list(),
+  grid_major = TRUE,
+  grid_major_colour = "grey80",
+  grid_major_linetype = 2,
+  grid_major_linewidth = 0.3,
   combine = TRUE,
   nrow = NULL,
   ncol = NULL,
@@ -146,6 +150,15 @@ interactions).}
 \item{theme_use}{Theme function used for styling.}
 
 \item{theme_args}{Arguments passed to the theme function.}
+
+\item{grid_major}{Whether to show major panel grid lines for applicable statistical panels.
+Default is \code{TRUE}.}
+
+\item{grid_major_colour}{Color of major panel grid lines.}
+
+\item{grid_major_linetype}{Linetype of major panel grid lines.}
+
+\item{grid_major_linewidth}{Line width of major panel grid lines.}
 
 \item{combine}{Whether to combine multiple panels.}
 

--- a/man/CellStatPlot.Rd
+++ b/man/CellStatPlot.Rd
@@ -41,6 +41,10 @@ CellStatPlot(
   legend.direction = "vertical",
   theme_use = "theme_scop",
   theme_args = list(),
+  grid_major = TRUE,
+  grid_major_colour = "grey80",
+  grid_major_linetype = 2,
+  grid_major_linewidth = 0.3,
   combine = TRUE,
   nrow = NULL,
   ncol = NULL,
@@ -149,6 +153,15 @@ Default is \code{"theme_scop"}.}
 
 \item{theme_args}{Other arguments passed to the \code{theme_use}.
 Default is \code{list()}.}
+
+\item{grid_major}{Whether to show major panel grid lines.
+Default is \code{TRUE}.}
+
+\item{grid_major_colour}{Color of major panel grid lines.}
+
+\item{grid_major_linetype}{Linetype of major panel grid lines.}
+
+\item{grid_major_linewidth}{Line width of major panel grid lines.}
 
 \item{combine}{Combine plots into a single \code{patchwork} object.
 If \code{FALSE}, return a list of ggplot objects.}

--- a/man/FeatureStatPlot.Rd
+++ b/man/FeatureStatPlot.Rd
@@ -77,6 +77,10 @@ FeatureStatPlot(
   legend.title = NULL,
   theme_use = "theme_scop",
   theme_args = list(),
+  grid_major = TRUE,
+  grid_major_colour = "grey80",
+  grid_major_linetype = 2,
+  grid_major_linewidth = 0.3,
   combine = TRUE,
   nrow = NULL,
   ncol = NULL,
@@ -310,6 +314,15 @@ Default is \code{"theme_scop"}.}
 
 \item{theme_args}{Other arguments passed to the \code{theme_use}.
 Default is \code{list()}.}
+
+\item{grid_major}{Whether to show major panel grid lines.
+Default is \code{TRUE}.}
+
+\item{grid_major_colour}{Color of major panel grid lines.}
+
+\item{grid_major_linetype}{Linetype of major panel grid lines.}
+
+\item{grid_major_linewidth}{Line width of major panel grid lines.}
 
 \item{combine}{Combine plots into a single \code{patchwork} object.
 If \code{FALSE}, return a list of ggplot objects.}


### PR DESCRIPTION
## Summary
- expose major grid configuration options in `CellStatPlot()`
- expose major grid configuration options in `FeatureStatPlot()` and internal `ExpressionStatPlot()`
- expose major grid configuration options in `CCCStatPlot()` bar plots
- update related documentation