### PR TITLE
Expose trend alluvial CellStatPlot type

### DIFF
--- a/R/CellStatPlot.R
+++ b/R/CellStatPlot.R
@@ -9,6 +9,10 @@
 #' Default is `NULL`.
 #' @param stat_type The type of statistic to compute for the plot.
 #' Can be one of `"percent"` or `"count"`.
+#' @param plot_type The type of plot to create.
+#' Can be one of `"bar"`, `"rose"`, `"ring"`, `"pie"`, `"trend"`,
+#' `"trend_alluvial"`, `"area"`, `"dot"`, `"sankey"`, `"chord"`,
+#' `"venn"`, or `"upset"`.
 #' @param position The position adjustment for the plot.
 #' Can be one of `"stack"` or `"dodge"`.
 #' @param label Whether to add labels on the plot.
@@ -131,6 +135,13 @@
 #'   stat.by = "Phase",
 #'   group.by = "CellType",
 #'   plot_type = "trend"
+#' )
+#'
+#' CellStatPlot(
+#'   pancreas_sub,
+#'   stat.by = "Phase",
+#'   group.by = "CellType",
+#'   plot_type = "trend_alluvial"
 #' )
 #'
 #' CellStatPlot(
@@ -296,6 +307,7 @@ CellStatPlot <- function(
       "ring",
       "pie",
       "trend",
+      "trend_alluvial",
       "area",
       "dot",
       "sankey",

--- a/man/CellStatPlot.Rd
+++ b/man/CellStatPlot.Rd
@@ -17,8 +17,8 @@ CellStatPlot(
   keep_empty = FALSE,
   individual = FALSE,
   stat_level = NULL,
-  plot_type = c("bar", "rose", "ring", "pie", "trend", "area", "dot", "sankey", "chord",
-    "venn", "upset"),
+  plot_type = c("bar", "rose", "ring", "pie", "trend", "trend_alluvial", "area",
+    "dot", "sankey", "chord", "venn", "upset"),
   stat_type = c("percent", "count"),
   position = c("stack", "dodge"),
   palette = "Chinese",
@@ -87,8 +87,9 @@ Default is \code{FALSE}.}
 Default is \code{NULL}.}
 
 \item{plot_type}{A string specifying the type of plot to create.
-Possible values are \code{"violin"}, \code{"box"}, \code{"bar"}, \code{"dot"}, or \code{"col"}.
-Default is \code{"violin"}.}
+Can be one of \code{"bar"}, \code{"rose"}, \code{"ring"}, \code{"pie"}, \code{"trend"},
+\code{"trend_alluvial"}, \code{"area"}, \code{"dot"}, \code{"sankey"}, \code{"chord"},
+\code{"venn"}, or \code{"upset"}.}
 
 \item{stat_type}{The type of statistic to compute for the plot.
 Can be one of \code{"percent"} or \code{"count"}.}
@@ -288,6 +289,13 @@ CellStatPlot(
   stat.by = "Phase",
   group.by = "CellType",
   plot_type = "trend"
+)
+
+CellStatPlot(
+  pancreas_sub,
+  stat.by = "Phase",
+  group.by = "CellType",
+  plot_type = "trend_alluvial"
 )
 
 CellStatPlot(


### PR DESCRIPTION
## Summary
- expose plot_type = "trend_alluvial" through CellStatPlot()
- update CellStatPlot documentation and examples for the new trend-alluvial mode
- keep the example on the default palette
<img width="4200" height="3300" alt="CellStatPlot-trend_alluvial" src="https://github.com/user-attachments/assets/b2525b02-e854-4dbd-ba13-8fc1130c1031" />
