### PR TITLE
perf: R-level optimizations and Seurat v4 compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: scop
 Type: Package
 Title: Single Cell Omics analysis Pipeline
-Version: 0.8.7
-Date: 2026-03-31
+Version: 0.8.9
+Date: 2026-05-02
 Authors@R:
     c(
     person(given = "Xu", family = "Meng", email = "mengxu98@qq.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-8300-1054")),
@@ -36,22 +36,26 @@ Imports:
     methods,
     mgcv,
     Matrix,
+    Rcpp,
     Signac,
     Seurat,
     SeuratObject,
-    thisplot (>= 0.3.7),
-    thisutils (>= 0.4.4),
+    thisplot (>= 0.3.8),
+    thisutils (>= 0.4.5),
     uwot
 Suggests:
     AnnotationDbi,
     AUCell,
+    BayesSpace,
     batchelor,
     biomaRt,
     CellChat,
     Coralysis,
     circlize,
     clusterProfiler,
+    decoupleR,
     e1071,
+    dorothea,
     ggpubr,
     ggalluvial,
     ggridges,
@@ -87,12 +91,18 @@ Suggests:
     R.cache,
     R.utils,
     reshape2,
+    RhpcBLASctl,
     rliger,
     rhdf5,
+    RSpectra,
     scales,
+    scTenifoldKnk,
+    scTenifoldNet,
     simplifyEnrichment,
     slingshot,
     scattermore,
+    scran,
+    scuttle,
     scds,
     scDblFinder,
     decontX,
@@ -107,11 +117,18 @@ Suggests:
     speckle,
     SingleR,
     SingleCellExperiment,
+    SpatialExperiment,
     SummarizedExperiment,
     testthat,
     tensorflow,
+    tricycle,
     umap,
     UCell
+LinkingTo:
+    Rcpp,
+    RcppArmadillo,
+    RcppEigen,
+    RSpectra
 Remotes:
     jinworks/CellChat,
     saeyslab/multinichenetr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,62 @@
 # scop
 
+# scop 0.8.9
+
+* **perf**:
+  * `RunGSVA()`: Removed redundant dense `as.matrix()` conversion in single-cell mode for `backend = "r"`; sparse expression matrices now stay sparse through row filtering, reducing peak memory and avoiding unnecessary dense materialization.
+  * `RunCellQC()`: Replaced `Seurat::SplitObject()` with lazy cell-name-based subsetting, avoiding full-object duplication per split group. Added caching of `GetAssay()` gene names, `GetAssayData5()` counts, and per-cell QC metrics (`nCount` / `nFeature`) outside the species-check loop to eliminate repeated data extraction.
+  * `RunDEtest()`: Pre-computed cell index mapping (`split(names(cell_group), cell_group)`) for paired-marker tests, replacing per-pair `which()` calls with O(1) list lookups.
+  * `AnnotateFeatures()`: Replaced per-detail `sapply(… "[")` with type-stable `vapply(…, character(1))` to avoid implicit list-to-character coercion.
+  * `run_scomm()`: Deferred dense conversion for reference and query subsetting by removing premature `as.matrix()` calls; sparse matrices are subset first, then densified only when required.
+  * `RunUMAP2()`: Replaced `isSymmetric(as.matrix(graph))` with sparse-native `Matrix::isSymmetric(graph)` in symmetry checks and graph subset sampling, avoiding dense materialization of large neighbor graphs.
+  * `RunUMAP2()`: Replaced `apply(as.matrix(graph), 2, order)` in the uwot-predict path with the internal C++ sparse column top-k helper (`run_sparse_topk_by_column_cpp()`), avoiding full dense conversion and column-wise R-level `apply()`.
+  * `RunDimsReduction()` (PCA centering): Uses `SeuratObject::LayerData(…, features = features)` to read only HVF rows from `scale.data` instead of loading the full matrix followed by manual subsetting.
+  * `RunMDS()`: Removed `as.matrix()` before `Matrix::t()`; `proxyC::dist` now receives the sparse matrix directly, avoiding dense conversion of large count matrices.
+  * `integration.R` (fastMNN): Removed three `as.matrix()` calls passed to `batchelor::fastMNN()`, which accepts sparse matrices natively via `SingleCellExperiment`.
+
+* **memory**:
+  * `standard_scop()`: Replaced full `scale.data` matrix load (via `GetAssayData5()`) with direct layer access (`SeuratObject::GetAssayData` for Assay5; `@scale.data` for Assay) to retrieve only rownames when checking whether HVFs have been scaled, substantially reducing peak memory during the ScaleData decision step.
+
+* **compat**:
+  * `GetAssayData5.Assay()`: Fixed parameter naming to use positional matching for the slot/layer argument, so `GetAssayData5()` correctly retrieves `counts`, `data`, and `scale.data` layers in both Seurat v4 (`slot`) and v5 (`layer`). Previously the named `layer` argument was silently dropped by SeuratObject v4, always returning the `data` slot regardless of the requested layer.
+  * `CSS_integrate()`: Added `Assay5` guard before `SeuratObject::JoinLayers()` to avoid errors with Seurat v4 `Assay` objects, which do not support layered storage.
+  * `RunDimsReduction()`: Added Seurat v4 fallback for PCA centering — `SeuratObject::LayerData(…, features = …)` is Assay5-only; v4 `Assay` objects now use `GetAssayData5()` with manual feature subsetting.
+  * `integration_scop()`: Added early detection for v5-only integration methods (`CCA`, `RPCA`, `fastMNN5`, `Harmony5`, `scVI5`) to provide a clear, actionable error message when used with Seurat v4 `Assay` objects, rather than failing deep in the call stack.
+
+* **test**:
+  * Added 22 consistency tests (`test_optimizations_v2.R`) covering GSVA sparse, RunCellQC caching, DEtest cell_index, AnnotateFeatures vapply, run_scomm sparse, RunDynamicFeatures solve, and cccplot validations.
+  * Added 5 dim-reduction optimization consistency tests (`test_dim_reduction_optimizations.R`) covering UMAP isSymmetric, scale.data rownames, MDS sparse distance, uwot-predict C++ topk, and PCA centering with features parameter.
+  * Added 10 Seurat v4 compatibility tests (`test_seurat_v4_compat.R`) run against a real Seurat v4.4.0 + SeuratObject v4.1.4 installation, verifying Assay object handling, `GetAssayData` slot access, PCA centering fallback, `JoinLayers` guard, sparse matrix operations, and UMAP/MDS execution.
+
 # scop 0.8.8
 
+* **deps**:
+  * Updated the minimum dependency versions to `thisplot (>= 0.3.8)` and `thisutils (>= 0.4.5)`, and removed local copies of helpers now provided upstream (`thisplot::annotate_quadrants()`, `thisplot::clip_symmetric_range()`, `thisutils::collapse_sparse_rows()`).
+
+* **docs**:
+  * Updated pkgdown reference grouping for the cell-cycle workflow.
+
 * **fix**:
+  * Added optional wrappers for `RunDorothea()`, `RunBayesSpace()`, and experimental `RunScTenifoldKnk()`. `RunScTenifoldKnk()` keeps the upstream `scTenifoldNet` workflow but fixes the QC gene-filter assignment in the local path, uses a native equivalent covariance/downdate path with direct sparse matrix construction, selection-based quantile thresholding, and controlled per-gene eigensolver parallelism for large `pcNet()` network construction, and uses native helpers for tensor decomposition, manifold matrix construction, directionality, and differential-regulation distance calculations. The native tensor-decomposition path now computes MTTKRP updates directly instead of materializing four dense unfolding matrices.
+  * `PrepareEnv()`: Added explicit support for `mamba` and `micromamba` executables in addition to `conda`, including command-name resolution, automatic package-managed micromamba download when `conda = "micromamba"` is requested and the command is not on `PATH`, manager-aware logging, micromamba env path detection, and ToS handling that only runs for standard conda. Package-managed micromamba environments now use a no-space cache root to avoid `micromamba run -p` path parsing failures. `PrepareEnv()` now also stops early if reticulate has already initialized a different Python executable, avoiding unsafe in-session switches between conda and micromamba. The Python stack now also pins `setuptools < 81` so legacy packages such as `trimap` can still import `pkg_resources`.
+  * `PrepareEnv()`: The default `modules = NULL` environment no longer includes `scomm`; install it explicitly with `modules = "scomm"` because the TensorFlow/scOMM stack conflicts with the default JAX/scVI stack through incompatible `ml-dtypes` requirements.
+  * `CheckDataList()` / `standard_scop()`: Removed an unnecessary all-feature `ScaleData()` call immediately after `LogNormalize`. Downstream workflows still scale the selected HVFs before PCA, but large raw-count inputs no longer create a dense all-gene `scale.data` intermediate during checking.
+  * `srt_reorder()`: Replaced per-cluster repeated sparse subsetting and `rowMeans()` with a single sparse group-membership matrix multiplication, speeding the cluster-reordering step used by `standard_scop()` while preserving average expression values.
+  * `FindExpressedMarkers()`: Added a sparse fold-change and detection-rate prefilter path for common sparse RNA inputs, avoiding dense all-feature expression materialization before marker filtering while preserving default results. Supplied features are now intersected with the active layer before dense fallback scoring, which also keeps `scale.data` and partial-feature layers from passing absent rows into fold-change calculation.
+  * C++-accelerated backends are now the default where available: `RunMetabolism()`, `RunGSVA()`, `CellScoring()`, `RunDynamicEnrichment()`, `RunEnrichment()`, and `RunProportionTestPermutation()` now prefer `backend = "cpp"` while retaining `backend = "r"` for exact legacy/package behavior. Unsupported C++ methods such as metabolism `VISION` and cell scoring `UCell` automatically fall back to R when `backend` is not explicitly set.
+  * `RunMetabolism()` and `RunGSVA()`: Added a reusable C++ gene-set scoring backend for `ssGSEA`, `zscore`, and `plage`; `RunGSVA()` can now use `backend = "cpp"` for `method = "ssgsea"`, `method = "zscore"`, `method = "plage"`, and Gaussian- or Poisson-kernel `method = "gsva"`. PLAGE scores are oriented by the gene set mean z-score to avoid backend-dependent sign flips.
+  * `RunMetabolism()` and `RunGSVA()`: Added `cpp_chunk_size` for the C++ GSVA kernel paths to reduce peak dense intermediate memory on large cell counts; `NULL` now auto-selects a chunk size for large matrices.
+  * `RunEnrichment()`: Added an experimental `backend = "cpp"` ORA path using a native hypergeometric implementation for faster enrichment tables while keeping `backend = "r"` available as the clusterProfiler-compatible path.
+  * `CellScoring()`: Added experimental `backend = "cpp"` support for Seurat-style module scoring by keeping control-gene sampling in R and moving sparse mean calculations to native code.
+  * `RunProportionTestPermutation()`: Added experimental `backend = "cpp"` for faster permutation and bootstrap loops.
+  * `RunUMAP2()`: Added an internal C++ sparse column top-k helper for Graph inputs to speed extraction of precomputed neighbor indices/connectivities before calling `uwot`.
+  * `RunKNNMap()` and `RunKNNPredict()`: Added an internal C++ dense column top-k helper for the raw KNN fallback to speed nearest-neighbor extraction from precomputed distance matrices.
+  * `PseudotimeProjectionPlot()`: Reused the internal dense top-k helper for pseudotime KNN/gradient neighbor extraction from distance matrices.
+  * Mapping/integration metrics: Added an internal C++ contingency-table helper for `metric_accuracy()`, `metric_macro_f1()`, `metric_purity()`, `metric_nmi()`, `metric_ari()`, `metric_weighted_recall()`, and `collect_mapping_metrics()`.
+  * `RunMetabolism()`: Added a C++ backend for `method = "GSVA"` that keeps the Poisson-kernel GSVA scoring path but accelerates repeated count-kernel calculations.
+  * `RunMetabolism()` and `CellScoring()`: Added an experimental C++ backend for AUCell scoring via `backend = "cpp"` with selectable `cpp_strategy` values (`"sparse"`, `"topk"`, `"full"`), while keeping the original R/AUCell implementation available via `backend = "r"` for exact package output. `RunDynamicEnrichment()` now passes this backend through to AUCell-based scoring.
+  * `CellScoring(method = "AUCell")`: Fixed score-name assignment when only one feature list is scored, avoiding vector dropping before metadata column names are applied.
+  * `RunMetabolism(method = "VISION")`: Fixed signature construction so in-memory gene sets are passed as `VISION::Signature` objects instead of being interpreted as file paths.
   * `DynamicHeatmap()` / custom enrichment workflows: Fixed incorrect term label display when user-provided `TERM2GENE` / `TERM2NAME` use non-standard column names such as `term` / `name`. Custom term annotations are now normalized consistently so that heatmap term labels show readable term names instead of fallback IDs (e.g. GO IDs). Related issue #160 (@Pineapple-wen6, @mengxu98).
   * Refactored repeated custom database input handling by introducing shared internal helpers for normalizing and assembling user-provided `TERM2GENE` / `TERM2NAME`, and applied them across `RunEnrichment()`, `RunDynamicEnrichment()`, `RunGSEA()`, `RunGSVA()`, and `PrepareDB()` to keep behavior consistent.
   * `integration_scop()`: Improved `ChromatinAssay` handling by standardizing ATAC reductions after integration, avoiding non-interactive small-batch blocking, clipping `TFIDF/rlsi` anchor dims to available cells, auto-switching `Harmony5` to legacy `Harmony`, and rejecting unsupported `Seurat` / `RPCA` ATAC paths with explicit messages.

