### PR TITLE
Require trend alluvial plot dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     Seurat,
     SeuratObject,
     SummarizedExperiment,
-    thisplot (>= 0.3.8),
+    thisplot (>= 0.3.9),
     thisutils (>= 0.4.5),
     uwot
 Suggests:
@@ -135,6 +135,7 @@ LinkingTo:
     RSpectra
 Remotes:
     jinworks/CellChat,
+    mengxu98/thisplot,
     mengxu98/thisutils,
     saeyslab/multinichenetr,
     saeyslab/nichenetr

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,5 @@
 destination: docs
+llm-docs: false
 
 toc:
   depth: 3


### PR DESCRIPTION
## Summary
- require thisplot >= 0.3.9 so CellStatPlot can use plot_type = 'trend_alluvial'
- point Remotes to the thisplot trend_alluvial branch while the companion thisplot PR is pending
- keep thisutils on mengxu98/thisutils because main already provides 0.4.5

## Validation
- locally installed thisutils 0.4.5 and thisplot 0.3.9
- loaded scop with pkgload::load_all(..., compile = FALSE)
- ran CellStatPlot(..., plot_type = 'trend_alluvial') for stat_type = 'percent' and 'count'
- verified percent y range is 0,1 and count height uses raw counts
- ran tools::checkRd on CellStatPlot.Rd