### PR TITLE
[codex] Require thisplot 0.3.9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     Signac,
     Seurat,
     SeuratObject,
-    thisplot (>= 0.3.8),
+    thisplot (>= 0.3.9),
     thisutils (>= 0.4.5),
     uwot
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -136,6 +136,7 @@ LinkingTo:
     RSpectra
 Remotes:
     jinworks/CellChat,
+    mengxu98/thisplot,
     mengxu98/thisutils,
     saeyslab/multinichenetr,
     saeyslab/nichenetr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -136,7 +136,7 @@ LinkingTo:
     RSpectra
 Remotes:
     jinworks/CellChat,
-    mengxu98/thisplot,
+    hurry060215-tech/thisplot@codex/bump-thisplot-039,
     mengxu98/thisutils,
     saeyslab/multinichenetr,
     saeyslab/nichenetr


### PR DESCRIPTION
## Summary
- require `thisplot (>= 0.3.9)` in `scop` Imports

## Why
`CellStatPlot(plot_type = "trend_alluvial")` delegates to `thisplot::StatPlot()`. The plot type exists only after the merged `thisplot` trend-alluvial change, so `scop` should not accept older installed `thisplot 0.3.8` builds.

## Validation
- parsed DESCRIPTION with R and confirmed Imports contains `thisplot (>= 0.3.9)`

## Dependency
This should be merged after https://github.com/mengxu98/thisplot/pull/11.