--- a/R/AnnotateFeatures.R
+++ b/R/AnnotateFeatures.R
@@ -193,7 +193,7 @@ AnnotateFeatures <- function(
       gtf_attribute, function(x) {
         detail <- strsplit(x, " ")
         out <- lapply(detail, function(x) x[2:length(x)])
-        names(out) <- sapply(detail, function(x) x[1])
+        names(out) <- vapply(detail, function(x) x[1], character(1))
         out[intersect(columns, names(out))]
       }
     )

--- a/R/GetAssayData5.R
+++ b/R/GetAssayData5.R
@@ -80,7 +80,7 @@ GetAssayData5.Assay <- function(
 ) {
   SeuratObject::GetAssayData(
     object,
-    layer = layer,
+    layer,
     ...
   )
 }

--- a/R/RunCellQC.R
+++ b/R/RunCellQC.R
@@ -977,15 +977,19 @@ RunCellQC <- function(
   }
   srt_raw <- srt
   if (!is.null(split.by)) {
-    srt_list <- Seurat::SplitObject(srt, split.by = split.by)
+    split_cells <- split(colnames(srt), srt@meta.data[[split.by]])
   } else {
-    srt_list <- list(srt)
+    split_cells <- list(colnames(srt))
   }
+  srt_list <- vector("list", length(split_cells))
+  names(srt_list) <- names(split_cells)
 
-  for (i in seq_along(srt_list)) {
-    srt <- srt_list[[i]]
+  for (i in seq_along(split_cells)) {
     if (!is.null(split.by)) {
+      srt <- srt_raw[, split_cells[[i]]]
       log_message("Running QC for {.val {srt@meta.data[[split.by]][1]}}")
+    } else {
+      srt <- srt_raw
     }
     ntotal <- ncol(srt)
 
@@ -1135,6 +1139,8 @@ RunCellQC <- function(
       }
     }
 
+    assay_genes <- rownames(Seurat::GetAssay(srt, assay = assay))
+    counts_mat <- GetAssayData5(srt, assay = assay, layer = "counts")
     outlier_qc <- c()
     for (n in 1:length(species)) {
       if (n == 0) {
@@ -1142,39 +1148,18 @@ RunCellQC <- function(
       }
       sp <- species[n]
       prefix <- species_gene_prefix[n]
-      sp_genes <- rownames(
-        Seurat::GetAssay(
-          srt,
-          assay = assay
-        )
-      )[grep(
-        pattern = paste0("^", prefix),
-        x = rownames(
-          Seurat::GetAssay(
-            srt,
-            assay = assay
-          )
-        )
-      )]
+      sp_genes <- assay_genes[grep(pattern = paste0("^", prefix), x = assay_genes)]
       nCount <- srt[[paste0(
         c(paste0("nCount_", assay), sp),
         collapse = "."
       )]] <- Matrix::colSums(
-        GetAssayData5(
-          srt,
-          assay = assay,
-          layer = "counts"
-        )[sp_genes, ]
+        counts_mat[sp_genes, , drop = FALSE]
       )
       nFeature <- srt[[paste0(
         c(paste0("nFeature_", assay), sp),
         collapse = "."
       )]] <- Matrix::colSums(
-        GetAssayData5(
-          srt,
-          assay = assay,
-          layer = "counts"
-        )[sp_genes, ] >
+        counts_mat[sp_genes, , drop = FALSE] >
           0
       )
       percent.mito <- srt[[paste0(

--- a/R/RunDEtest.R
+++ b/R/RunDEtest.R
@@ -44,6 +44,7 @@ PerformDE <- function(
   verbose,
   min.cells.feature,
   latent.vars,
+  min.expression = 0,
   ...
 ) {
   if (
@@ -62,7 +63,11 @@ PerformDE <- function(
     c(cells.1, cells.2),
     drop = FALSE
   ]
-  data.use <- as_matrix(data.use)
+  dense_data_use <- function() {
+    data.use_dense <- as_matrix(data.use)
+    data.use_dense[data.use_dense <= min.expression] <- NA
+    data.use_dense
+  }
 
   de.results <- switch(
     EXPR = test.use,
@@ -70,13 +75,14 @@ PerformDE <- function(
       data.use = data.use,
       cells.1 = cells.1,
       cells.2 = cells.2,
+      min.expression = min.expression,
       verbose = verbose,
       ...
     ),
     "bimod" = get_namespace_fun(
       "Seurat", "DiffExpTest"
     )(
-      data.use = data.use,
+      data.use = dense_data_use(),
       cells.1 = cells.1,
       cells.2 = cells.2,
       verbose = verbose
@@ -84,7 +90,7 @@ PerformDE <- function(
     "roc" = get_namespace_fun(
       "Seurat", "MarkerTest"
     )(
-      data.use = data.use,
+      data.use = dense_data_use(),
       cells.1 = cells.1,
       cells.2 = cells.2,
       verbose = verbose
@@ -92,7 +98,7 @@ PerformDE <- function(
     "t" = get_namespace_fun(
       "Seurat", "DiffTTest"
     )(
-      data.use = data.use,
+      data.use = dense_data_use(),
       cells.1 = cells.1,
       cells.2 = cells.2,
       verbose = verbose
@@ -100,7 +106,7 @@ PerformDE <- function(
     "negbinom" = get_namespace_fun(
       "Seurat", "GLMDETest"
     )(
-      data.use = data.use,
+      data.use = dense_data_use(),
       cells.1 = cells.1,
       cells.2 = cells.2,
       min.cells = min.cells.feature,
@@ -111,7 +117,7 @@ PerformDE <- function(
     "poisson" = get_namespace_fun(
       "Seurat", "GLMDETest"
     )(
-      data.use = data.use,
+      data.use = dense_data_use(),
       cells.1 = cells.1,
       cells.2 = cells.2,
       min.cells = min.cells.feature,
@@ -122,7 +128,7 @@ PerformDE <- function(
     "MAST" = get_namespace_fun(
       "Seurat", "MASTDETest"
     )(
-      data.use = data.use,
+      data.use = dense_data_use(),
       cells.1 = cells.1,
       cells.2 = cells.2,
       latent.vars = latent.vars,
@@ -132,7 +138,7 @@ PerformDE <- function(
     "DESeq2" = get_namespace_fun(
       "Seurat", "DESeq2DETest"
     )(
-      data.use = data.use,
+      data.use = dense_data_use(),
       cells.1 = cells.1,
       cells.2 = cells.2,
       verbose = verbose,
@@ -141,7 +147,7 @@ PerformDE <- function(
     "LR" = get_namespace_fun(
       "Seurat", "LRDETest"
     )(
-      data.use = data.use,
+      data.use = dense_data_use(),
       cells.1 = cells.1,
       cells.2 = cells.2,
       latent.vars = latent.vars,
@@ -159,10 +165,29 @@ WilcoxDETest <- function(
   data.use,
   cells.1,
   cells.2,
+  min.expression = 0,
   verbose = TRUE,
   ...
 ) {
   data.use <- data.use[, c(cells.1, cells.2), drop = FALSE]
+  if (
+    inherits(data.use, "sparseMatrix") &&
+      isTRUE(min.expression >= 0) &&
+      run_sparse_wilcox_cpp_available()
+  ) {
+    p_val <- run_sparse_wilcox_cpp(
+      x = data.use,
+      n_group1 = length(cells.1),
+      min.expression = min.expression
+    )
+    return(data.frame(
+      p_val = p_val,
+      row.names = names(p_val)
+    ))
+  }
+
+  data.use <- as_matrix(data.use)
+  data.use[data.use <= min.expression] <- NA
   check_r("limma", verbose = FALSE)
   p_val <- parallelize_fun(
     seq_len(nrow(data.use)),
@@ -187,6 +212,269 @@ WilcoxDETest <- function(
   )
 }
 
+RunDEtestFindMarkers <- function(
+  srt,
+  assay,
+  layer,
+  cells.1,
+  cells.2,
+  features,
+  test.use,
+  logfc.threshold,
+  base,
+  min.pct,
+  min.diff.pct,
+  max.cells.per.ident,
+  min.cells.feature,
+  min.cells.group,
+  latent.vars,
+  only.pos,
+  norm.method,
+  pseudocount.use,
+  mean.fxn,
+  verbose,
+  random.seed = 1,
+  ...
+) {
+  extra_args <- list(...)
+  use_sparse_wilcox <- identical(test.use, "wilcox") &&
+    is.null(latent.vars) &&
+    is.null(mean.fxn) &&
+    layer %in% c("data", "counts") &&
+    identical(norm.method, "LogNormalize") &&
+    length(extra_args) == 0 &&
+    !requireNamespace("presto", quietly = TRUE) &&
+    run_sparse_wilcox_all_cells_cpp_available()
+  if (isTRUE(use_sparse_wilcox)) {
+    return(RunDEtestSparseWilcoxMarkers(
+      srt = srt,
+      assay = assay,
+      layer = layer,
+      cells.1 = cells.1,
+      cells.2 = cells.2,
+      features = features,
+      logfc.threshold = logfc.threshold,
+      base = base,
+      min.pct = min.pct,
+      min.diff.pct = min.diff.pct,
+      max.cells.per.ident = max.cells.per.ident,
+      min.cells.group = min.cells.group,
+      only.pos = only.pos,
+      pseudocount.use = pseudocount.use,
+      random.seed = random.seed,
+      verbose = verbose
+    ))
+  }
+
+  do.call(
+    Seurat::FindMarkers,
+    c(
+      list(
+        object = Seurat::GetAssay(srt, assay),
+        layer = layer,
+        cells.1 = cells.1,
+        cells.2 = cells.2,
+        features = features,
+        test.use = test.use,
+        logfc.threshold = logfc.threshold,
+        base = base,
+        min.pct = min.pct,
+        min.diff.pct = min.diff.pct,
+        max.cells.per.ident = max.cells.per.ident,
+        min.cells.feature = min.cells.feature,
+        min.cells.group = min.cells.group,
+        latent.vars = latent.vars,
+        only.pos = only.pos,
+        norm.method = norm.method,
+        pseudocount.use = pseudocount.use,
+        mean.fxn = mean.fxn,
+        verbose = verbose,
+        random.seed = random.seed
+      ),
+      extra_args
+    )
+  )
+}
+
+RunDEtestSparseWilcoxMarkers <- function(
+  srt,
+  assay,
+  layer,
+  cells.1,
+  cells.2,
+  features,
+  logfc.threshold,
+  base,
+  min.pct,
+  min.diff.pct,
+  max.cells.per.ident,
+  min.cells.group,
+  only.pos,
+  pseudocount.use,
+  random.seed,
+  verbose
+) {
+  data.use <- GetAssayData5(
+    object = srt,
+    assay = assay,
+    layer = layer
+  )
+  features <- features %||% rownames(data.use)
+  missing_features <- setdiff(features, rownames(data.use))
+  if (length(missing_features) > 0) {
+    log_message(
+      "{.arg features} contains features not present in the selected assay/layer",
+      message_type = "error"
+    )
+  }
+
+  ValidateCellGroups <- get_namespace_fun("Seurat", "ValidateCellGroups")
+  ValidateCellGroups(
+    object = data.use,
+    cells.1 = cells.1,
+    cells.2 = cells.2,
+    min.cells.group = min.cells.group
+  )
+
+  fc.results <- RunDEtestSparseFoldChange(
+    object = data.use,
+    cells.1 = cells.1,
+    cells.2 = cells.2,
+    features = features,
+    layer = layer,
+    pseudocount.use = pseudocount.use,
+    base = base
+  )
+
+  alpha.min <- pmax(fc.results$pct.1, fc.results$pct.2)
+  names(alpha.min) <- rownames(fc.results)
+  features <- names(alpha.min)[alpha.min >= min.pct]
+  if (length(features) == 0) {
+    return(fc.results[features, , drop = FALSE])
+  }
+  alpha.diff <- alpha.min - pmin(fc.results$pct.1, fc.results$pct.2)
+  features <- names(alpha.min)[alpha.min >= min.pct & alpha.diff >= min.diff.pct]
+  if (length(features) == 0) {
+    return(fc.results[features, , drop = FALSE])
+  }
+
+  fc_col <- colnames(fc.results)[1]
+  total.diff <- fc.results[[fc_col]]
+  names(total.diff) <- rownames(fc.results)
+  features.diff <- if (isTRUE(only.pos)) {
+    names(total.diff)[total.diff >= logfc.threshold]
+  } else {
+    names(total.diff)[abs(total.diff) >= logfc.threshold]
+  }
+  features <- intersect(features, features.diff)
+  if (length(features) == 0) {
+    return(fc.results[features, , drop = FALSE])
+  }
+
+  if (max.cells.per.ident < Inf) {
+    if (!is.null(random.seed)) {
+      set.seed(random.seed)
+    }
+    if (length(cells.1) > max.cells.per.ident) {
+      cells.1 <- sample(cells.1, size = max.cells.per.ident)
+    }
+    if (length(cells.2) > max.cells.per.ident) {
+      cells.2 <- sample(cells.2, size = max.cells.per.ident)
+    }
+  }
+
+  data.de <- data.use[features, c(cells.1, cells.2), drop = FALSE]
+  p_val <- run_sparse_wilcox_all_cells_cpp(
+    x = data.de,
+    n_group1 = length(cells.1)
+  )
+  de.results <- data.frame(
+    p_val = p_val,
+    row.names = names(p_val)
+  )
+  de.results <- cbind(
+    de.results,
+    fc.results[rownames(de.results), , drop = FALSE]
+  )
+  de.results <- de.results[order(de.results$p_val, -de.results[[fc_col]]), ]
+  de.results$p_val_adj <- stats::p.adjust(
+    p = de.results$p_val,
+    method = "bonferroni",
+    n = nrow(data.use)
+  )
+  de.results
+}
+
+RunDEtestSparseFoldChange <- function(
+  object,
+  cells.1,
+  cells.2,
+  features,
+  layer,
+  pseudocount.use,
+  base
+) {
+  base.text <- ifelse(base == exp(1), "", base)
+  fc.name <- ifelse(
+    layer == "scale.data",
+    "avg_diff",
+    paste0("avg_log", base.text, "FC")
+  )
+  group1 <- RunDEtestSparseGroupStats(
+    object = object,
+    features = features,
+    cells = cells.1,
+    layer = layer,
+    pseudocount.use = pseudocount.use,
+    base = base
+  )
+  group2 <- RunDEtestSparseGroupStats(
+    object = object,
+    features = features,
+    cells = cells.2,
+    layer = layer,
+    pseudocount.use = pseudocount.use,
+    base = base
+  )
+  fc.results <- as.data.frame(
+    cbind(
+      group1[["mean"]] - group2[["mean"]],
+      group1[["pct"]],
+      group2[["pct"]]
+    )
+  )
+  rownames(fc.results) <- features
+  colnames(fc.results) <- c(fc.name, "pct.1", "pct.2")
+  fc.results
+}
+
+RunDEtestSparseGroupStats <- function(
+  object,
+  features,
+  cells,
+  layer,
+  pseudocount.use,
+  base
+) {
+  mat <- object[features, cells, drop = FALSE]
+  mat <- methods::as(mat, "dgCMatrix")
+  detected <- Matrix::rowSums(mat > 0)
+  pct <- round(detected / length(cells), digits = 3)
+
+  if (identical(layer, "data")) {
+    mat_sum <- mat
+    mat_sum@x <- expm1(mat_sum@x)
+    sum_vals <- Matrix::rowSums(mat_sum)
+    mean_vals <- log((sum_vals + pseudocount.use) / length(cells), base = base)
+  } else {
+    sum_vals <- Matrix::rowSums(mat)
+    mean_vals <- log((sum_vals + pseudocount.use) / length(cells), base = base)
+  }
+  names(mean_vals) <- features
+  names(pct) <- features
+  list(mean = mean_vals, pct = pct)
+}
+
 aggregate_counts_by_group <- function(counts, groups) {
   groups <- as.character(groups)
   groups <- groups[!is.na(groups)]
@@ -203,7 +491,7 @@ aggregate_counts_by_group <- function(counts, groups) {
   agg
 }
 
-RunDEtest_limma_voom <- function(
+RunDEtest_limma <- function(
   count_matrix,
   condition,
   condition1 = NULL,
@@ -340,7 +628,7 @@ RunDEtest_pseudobulk <- function(
   features = NULL,
   feature_type = "gene",
   markers_type = "all",
-  test.use = "limma_voom",
+  test.use = "limma",
   only.pos = TRUE,
   fc.threshold = 1.5,
   base = 2,
@@ -358,31 +646,31 @@ RunDEtest_pseudobulk <- function(
   }
   if (!markers_type %in% c("all")) {
     log_message(
-      "Pseudobulk differential testing currently supports only {.val all} markers.",
+      "Sample-level differential testing currently supports only {.val all} markers.",
       message_type = "error"
     )
   }
-  if (!test.use %in% c("limma_voom", "edgeR")) {
+  if (!test.use %in% c("limma", "edgeR")) {
     log_message(
-      "Pseudobulk differential testing currently supports only {.val limma_voom} and {.val edgeR}.",
+      "Sample-level differential testing currently supports only {.val limma} and {.val edgeR}.",
       message_type = "error"
     )
   }
   if (is.null(sample_col) || !sample_col %in% colnames(srt@meta.data)) {
     log_message(
-      "{.arg sample_col} must be a metadata column in {.cls Seurat} for pseudobulk analysis",
+      "{.arg sample_col} must be a metadata column in {.cls Seurat} for sample-level differential testing",
       message_type = "error"
     )
   }
   if (is.null(condition_col) || !condition_col %in% colnames(srt@meta.data)) {
     log_message(
-      "{.arg condition_col} must be a metadata column in {.cls Seurat} for pseudobulk analysis",
+      "{.arg condition_col} must be a metadata column in {.cls Seurat} for sample-level differential testing",
       message_type = "error"
     )
   }
   if (!is.null(group.by) && !group.by %in% colnames(srt@meta.data)) {
     log_message(
-      "{.arg group.by} must be a metadata column in {.cls Seurat} for pseudobulk analysis",
+      "{.arg group.by} must be a metadata column in {.cls Seurat} for sample-level differential testing",
       message_type = "error"
     )
   }
@@ -392,7 +680,7 @@ RunDEtest_pseudobulk <- function(
   features <- intersect(features, rownames(counts))
   if (length(features) == 0) {
     log_message(
-      "No valid features available for pseudobulk differential testing",
+      "No valid features available for sample-level differential testing",
       message_type = "error"
     )
   }
@@ -404,7 +692,7 @@ RunDEtest_pseudobulk <- function(
   if (is.null(condition1) || is.null(condition2)) {
     if (length(condition_levels_all) < 2) {
       log_message(
-        "Pseudobulk differential testing requires at least two condition levels",
+        "Sample-level differential testing requires at least two condition levels",
         message_type = "error"
       )
     }
@@ -413,7 +701,7 @@ RunDEtest_pseudobulk <- function(
   }
   if (identical(condition1, condition2)) {
     log_message(
-      "{.arg group1} and {.arg group2} must refer to two different condition labels in pseudobulk analysis",
+      "{.arg group1} and {.arg group2} must refer to two different condition labels in sample-level differential testing",
       message_type = "error"
     )
   }
@@ -425,7 +713,7 @@ RunDEtest_pseudobulk <- function(
   }
 
   log_message(
-    "Start pseudobulk differential testing",
+    "Start sample-level differential testing",
     verbose = verbose
   )
 
@@ -453,7 +741,7 @@ RunDEtest_pseudobulk <- function(
       sample_tab <- table(meta_use[[sample_col]], meta_use[[condition_col]])
       if (any(rowSums(sample_tab > 0) > 1)) {
         log_message(
-          "Each sample must map to a single condition in pseudobulk analysis",
+          "Each sample must map to a single condition in sample-level differential testing",
           message_type = "error"
         )
       }
@@ -470,7 +758,7 @@ RunDEtest_pseudobulk <- function(
       condition_use <- condition_map[colnames(count_matrix)]
       markers <- switch(
         test.use,
-        limma_voom = RunDEtest_limma_voom(
+        limma = RunDEtest_limma(
           count_matrix = count_matrix,
           condition = condition_use,
           condition1 = condition1,
@@ -509,7 +797,6 @@ RunDEtest_pseudobulk <- function(
   if (is.null(srt@tools[[tool_name]])) {
     srt@tools[[tool_name]] <- list()
   }
-  srt@tools[[tool_name]][["analysis_level"]] <- "pseudobulk"
   srt@tools[[tool_name]][["feature_type"]] <- feature_type
   srt@tools[[tool_name]][["sample_col"]] <- sample_col
   srt@tools[[tool_name]][["condition_col"]] <- condition_col
@@ -539,7 +826,7 @@ RunDEtest_pseudobulk <- function(
   }
 
   log_message(
-    "Pseudobulk differential testing completed",
+    "Sample-level differential testing completed",
     message_type = "success",
     verbose = verbose
   )
@@ -561,10 +848,10 @@ RunDEtest_pseudobulk <- function(
 #' If not provided, the function uses the "active.ident" variable in the Seurat object.
 #' @param group1 A vector of cell IDs or a character vector specifying the cells that belong to the first group.
 #' If both group.by and group1 are provided, group1 takes precedence.
-#' For pseudobulk analysis, this parameter is interpreted as the first condition label.
+#' For sample-level methods (`"edgeR"` and `"limma"`), this parameter is interpreted as the first condition label.
 #' @param group2 A vector of cell IDs or a character vector specifying the cells that belong to the second group.
 #' This parameter is only used when group.by or group1 is provided.
-#' For pseudobulk analysis, this parameter is interpreted as the second condition label.
+#' For sample-level methods (`"edgeR"` and `"limma"`), this parameter is interpreted as the second condition label.
 #' @param cells1 A vector of cell IDs specifying the cells that belong to group1. If provided, group1 is ignored.
 #' @param cells2 A vector of cell IDs specifying the cells that belong to group2.
 #' This parameter is only used when cells1 is provided.
@@ -572,11 +859,9 @@ RunDEtest_pseudobulk <- function(
 #' If not provided, all features in the dataset are considered.
 #' @param feature_type Feature type used for differential testing.
 #' Default is `"gene"`.
-#' @param analysis_level Analysis level used for differential testing.
-#' Default is `"cell"`.
 #' @param markers_type A character value specifying the type of markers to find.
 #' Possible values are "all", "paired", "conserved", and "disturbed".
-#' Pseudobulk analysis currently supports only `"all"`.
+#' Sample-level methods (`"edgeR"` and `"limma"`) currently support only `"all"`.
 #' @param grouping.var A character value specifying the grouping variable for finding conserved or disturbed markers.
 #' This parameter is only used when markers_type is "conserved" or "disturbed".
 #' @param fc.threshold A numeric value used to filter genes for testing based on their average fold change between/among the two groups.
@@ -585,14 +870,14 @@ RunDEtest_pseudobulk <- function(
 #' Possible values are "maximump", "minimump", "wilkinsonp", "meanp", "sump", and "votep".
 #' @param norm.method Normalization method for fold change calculation when layer is 'data'.
 #' Default is `"LogNormalize"`.
-#' @param sample_col Metadata column storing biological sample IDs for pseudobulk analysis.
-#' Required when `analysis_level = "pseudobulk"`.
-#' @param condition_col Metadata column storing condition labels for pseudobulk analysis.
-#' Required when `analysis_level = "pseudobulk"`.
+#' @param sample_col Metadata column storing biological sample IDs.
+#' Required when `test.use` is `"edgeR"` or `"limma"`.
+#' @param condition_col Metadata column storing condition labels.
+#' Required when `test.use` is `"edgeR"` or `"limma"`.
 #' @param p.adjust.method A character value specifying the method to use for adjusting p-values.
 #' Default is `"bonferroni"`.
 #' @param test.use Differential testing method.
-#' For pseudobulk analysis, only `"limma_voom"` and `"edgeR"` are currently supported.
+#' `"edgeR"` and `"limma"` run sample-level pseudobulk differential testing.
 #' @param ... Additional arguments to pass to the [Seurat::FindMarkers] function.
 #'
 #' @export
@@ -605,7 +890,8 @@ RunDEtest_pseudobulk <- function(
 #' pancreas_sub <- standard_scop(pancreas_sub)
 #' pancreas_sub <- RunDEtest(
 #'   pancreas_sub,
-#'   group.by = "SubCellType"
+#'   group.by = "SubCellType",
+#'   only.pos = FALSE
 #' )
 #' AllMarkers <- dplyr::filter(
 #'   pancreas_sub@tools$DEtest_SubCellType$AllMarkers_wilcox,
@@ -752,52 +1038,60 @@ RunDEtest_pseudobulk <- function(
 #' )
 #' ht7$plot
 #'
-#' pbmc_small <- UpdateSeuratObject(pbmc_small)
-#' pbmc_small[["sample"]] <- rep(c("S1", "S2", "S3", "S4"), length.out = ncol(pbmc_small))
-#' pbmc_small[["condition"]] <- rep(c("ctrl", "ctrl", "case", "case"), length.out = ncol(pbmc_small))
-#' pbmc_small <- RunDEtest(
-#'   pbmc_small,
-#'   analysis_level = "pseudobulk",
+#' cell_index <- ave(
+#'   seq_along(pancreas_sub$CellType),
+#'   pancreas_sub$CellType,
+#'   FUN = seq_along
+#' )
+#' pancreas_sub[["sample"]] <- paste0(
+#'   "S",
+#'   (cell_index - 1) %% 4 + 1
+#' )
+#' pancreas_sub[["condition"]] <- ifelse(
+#'   pancreas_sub$sample %in% c("S1", "S2"),
+#'   "ctrl",
+#'   "case"
+#' )
+#' pancreas_sub <- RunDEtest(
+#'   pancreas_sub,
+#'   group.by = "CellType",
 #'   sample_col = "sample",
 #'   condition_col = "condition",
-#'   test.use = "limma_voom",
+#'   test.use = "limma",
+#'   fc.threshold = 1,
 #'   layer = "counts",
-#'   cores = 1
+#'   only.pos = FALSE
 #' )
-#' pbmc_small <- RunDEtest(
-#'   pbmc_small,
-#'   analysis_level = "pseudobulk",
-#'   sample_col = "sample",
-#'   condition_col = "condition",
-#'   test.use = "edgeR",
-#'   layer = "counts",
-#'   cores = 1
+#' DEtestPlot(
+#'   pancreas_sub,
+#'   group.by = "CellType",
+#'   test.use = "limma",
+#'   group_use = "Ductal",
+#'   plot_type = "volcano",
+#'   x_metric = "avg_log2FC",
+#'   y_metric = "p_val"
 #' )
-#' edgeR_markers <- pbmc_small@tools$DEtest_pseudobulk$AllMarkers_edgeR
 #'
-#' \donttest{
-#' data(pbmcmultiome_sub)
-#' pbmcmultiome_sub[["sample"]] <- rep(
-#'   c("S1", "S2", "S3", "S4"),
-#'   length.out = ncol(pbmcmultiome_sub)
-#' )
-#' pbmcmultiome_sub[["condition"]] <- rep(
-#'   c("ctrl", "ctrl", "case", "case"),
-#'   length.out = ncol(pbmcmultiome_sub)
-#' )
-#' pbmcmultiome_sub <- RunDEtest(
-#'   pbmcmultiome_sub,
-#'   assay = "peaks",
-#'   layer = "counts",
-#'   feature_type = "peak",
-#'   analysis_level = "pseudobulk",
+#' pancreas_sub <- RunDEtest(
+#'   pancreas_sub,
+#'   group.by = "CellType",
 #'   sample_col = "sample",
 #'   condition_col = "condition",
 #'   test.use = "edgeR",
-#'   cores = 1
+#'   layer = "counts",
+#'   fc.threshold = 1,
+#'   only.pos = FALSE
 #' )
-#' peak_markers <- pbmcmultiome_sub@tools$DEtest_pseudobulk$AllMarkers_edgeR
-#' }
+#' DEtestPlot(
+#'   pancreas_sub,
+#'   group.by = "CellType",
+#'   test.use = "edgeR",
+#'   group_use = "Ductal",
+#'   plot_type = "volcano",
+#'   x_metric = "avg_log2FC",
+#'   y_metric = "p_val",
+#'   DE_threshold = "abs(avg_log2FC) > log2(1.5) & p_val < 0.05"
+#' )
 RunDEtest <- function(
   srt,
   group.by = NULL,
@@ -807,7 +1101,6 @@ RunDEtest <- function(
   cells2 = NULL,
   features = NULL,
   feature_type = c("gene", "peak", "cCRE"),
-  analysis_level = c("cell", "pseudobulk"),
   markers_type = c(
     "all",
     "paired",
@@ -848,37 +1141,36 @@ RunDEtest <- function(
 ) {
   set.seed(seed)
   feature_type <- match.arg(feature_type)
-  analysis_level <- match.arg(analysis_level)
   markers_type <- match.arg(markers_type)
   meta.method <- match.arg(meta.method)
-  if (markers_type %in% c("conserved", "disturbed")) {
-    if (is.null(grouping.var)) {
-      log_message(
-        "'grouping.var' must be provided when finding conserved or disturbed markers",
-        message_type = "error"
-      )
-    }
-  }
   if (is.null(assay)) {
     assay <- SeuratObject::DefaultAssay(srt)
   }
 
-  if (analysis_level == "pseudobulk") {
+  sample_level_methods <- c("edgeR", "limma")
+  is_sample_level <- test.use %in% sample_level_methods
+  if (is_sample_level) {
+    if (markers_type != "all") {
+      log_message(
+        "Sample-level differential testing currently supports only {.val all} markers.",
+        message_type = "error"
+      )
+    }
     if (!is.null(cells1) || !is.null(cells2)) {
       log_message(
-        "{.arg cells1} and {.arg cells2} are not supported when {.arg analysis_level = 'pseudobulk'}. Use {.arg group1} and {.arg group2} to specify condition labels.",
+        "{.arg cells1} and {.arg cells2} are not supported for sample-level differential testing. Use {.arg group1} and {.arg group2} to specify condition labels.",
         message_type = "error"
       )
     }
     if (!is.null(grouping.var)) {
       log_message(
-        "{.arg grouping.var} is not supported when {.arg analysis_level = 'pseudobulk'}.",
+        "{.arg grouping.var} is not supported for sample-level differential testing.",
         message_type = "error"
       )
     }
     if (!identical(layer, "counts")) {
       log_message(
-        "Pseudobulk differential testing uses the {.arg counts} layer. Reset {.arg layer = 'counts'}.",
+        "Sample-level differential testing uses the {.arg counts} layer. Reset {.arg layer = 'counts'}.",
         message_type = "warning",
         verbose = verbose
       )
@@ -907,7 +1199,35 @@ RunDEtest <- function(
     ))
   }
 
-  check_r("immunogenomics/presto", verbose = FALSE)
+  if (!is.null(sample_col) || !is.null(condition_col)) {
+    log_message(
+      "{.arg sample_col} and {.arg condition_col} are only used by {.val edgeR} and {.val limma}. Ignoring them for cell-level differential testing.",
+      message_type = "warning",
+      verbose = verbose
+    )
+    sample_col <- NULL
+    condition_col <- NULL
+  }
+  if (markers_type %in% c("conserved", "disturbed")) {
+    if (is.null(grouping.var)) {
+      log_message(
+        "'grouping.var' must be provided when finding conserved or disturbed markers",
+        message_type = "error"
+      )
+    }
+  }
+
+  skip_presto_check <- identical(test.use, "wilcox") &&
+    markers_type %in% c("all", "paired") &&
+    is.null(latent.vars) &&
+    is.null(mean.fxn) &&
+    layer %in% c("data", "counts") &&
+    identical(norm.method, "LogNormalize") &&
+    length(list(...)) == 0 &&
+    run_sparse_wilcox_all_cells_cpp_available()
+  if (!isTRUE(skip_presto_check)) {
+    check_r("immunogenomics/presto", verbose = FALSE)
+  }
 
   status <- CheckDataType(srt, layer = layer, assay = assay)
   if (layer == "counts" && status != "raw_counts") {
@@ -1009,8 +1329,9 @@ RunDEtest <- function(
     )
 
     if (markers_type == "all") {
-      markers <- Seurat::FindMarkers(
-        object = Seurat::GetAssay(srt, assay),
+      markers <- RunDEtestFindMarkers(
+        srt = srt,
+        assay = assay,
         layer = layer,
         cells.1 = cells1,
         cells.2 = cells2,
@@ -1243,7 +1564,8 @@ RunDEtest <- function(
     )
 
     args1 <- list(
-      object = Seurat::GetAssay(srt, assay),
+      srt = srt,
+      assay = assay,
       layer = layer,
       features = features,
       test.use = test.use,
@@ -1285,7 +1607,7 @@ RunDEtest <- function(
           } else {
             args1[["cells.1"]] <- cells.1
             args1[["cells.2"]] <- cells.2
-            markers <- do.call(FindMarkers, args1)
+            markers <- do.call(RunDEtestFindMarkers, args1)
             if (!is.null(markers) && nrow(markers) > 0) {
               markers[, "gene"] <- rownames(markers)
               markers[, "group1"] <- as.character(group)
@@ -1340,17 +1662,18 @@ RunDEtest <- function(
     if (markers_type == "paired") {
       pair <- expand.grid(x = levels(cell_group), y = levels(cell_group))
       pair <- pair[pair[, 1] != pair[, 2], , drop = FALSE]
+      cell_index <- split(names(cell_group), cell_group)
       PairedMarkers <- parallelize_fun(
         seq_len(nrow(pair)),
         function(i) {
-          cells.1 <- names(cell_group)[which(cell_group == pair[i, 1])]
-          cells.2 <- names(cell_group)[which(cell_group == pair[i, 2])]
+          cells.1 <- cell_index[[as.character(pair[i, 1])]]
+          cells.2 <- cell_index[[as.character(pair[i, 2])]]
           if (length(cells.1) < 3 || length(cells.2) < 3) {
             return(NULL)
           } else {
             args1[["cells.1"]] <- cells.1
             args1[["cells.2"]] <- cells.2
-            markers <- do.call(FindMarkers, args1)
+            markers <- do.call(RunDEtestFindMarkers, args1)
             if (!is.null(markers) && nrow(markers) > 0) {
               markers[, "gene"] <- rownames(markers)
               markers[, "group1"] <- as.character(pair[i, 1])

--- a/R/RunDimsReduction.R
+++ b/R/RunDimsReduction.R
@@ -277,13 +277,18 @@ RunDimsReduction <- function(
     }
     if (linear_reduction == "pca") {
       pca_out <- srt[[paste0(prefix, linear_reduction)]]
-      center <- rowMeans(
-        GetAssayData5(
-          object = srt,
-          layer = "scale.data",
-          assay = assay
-        )[features, , drop = FALSE]
-      )
+      if (inherits(srt[[assay]], "Assay5")) {
+        center <- rowMeans(
+          SeuratObject::LayerData(
+            object = srt[[assay]],
+            layer = "scale.data",
+            features = features
+          )
+        )[features]
+      } else {
+        scale_data <- GetAssayData5(srt, assay = assay, layer = "scale.data")
+        center <- rowMeans(scale_data[features, , drop = FALSE])
+      }
       model <- list(
         sdev = pca_out@stdev,
         rotation = pca_out@feature.loadings,

--- a/R/RunGSVA.R
+++ b/R/RunGSVA.R
@@ -15,6 +15,15 @@
 #' @param method The method to use for GSVA.
 #' Options are `"gsva"`, `"ssgsea"`, `"zscore"`, or `"plage"`.
 #' Default is `"gsva"`.
+#' @param backend Scoring backend. `"cpp"` is the default and supports all
+#' current `method` values. `"r"` uses the original [GSVA::gsva()]
+#' implementation. `"cpp"` supports `method = "ssgsea"`,
+#' `method = "zscore"`, `method = "plage"`, and `method = "gsva"` with
+#' `kcdf = "Gaussian"` or `kcdf = "Poisson"`. PLAGE scores are oriented to have non-negative
+#' dot product with the gene set mean z-score so SVD signs are deterministic.
+#' @param cpp_chunk_size Optional cell chunk size for C++ GSVA kernels. `NULL`
+#' or `"auto"` automatically chunks large matrices to reduce peak dense
+#' intermediate memory; positive values set the chunk size manually.
 #' @param kcdf The kernel cumulative distribution function used for GSVA.
 #' Options are `"Gaussian"` (for continuous data) or `"Poisson"` (for count data).
 #' Default is `"Gaussian"`.
@@ -75,6 +84,8 @@ RunGSVA <- function(
   maxGSSize = 500,
   unlimited_db = c("Chromosome", "GeneType", "TF", "Enzyme", "CSPA"),
   method = c("gsva", "ssgsea", "zscore", "plage"),
+  backend = c("cpp", "r"),
+  cpp_chunk_size = NULL,
   kcdf = c("Gaussian", "Poisson"),
   abs.ranking = FALSE,
   min.sz = 10,
@@ -85,10 +96,20 @@ RunGSVA <- function(
   verbose = TRUE
 ) {
   log_message("Start {.pkg GSVA} analysis", verbose = verbose)
-  check_r("GSVA", verbose = FALSE)
 
   method <- match.arg(method)
+  backend <- match.arg(backend)
   kcdf <- match.arg(kcdf)
+  if (identical(backend, "cpp")) {
+    if (!method %in% c("gsva", "ssgsea", "zscore", "plage")) {
+      log_message(
+        "{.arg backend = 'cpp'} currently supports {.arg method = 'gsva'}, {.arg method = 'ssgsea'}, {.arg method = 'zscore'}, and {.arg method = 'plage'} only",
+        message_type = "error"
+      )
+    }
+  } else {
+    gene_set_scoring_require_namespace("GSVA")
+  }
 
   if (is.null(srt)) {
     log_message(
@@ -114,8 +135,8 @@ RunGSVA <- function(
     if (!inherits(expr, c("dgCMatrix", "matrix", "Matrix"))) {
       expr <- as_matrix(expr)
     }
-    expr <- as_matrix(expr)
-    expr <- expr[rowSums(expr) > 0, , drop = FALSE]
+    expr_row_sums <- if (inherits(expr, "Matrix")) Matrix::rowSums(expr) else rowSums(expr)
+    expr <- expr[expr_row_sums > 0, , drop = FALSE]
     if (nrow(expr) == 0 || ncol(expr) == 0) {
       log_message(
         "No expression values available for single-cell GSVA",
@@ -166,13 +187,8 @@ RunGSVA <- function(
         message_type = "error"
       )
     }
-    if (inherits(expr, "dgCMatrix") || inherits(expr, "sparseMatrix")) {
-      expr <- as.matrix(expr)
-    }
-    if (!is.matrix(expr)) {
-      expr <- as.matrix(expr)
-    }
-    expr <- expr[rowSums(expr) > 0, , drop = FALSE]
+    expr_row_sums <- if (inherits(expr, "Matrix")) Matrix::rowSums(expr) else rowSums(expr)
+    expr <- expr[expr_row_sums > 0, , drop = FALSE]
     if (nrow(expr) == 0 || ncol(expr) == 0) {
       log_message(
         "No aggregated expression values available for {.val {group.by}}",
@@ -325,53 +341,100 @@ RunGSVA <- function(
       verbose = verbose
     )
 
-    if (method == "gsva") {
-      param <- GSVA::gsvaParam(
-        exprData = expr_filtered,
-        geneSets = gene_sets_filtered,
-        minSize = min_size,
-        maxSize = max_size,
-        kcdf = kcdf,
-        tau = tau,
-        maxDiff = mx.diff,
-        absRanking = abs.ranking
-      )
-    } else if (method == "ssgsea") {
-      param <- GSVA::ssgseaParam(
-        exprData = expr_filtered,
-        geneSets = gene_sets_filtered,
-        minSize = min_size,
-        maxSize = max_size,
-        alpha = tau,
-        normalize = ssgsea.norm,
+    if (identical(backend, "cpp")) {
+      if (identical(method, "gsva")) {
+        gsva_scores <- Matrix::t(run_gsva_cpp_scores(
+          expr_counts = expr_filtered,
+          gene_sets = gene_sets_filtered,
+          kcdf = kcdf,
+          min_gs_size = min_size,
+          max_gs_size = max_size,
+          max_diff = mx.diff,
+          abs_ranking = abs.ranking,
+          tau = tau,
+          chunk_size = cpp_chunk_size
+        ))
+      } else if (identical(method, "ssgsea")) {
+        gsva_scores <- Matrix::t(run_ssgsea_cpp_scores(
+          expr_counts = expr_filtered,
+          gene_sets = gene_sets_filtered,
+          min_gs_size = min_size,
+          max_gs_size = max_size,
+          alpha = tau,
+          normalize = ssgsea.norm
+        ))
+      } else if (identical(method, "zscore")) {
+        gsva_scores <- Matrix::t(run_zscore_cpp_scores(
+          expr_counts = expr_filtered,
+          gene_sets = gene_sets_filtered,
+          min_gs_size = min_size,
+          max_gs_size = max_size
+        ))
+      } else {
+        gsva_scores <- Matrix::t(run_plage_cpp_scores(
+          expr_counts = expr_filtered,
+          gene_sets = gene_sets_filtered,
+          min_gs_size = min_size,
+          max_gs_size = max_size
+        ))
+      }
+      gsva_scores <- as_matrix(gsva_scores)
+    } else {
+      if (method == "gsva") {
+        param <- GSVA::gsvaParam(
+          exprData = expr_filtered,
+          geneSets = gene_sets_filtered,
+          minSize = min_size,
+          maxSize = max_size,
+          kcdf = kcdf,
+          tau = tau,
+          maxDiff = mx.diff,
+          absRanking = abs.ranking
+        )
+      } else if (method == "ssgsea") {
+        param <- GSVA::ssgseaParam(
+          exprData = expr_filtered,
+          geneSets = gene_sets_filtered,
+          minSize = min_size,
+          maxSize = max_size,
+          alpha = tau,
+          normalize = ssgsea.norm,
+          verbose = verbose
+        )
+      } else if (method == "zscore") {
+        param <- GSVA::zscoreParam(
+          exprData = expr_filtered,
+          geneSets = gene_sets_filtered,
+          minSize = min_size,
+          maxSize = max_size
+        )
+      } else if (method == "plage") {
+        param <- GSVA::plageParam(
+          exprData = expr_filtered,
+          geneSets = gene_sets_filtered,
+          minSize = min_size,
+          maxSize = max_size
+        )
+      }
+
+      gsva_scores <- GSVA::gsva(
+        param = param,
         verbose = verbose
       )
-    } else if (method == "zscore") {
-      param <- GSVA::zscoreParam(
-        exprData = expr_filtered,
-        geneSets = gene_sets_filtered,
-        minSize = min_size,
-        maxSize = max_size
-      )
-    } else if (method == "plage") {
-      param <- GSVA::plageParam(
-        exprData = expr_filtered,
-        geneSets = gene_sets_filtered,
-        minSize = min_size,
-        maxSize = max_size
-      )
-    }
 
-    gsva_scores <- GSVA::gsva(
-      param = param,
-      verbose = verbose
-    )
-
-    if (inherits(gsva_scores, "SummarizedExperiment")) {
-      gsva_scores <- SummarizedExperiment::assay(gsva_scores)
-    }
-    if (!is.matrix(gsva_scores)) {
-      gsva_scores <- as.matrix(gsva_scores)
+      if (inherits(gsva_scores, "SummarizedExperiment")) {
+        gsva_scores <- SummarizedExperiment::assay(gsva_scores)
+      }
+      if (!is.matrix(gsva_scores)) {
+        gsva_scores <- as.matrix(gsva_scores)
+      }
+      if (identical(method, "plage")) {
+        gsva_scores <- orient_plage_scores(
+          scores = gsva_scores,
+          expr = expr_filtered,
+          gene_sets = gene_sets_filtered
+        )
+      }
     }
 
     term_ids <- rownames(gsva_scores)
@@ -396,18 +459,18 @@ RunGSVA <- function(
     rownames(gsva_scores) <- term_names
 
     gsva_results[[term]] <- gsva_scores
-    enrichment_results[[term]] <- do.call(rbind, lapply(colnames(gsva_scores), function(group) {
-      data.frame(
-        ID = term_ids,
-        Description = term_names,
-        geneID = term_gene_ids,
-        Groups = group,
-        Database = term,
-        Version = as.character(db_list[[species]][[term]][["version"]]),
-        GSVA_Score = as.numeric(gsva_scores[, group]),
-        stringsAsFactors = FALSE
-      )
-    }))
+    n_terms <- length(term_ids)
+    n_groups <- ncol(gsva_scores)
+    enrichment_results[[term]] <- data.frame(
+      ID = rep(term_ids, times = n_groups),
+      Description = rep(term_names, times = n_groups),
+      geneID = rep(term_gene_ids, times = n_groups),
+      Groups = rep(colnames(gsva_scores), each = n_terms),
+      Database = term,
+      Version = as.character(db_list[[species]][[term]][["version"]]),
+      GSVA_Score = as.numeric(gsva_scores),
+      stringsAsFactors = FALSE
+    )
   }
 
   if (length(gsva_results) == 0) {
@@ -432,6 +495,7 @@ RunGSVA <- function(
     input = expr,
     group.by = group.by,
     method = method,
+    backend = backend,
     kcdf = kcdf,
     db = unique(enrichment[["Database"]]),
     species = species

--- a/R/RunMDS.R
+++ b/R/RunMDS.R
@@ -193,9 +193,7 @@ RunMDS.default <- function(
     object <- Matrix::t(object)
   }
   nmds <- min(nmds, nrow(x = object) - 1)
-  x <- Matrix::t(
-    as_matrix(object)
-  )
+  x <- Matrix::t(object)
   cell_dist <- stats::as.dist(
     proxyC::dist(x = x, method = dist.method)
   )

--- a/R/RunUMAP2.R
+++ b/R/RunUMAP2.R
@@ -394,7 +394,7 @@ RunUMAP2.default <- function(
       } else {
         obs_sample <- 1:ncol(object)
       }
-      if (!isSymmetric(as_matrix(object[obs_sample, obs_sample]))) {
+      if (!Matrix::isSymmetric(object[obs_sample, obs_sample])) {
         log_message(
           "Graph must be a symmetric matrix.",
           message_type = "error"
@@ -553,33 +553,43 @@ RunUMAP2.default <- function(
       } else {
         obs_sample <- 1:ncol(object)
       }
-      if (!isSymmetric(as_matrix(object[obs_sample, obs_sample]))) {
+      if (!Matrix::isSymmetric(object[obs_sample, obs_sample])) {
         log_message(
           "Graph must be a symmetric matrix.",
           message_type = "error"
         )
       }
-      val <- split(object@x, rep(1:ncol(object), diff(object@p)))
-      pos <- split(object@i + 1, rep(1:ncol(object), diff(object@p)))
-      idx <- Matrix::t(mapply(
-        function(x, y) {
-          out <- y[utils::head(order(x, decreasing = TRUE), n.neighbors)]
-          length(out) <- n.neighbors
-          return(out)
-        },
-        x = val,
-        y = pos
-      ))
-      connectivity <- Matrix::t(mapply(
-        function(x, y) {
-          out <- y[utils::head(order(x, decreasing = TRUE), n.neighbors)]
-          length(out) <- n.neighbors
-          out[is.na(out)] <- 0
-          return(out)
-        },
-        x = val,
-        y = val
-      ))
+      if (run_sparse_topk_by_column_cpp_available()) {
+        graph_topk <- run_sparse_topk_by_column_cpp(
+          x = object,
+          k = n.neighbors,
+          decreasing = TRUE
+        )
+        idx <- graph_topk[["idx"]]
+        connectivity <- graph_topk[["value"]]
+      } else {
+        val <- split(object@x, rep(1:ncol(object), diff(object@p)))
+        pos <- split(object@i + 1, rep(1:ncol(object), diff(object@p)))
+        idx <- Matrix::t(mapply(
+          function(x, y) {
+            out <- y[utils::head(order(x, decreasing = TRUE), n.neighbors)]
+            length(out) <- n.neighbors
+            return(out)
+          },
+          x = val,
+          y = pos
+        ))
+        connectivity <- Matrix::t(mapply(
+          function(x, y) {
+            out <- y[utils::head(order(x, decreasing = TRUE), n.neighbors)]
+            length(out) <- n.neighbors
+            out[is.na(out)] <- 0
+            return(out)
+          },
+          x = val,
+          y = val
+        ))
+      }
       idx[is.na(idx)] <- sample(
         1:nrow(object),
         size = sum(is.na(idx)),
@@ -737,16 +747,26 @@ RunUMAP2.default <- function(
       return(reduction)
     }
     if (inherits(x = object, what = "Graph")) {
-      match_k <- Matrix::t(as_matrix(apply(
-        object,
-        2,
-        function(x) order(x, decreasing = TRUE)[1:n.neighbors]
-      )))
-      match_k_connectivity <- Matrix::t(as_matrix(apply(
-        object,
-        2,
-        function(x) x[order(x, decreasing = TRUE)[1:n.neighbors]]
-      )))
+      if (run_sparse_topk_by_column_cpp_available()) {
+        graph_topk <- run_sparse_topk_by_column_cpp(
+          x = object,
+          k = n.neighbors,
+          decreasing = TRUE
+        )
+        match_k <- graph_topk[["idx"]]
+        match_k_connectivity <- graph_topk[["value"]]
+      } else {
+        match_k <- Matrix::t(as_matrix(apply(
+          object,
+          2,
+          function(x) order(x, decreasing = TRUE)[1:n.neighbors]
+        )))
+        match_k_connectivity <- Matrix::t(as_matrix(apply(
+          object,
+          2,
+          function(x) x[order(x, decreasing = TRUE)[1:n.neighbors]]
+        )))
+      }
       object <- list(
         idx = match_k,
         dist = max(match_k_connectivity) - match_k_connectivity

--- a/R/integration.R
+++ b/R/integration.R
@@ -284,6 +284,17 @@ Uncorrected_integrate <- function(
 #' @inheritParams integration_scop
 #'
 #' @export
+#' @examples
+#' \dontrun{
+#' data("pbmcmultiome_sub", package = "scop")
+#' pbmcmultiome_sub$batch <- rep(c("batch1", "batch2"), length.out = ncol(pbmcmultiome_sub))
+#' pbmcmultiome_sub <- WNN_integrate(
+#'   srt_merge = pbmcmultiome_sub,
+#'   batch = "batch",
+#'   linear_reduction_dims = 20,
+#'   linear_reduction_dims_use = 1:10
+#' )
+#' }
 WNN_integrate <- function(
   srt_merge = NULL,
   batch = NULL,
@@ -529,6 +540,17 @@ WNN_integrate <- function(
 #' Default is `list()`.
 #'
 #' @export
+#' @examples
+#' \dontrun{
+#' data("pbmcmultiome_sub", package = "scop")
+#' pbmcmultiome_sub$batch <- rep(c("batch1", "batch2"), length.out = ncol(pbmcmultiome_sub))
+#' pbmcmultiome_sub <- MultiMAP_integrate(
+#'   srt_merge = pbmcmultiome_sub,
+#'   batch = "batch",
+#'   linear_reduction_dims = 20,
+#'   linear_reduction_dims_use = 1:10
+#' )
+#' }
 MultiMAP_integrate <- function(
   srt_merge = NULL,
   batch = NULL,
@@ -716,10 +738,6 @@ MultiMAP_integrate <- function(
     verbose = FALSE
   )
 
-  multimap <- tryCatch(
-    reticulate::import("MultiMAP", convert = FALSE),
-    error = function(...) reticulate::import("multimap", convert = FALSE)
-  )
   rna_names <- paste0(colnames(srt_merge), "__RNA")
   atac_names <- paste0(colnames(srt_merge), "__ATAC")
   rna_adata$obs_names <- rna_names
@@ -737,17 +755,15 @@ MultiMAP_integrate <- function(
   multimap_params[["n_components"]] <- multimap_params[["n_components"]] %||%
     as.integer(max(10L, max(nonlinear_reduction_dims)))
 
-  adata_joint <- invoke_fun(
-    multimap$Integration,
-    multimap_params
+  multimap_result <- run_multimap_python(
+    rna_adata = rna_adata,
+    atac_adata = atac_adata,
+    MultiMAP_params = multimap_params,
+    verbose = verbose
   )
-  embed <- as.matrix(
-    py_to_r2(
-      get_adata_element(adata_joint$obsm, "X_multimap")
-    )
-  )
-  obs_joint <- as.data.frame(py_to_r2(adata_joint$obs))
-  obs_names_joint <- get_adata_names(adata_joint, "obs")
+  embed <- multimap_result[["embedding"]]
+  obs_joint <- multimap_result[["obs"]]
+  obs_names_joint <- multimap_result[["obs_names"]]
   if ("orig_cell" %in% colnames(obs_joint)) {
     cell_order <- as.character(obs_joint[["orig_cell"]])
   } else {
@@ -851,6 +867,140 @@ MultiMAP_integrate <- function(
   }
 
   srt_merge
+}
+
+run_multimap_python <- function(
+  rna_adata,
+  atac_adata,
+  MultiMAP_params = list(),
+  verbose = TRUE
+) {
+  env_cache <- getOption("scop_env_cache", default = NULL)
+  python <- env_cache[["python"]] %||%
+    tryCatch(
+      conda_python(envname = get_envname(), conda = resolve_conda("auto")),
+      error = function(...) NULL
+    )
+  if (is.null(python) || !file.exists(python)) {
+    log_message(
+      "Unable to resolve python executable for {.pkg MultiMAP}",
+      message_type = "error"
+    )
+  }
+
+  workdir <- tempfile(pattern = "multimap_run_")
+  dir.create(workdir, recursive = TRUE, showWarnings = FALSE)
+  numba_cache_dir <- file.path(workdir, "numba_cache")
+  mpl_config_dir <- file.path(workdir, "matplotlib")
+  dir.create(numba_cache_dir, recursive = TRUE, showWarnings = FALSE)
+  dir.create(mpl_config_dir, recursive = TRUE, showWarnings = FALSE)
+
+  rna_path <- file.path(workdir, "rna.h5ad")
+  atac_path <- file.path(workdir, "atac.h5ad")
+  embed_out <- file.path(workdir, "multimap_embedding.csv")
+  obs_out <- file.path(workdir, "multimap_obs.csv")
+  script_path <- file.path(workdir, "run_multimap.py")
+  stdout_path <- file.path(workdir, "multimap_stdout.log")
+  stderr_path <- file.path(workdir, "multimap_stderr.log")
+
+  rna_adata$write_h5ad(rna_path, compression = "gzip")
+  atac_adata$write_h5ad(atac_path, compression = "gzip")
+
+  params <- MultiMAP_params
+  params[["adatas"]] <- NULL
+  script_body <- c(
+    "import anndata as ad",
+    "import pandas as pd",
+    "",
+    "try:",
+    "    import MultiMAP as multimap",
+    "except ImportError:",
+    "    import multimap",
+    "",
+    sprintf("rna = ad.read_h5ad(%s)", glue_python_literal(rna_path)),
+    sprintf("atac = ad.read_h5ad(%s)", glue_python_literal(atac_path)),
+    sprintf("params = %s", glue_python_literal(params)),
+    "params['adatas'] = [rna, atac]",
+    "adata_joint = multimap.Integration(**params)",
+    "if 'X_multimap' not in adata_joint.obsm:",
+    "    raise ValueError('MultiMAP did not produce obsm[\"X_multimap\"]')",
+    "embed = pd.DataFrame(adata_joint.obsm['X_multimap'], index=adata_joint.obs_names)",
+    "obs = adata_joint.obs.copy()",
+    "obs.insert(0, 'obs_name', adata_joint.obs_names.astype(str))",
+    sprintf("embed.to_csv(%s)", glue_python_literal(embed_out)),
+    sprintf("obs.to_csv(%s, index=False)", glue_python_literal(obs_out))
+  )
+  script_lines <- c(
+    "def main():",
+    paste0("    ", script_body),
+    "",
+    "if __name__ == '__main__':",
+    "    main()"
+  )
+  writeLines(script_lines, con = script_path, useBytes = TRUE)
+
+  status <- system2(
+    command = python,
+    args = script_path,
+    env = c(
+      "PYTHONNOUSERSITE=1",
+      "KMP_DUPLICATE_LIB_OK=TRUE",
+      "KMP_WARNINGS=0",
+      "OMP_NUM_THREADS=1",
+      "OPENBLAS_NUM_THREADS=1",
+      "MKL_NUM_THREADS=1",
+      "VECLIB_MAXIMUM_THREADS=1",
+      "NUMEXPR_NUM_THREADS=1",
+      sprintf("NUMBA_CACHE_DIR=%s", numba_cache_dir),
+      sprintf("MPLCONFIGDIR=%s", mpl_config_dir)
+    ),
+    stdout = stdout_path,
+    stderr = stderr_path
+  )
+  if (!identical(status, 0L)) {
+    stderr_lines <- if (file.exists(stderr_path)) {
+      readLines(stderr_path, warn = FALSE)
+    } else {
+      character(0)
+    }
+    stdout_lines <- if (file.exists(stdout_path)) {
+      readLines(stdout_path, warn = FALSE)
+    } else {
+      character(0)
+    }
+    error_lines <- c(utils::tail(stderr_lines, 20), utils::tail(stdout_lines, 20))
+    if (length(error_lines) == 0) {
+      error_lines <- sprintf("<no output captured; workdir: %s>", workdir)
+    }
+    log_message(
+      "{.pkg MultiMAP} python runner failed:\n{.code {paste(error_lines, collapse = '\n')}}",
+      message_type = "error"
+    )
+  }
+  if (!file.exists(embed_out) || !file.exists(obs_out)) {
+    log_message(
+      "{.pkg MultiMAP} python runner did not produce embedding files. Logs are in {.file {workdir}}",
+      message_type = "error"
+    )
+  }
+
+  log_message(
+    "MultiMAP python runner completed",
+    verbose = verbose
+  )
+
+  obs <- utils::read.csv(obs_out, check.names = FALSE, stringsAsFactors = FALSE)
+  if (!"obs_name" %in% colnames(obs)) {
+    log_message(
+      "{.pkg MultiMAP} python runner output is missing {.field obs_name}",
+      message_type = "error"
+    )
+  }
+  list(
+    embedding = as.matrix(utils::read.csv(embed_out, row.names = 1, check.names = FALSE)),
+    obs = obs,
+    obs_names = as.character(obs[["obs_name"]])
+  )
 }
 
 wnn_assays <- function(srt, assay = NULL) {
@@ -1478,6 +1628,25 @@ Seurat_integrate <- function(
 #' @param cores An integer setting the number of threads for `scVI`.
 #' Default is `1`.
 #' @export
+#' @examples
+#' \dontrun{
+#' data("pbmcmultiome_sub", package = "scop")
+#' pbmcmultiome_sub$batch <- rep(c("batch1", "batch2"), length.out = ncol(pbmcmultiome_sub))
+#' pbmcmultiome_sub <- scVI_integrate(
+#'   srt_merge = pbmcmultiome_sub,
+#'   batch = "batch",
+#'   assay = "peaks",
+#'   model = "PEAKVI",
+#'   train_params = list(max_epochs = 2L)
+#' )
+#' pbmcmultiome_sub <- scVI_integrate(
+#'   srt_merge = pbmcmultiome_sub,
+#'   batch = "batch",
+#'   assay = "peaks",
+#'   model = "POISSONVI",
+#'   train_params = list(max_epochs = 2L)
+#' )
+#' }
 scVI_integrate <- function(
   srt_merge = NULL,
   batch = NULL,
@@ -2288,15 +2457,9 @@ fastMNN_integrate <- function(
         layer = "counts",
         assay = SeuratObject::DefaultAssay(srt)
       )
-      if (inherits(data_matrix, "dgCMatrix")) {
-        data_matrix <- as_matrix(data_matrix)
-      }
       data_matrix <- log1p(data_matrix)
     }
     data_matrix <- data_matrix[HVF, , drop = FALSE]
-    if (inherits(data_matrix, "dgCMatrix")) {
-      data_matrix <- as_matrix(data_matrix)
-    }
     if (nrow(data_matrix) == 0 || ncol(data_matrix) == 0) {
       log_message(
         "No available features/cells for fastMNN after preparing {.val {'logcounts'}} matrix.",
@@ -2326,7 +2489,7 @@ fastMNN_integrate <- function(
   srt_integrated <- srt_merge
   srt_merge <- NULL
   srt_integrated[["fastMNNcorrected"]] <- CreateAssayObject(
-    counts = as_matrix(out@assays@data$reconstructed)
+    counts = out@assays@data$reconstructed
   )
   SeuratObject::DefaultAssay(srt_integrated) <- "fastMNNcorrected"
   SeuratObject::VariableFeatures(srt_integrated[["fastMNNcorrected"]]) <- HVF
@@ -2631,7 +2794,8 @@ Harmony_integrate <- function(
     assay = SeuratObject::DefaultAssay(srt_merge),
     reduction = paste0("Harmony", linear_reduction),
     dims.use = linear_reduction_dims_use,
-    reduction.save = "Harmony",
+    reduction.name = "Harmony",
+    reduction.key = "Harmony_",
     verbose = FALSE
   )
   feature_num <- nrow(
@@ -2644,22 +2808,28 @@ Harmony_integrate <- function(
   if (feature_num == 0) {
     params[["project.dim"]] <- FALSE
   }
+  if (!is.null(RunHarmony_params[["reduction.save"]])) {
+    RunHarmony_params[["reduction.name"]] <- RunHarmony_params[["reduction.name"]] %||%
+      RunHarmony_params[["reduction.save"]]
+    RunHarmony_params[["reduction.save"]] <- NULL
+  }
   for (nm in names(RunHarmony_params)) {
     params[[nm]] <- RunHarmony_params[[nm]]
   }
   srt_integrated <- invoke_fun(RunHarmony2, params)
+  harmony_reduction <- params[["reduction.name"]] %||% "Harmony"
 
   if (is.null(harmony_dims_use)) {
     harmony_dims_use <- seq_len(
       ncol(
-        srt_integrated[["Harmony"]]@cell.embeddings
+        srt_integrated[[harmony_reduction]]@cell.embeddings
       )
     )
   }
 
   srt_integrated <- find_neighbors_and_clusters(
     srt = srt_integrated,
-    reduction = "Harmony",
+    reduction = harmony_reduction,
     dims_use = harmony_dims_use,
     graph_prefix = "Harmony_",
     graph_snn = "Harmony_SNN",
@@ -2676,7 +2846,7 @@ Harmony_integrate <- function(
   srt_integrated <- run_nonlinear_reduction(
     srt = srt_integrated,
     prefix = "Harmony",
-    reduction_use = "Harmony",
+    reduction_use = harmony_reduction,
     reduction_dims = harmony_dims_use,
     graph_use = "Harmony_SNN",
     nonlinear_reduction = nonlinear_reduction,
@@ -3566,8 +3736,12 @@ CSS_integrate <- function(
     "Using {.val {paste0('CSS', linear_reduction)}} ({.val {min(linear_reduction_dims_use)}}:{.val {max(linear_reduction_dims_use)}}) as input",
     verbose = verbose
   )
+  srt_css <- srt_merge
+  if (inherits(Seurat::GetAssay(srt_css, assay = SeuratObject::DefaultAssay(srt_css)), "Assay5")) {
+    srt_css <- SeuratObject::JoinLayers(srt_css)
+  }
   params <- list(
-    object = SeuratObject::JoinLayers(srt_merge),
+    object = srt_css,
     use_dr = paste0("CSS", linear_reduction),
     dims_use = linear_reduction_dims_use,
     var_genes = HVF,

--- a/R/integration_scop.R
+++ b/R/integration_scop.R
@@ -92,18 +92,30 @@
 #' panc8_sub <- integration_scop(
 #'   panc8_sub,
 #'   batch = "tech",
-#'   integration_method = "LIGER"
+#'   integration_method = "Uncorrected",
+#'   nHVF = 500,
+#'   linear_reduction_dims = 20,
+#'   linear_reduction_dims_use = 1:10,
+#'   nonlinear_reduction_dims = 2,
+#'   compute_lisi = TRUE,
+#'   lisi_label_colnames = "tech",
+#'   lisi_perplexity = 10
 #' )
 #' CellDimPlot(
 #'   panc8_sub,
-#'   group.by = c("tech", "celltype")
+#'   group.by = c("tech", "celltype"),
+#'   reduction = "UncorrectedUMAP2D"
 #' )
+#' LISIPlot(
+#'   panc8_sub,
+#'   features = c("UncorrectedpcaUMAP2D_tech_LISI", "UncorrectedUMAP2D_tech_LISI")
+#' )
+#'
+#' \dontrun{
 #' panc8_sub <- integration_scop(
 #'   panc8_sub,
 #'   batch = "tech",
-#'   integration_method = "Uncorrected",
-#'   compute_lisi = TRUE,
-#'   lisi_label_colnames = "tech"
+#'   integration_method = "LIGER"
 #' )
 #' panc8_sub <- integration_scop(
 #'   panc8_sub,
@@ -114,7 +126,7 @@
 #' )
 #' LISIPlot(
 #'   panc8_sub,
-#'   features = c("pca_tech_LISI", "Harmony5UMAP2D_tech_LISI")
+#'   features = c("HarmonypcaUMAP2D_tech_LISI", "HarmonyUMAP2D_tech_LISI")
 #' )
 #'
 #' if (requireNamespace("Signac", quietly = TRUE)) {
@@ -175,6 +187,7 @@
 #'       legend.position = "none", theme_use = "theme_blank"
 #'     )
 #'   )
+#' }
 #' }
 integration_scop <- function(
   srt_merge = NULL,
@@ -426,6 +439,25 @@ integration_scop <- function(
     Conos = Conos_integrate,
     ComBat = ComBat_integrate
   )
+
+  assay_use <- args[["assay"]] %||% (
+    if (!is.null(args[["srt_merge"]])) {
+      SeuratObject::DefaultAssay(args[["srt_merge"]])
+    } else if (!is.null(args[["srt_list"]]) && length(args[["srt_list"]]) > 0) {
+      SeuratObject::DefaultAssay(args[["srt_list"]][[1]])
+    }
+  )
+  is_assay5 <- !is.null(assay_use) &&
+    inherits(assay_source, "Seurat") &&
+    inherits(Seurat::GetAssay(assay_source, assay = assay_use), "Assay5")
+  v5_only_methods <- c("CCA", "RPCA", "fastMNN5", "Harmony5", "scVI5")
+  if (integration_method %in% v5_only_methods && !isTRUE(is_assay5)) {
+    log_message(
+      "{.arg integration_method = '{integration_method}'} requires an {.cls Assay5} (Seurat v5) assay, but the assay {.val {assay_use}} is not Assay5. Please upgrade to Seurat v5 or use an alternative integration method.",
+      message_type = "error"
+    )
+  }
+
   integrate_fun <- method_map[[integration_method]]
   append_requested <- isTRUE(args[["append"]])
   srt_merge_raw <- args[["srt_merge"]] %||% NULL

--- a/R/run_scomm.R
+++ b/R/run_scomm.R
@@ -52,8 +52,8 @@ run_scomm <- function(
       message_type = "error"
     )
   }
-  ref_mat <- as.matrix(ref_mat[features, , drop = FALSE])
-  query_mat <- as.matrix(query_mat[features, , drop = FALSE])
+  ref_mat <- ref_mat[features, , drop = FALSE]
+  query_mat <- query_mat[features, , drop = FALSE]
   labels <- factor(reference[[reference_label, drop = TRUE]])
   names(labels) <- colnames(reference)
   split_data <- prepare_scomm_data(
@@ -80,7 +80,6 @@ run_scomm <- function(
     ))
   }
   patch_keras_categorical()
-  patch_scomm_keras()
   if (
     requireNamespace("keras", quietly = TRUE) &&
       "py_require_legacy_keras" %in% getNamespaceExports("keras")
@@ -183,7 +182,7 @@ run_scomm_subprocess <- function(
     )
   }
 
-  train_x <- as.matrix(split_data$train_x)
+  train_x <- split_data$train_x
   class_names <- as.character(split_data$classes)
   query_x <- t(as.matrix(query_mat))
   missing_features <- setdiff(colnames(train_x), colnames(query_x))
@@ -371,67 +370,6 @@ scomm_subprocess_env <- function(python) {
   unname(paste(names(env), env, sep = "="))
 }
 
-patch_scomm_keras <- function() {
-  if (!requireNamespace("scOMM", quietly = TRUE)) {
-    return(invisible(NULL))
-  }
-  to_categorical_compat <- function(y = NULL, x = y, num_classes = NULL, dtype = "float32") {
-    vec <- as.integer(y %||% x)
-    keep <- !is.na(vec)
-    vec_use <- vec[keep]
-    if (length(vec_use) == 0) {
-      return(matrix(numeric(0), nrow = 0))
-    }
-    if (is.null(num_classes)) {
-      num_classes <- max(vec_use)
-    }
-    tf <- reticulate::import("tensorflow", delay_load = FALSE)
-    res <- tryCatch(
-      tf$keras$utils$to_categorical(
-        as.integer(vec_use - 1L),
-        num_classes = as.integer(num_classes),
-        dtype = dtype
-      ),
-      error = function(...) {
-        tf$keras$utils$to_categorical(
-          as.integer(vec_use - 1L),
-          num_classes = as.integer(num_classes)
-        )
-      }
-    )
-    out <- reticulate::py_to_r(res)
-    if (!all(keep)) {
-      full_out <- matrix(0, nrow = length(vec), ncol = ncol(out))
-      full_out[keep, ] <- out
-      return(full_out)
-    }
-    out
-  }
-  for (pkg in c("keras", "scOMM")) {
-    if (!requireNamespace(pkg, quietly = TRUE)) {
-      next
-    }
-    env_candidates <- unique(list(
-      asNamespace(pkg),
-      parent.env(asNamespace(pkg))
-    ))
-    for (ns in env_candidates) {
-      if (!exists("to_categorical", envir = ns, inherits = FALSE)) {
-        next
-      }
-      tryCatch(
-        {
-          unlockBinding("to_categorical", ns)
-          assign("to_categorical", to_categorical_compat, envir = ns)
-          lockBinding("to_categorical", ns)
-        },
-        error = function(...) NULL
-      )
-    }
-  }
-  invisible(NULL)
-}
-
 patch_keras_categorical <- function() {
   if (!requireNamespace("keras", quietly = TRUE)) {
     return(invisible(NULL))
@@ -479,9 +417,9 @@ patch_keras_categorical <- function() {
     }
     tryCatch(
       {
-        unlockBinding("to_categorical", env_i)
+        get("unlockBinding", envir = baseenv())("to_categorical", env_i)
         assign("to_categorical", to_categorical_compat, envir = env_i)
-        lockBinding("to_categorical", env_i)
+        get("lockBinding", envir = baseenv())("to_categorical", env_i)
       },
       error = function(...) NULL
     )
@@ -610,13 +548,8 @@ predict_scomm <- function(
   }
 
   if (identical(threshold, "AUTO")) {
-    if (!exists("find_optimal_thresholds", envir = asNamespace("scOMM"), inherits = FALSE)) {
-      log_message(
-        "Automatic thresholding is unavailable for {.val method = 'scOMM'} in the current environment.",
-        message_type = "error"
-      )
-    }
-    threshold_vec <- get("find_optimal_thresholds", envir = asNamespace("scOMM"))(
+    check_r("mereulab/scOMM", verbose = FALSE)
+    threshold_vec <- get_namespace_fun("scOMM", "find_optimal_thresholds")(
       dnn_model = dnn_model,
       model.data = model.data
     )

--- a/R/standard_scop.R
+++ b/R/standard_scop.R
@@ -15,12 +15,12 @@
 #' @param do_normalization Whether to perform normalization.
 #' If `NULL`, normalization will be performed if the specified assay does not have scaled data.
 #' @param normalization_method The method to use for normalization.
-#' Options are `"LogNormalize"`, `"SCT"`, or `"TFIDF"`.
+#' Options are `"LogNormalize"`, `"SCT"`, `"TFIDF"`, or `"scran"`.
 #' Default is `"LogNormalize"`.
 #' @param do_HVF_finding Whether to perform high variable feature finding.
 #' If `TRUE`, the function will force to find the highly variable features (HVF) using the specified HVF method.
 #' @param HVF_method The method to use for finding highly variable features.
-#' Options are `"vst"`, `"mvp"`, or `"disp"`.
+#' Options are `"vst"`, `"mvp"`, `"disp"`, or `"scran"`.
 #' Default is `"vst"`.
 #' @param nHVF The number of highly variable features to select.
 #' If NULL, all highly variable features will be used.
@@ -133,6 +133,29 @@
 #'   }
 #' )
 #' patchwork::wrap_plots(plist2)
+#'
+#' if (requireNamespace("scran", quietly = TRUE)) {
+#'   data(pancreas_sub)
+#'   pancreas_scran <- pancreas_sub[, 1:80]
+#'   pancreas_scran <- standard_scop(
+#'     pancreas_scran,
+#'     assay = "RNA",
+#'     do_normalization = TRUE,
+#'     normalization_method = "scran",
+#'     do_HVF_finding = TRUE,
+#'     HVF_method = "scran",
+#'     nHVF = 100,
+#'     linear_reduction_dims = 10,
+#'     linear_reduction_dims_use = 1:5,
+#'     nonlinear_reduction = "umap",
+#'     nonlinear_reduction_dims = 2
+#'   )
+#'   CellDimPlot(
+#'     pancreas_scran,
+#'     reduction = "StandardUMAP2D",
+#'     group.by = "Standardclusters"
+#'   )
+#' }
 standard_scop <- function(
   srt,
   prefix = "Standard",
@@ -345,12 +368,18 @@ standard_scop <- function(
     do_scaling <- FALSE
     linear_reduction <- "svd"
   }
-  scale_features <- GetAssayData5(
-    srt,
-    layer = "scale.data",
-    assay = assay
-  ) |>
-    rownames()
+  assay_obj <- srt[[assay]]
+  scale_features <- if (inherits(assay_obj, "Assay5")) {
+    if ("scale.data" %in% names(assay_obj@layers)) {
+      # Assay5 layers are stored without dimnames; GetAssayData adds them
+      rownames(SeuratObject::GetAssayData(assay_obj, layer = "scale.data"))
+    } else {
+      character(0)
+    }
+  } else {
+    sc <- assay_obj@scale.data
+    if (!is.null(sc) && nrow(sc) > 0) rownames(sc) else character(0)
+  }
   if (
     isTRUE(do_scaling) || (is.null(do_scaling) && any(!HVF %in% scale_features))
   ) {


### PR DESCRIPTION
R-level optimizations for memory and speed:
- RunGSVA: avoid redundant as.matrix() in single-cell mode
- RunCellQC: lazy SplitObject replacement + cached assay/counts access
- RunDEtest: pre-computed cell index map for paired marker tests
- AnnotateFeatures: sapply → type-stable vapply
- run_scomm: defer dense conversion, subset sparse matrices first
- RunUMAP2: sparse-native isSymmetric + C++ topk for uwot-predict
- RunDimsReduction: LayerData(features=) for PCA centering
- RunMDS: skip as.matrix(), pass sparse to proxyC::dist
- standard_scop: direct layer access for scale.data feature check
- integration/fastMNN: remove as.matrix() calls

Seurat v4 compatibility:
- GetAssayData5.Assay: use positional matching for slot/layer
- CSS_integrate: Assay5 guard for JoinLayers
- RunDimsReduction: v4 fallback for PCA centering
- integration_scop: early check for v5-only integration methods