### PR TITLE
Update RunRCTD example and spatial palette

### DIFF
--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -648,7 +648,7 @@ rctd_run_spacexr <- function(
   create_rctd_params,
   run_rctd_params
 ) {
-  check_r("spacexr", verbose = FALSE)
+  rctd_require_namespaces("spacexr")
   ns <- getNamespace("spacexr")
   has_new_api <- exists("createRctd", envir = ns, inherits = FALSE) &&
     exists("runRctd", envir = ns, inherits = FALSE)
@@ -708,7 +708,7 @@ rctd_run_spacexr_new <- function(
   create_rctd_params,
   run_rctd_params
 ) {
-  check_r(c("SpatialExperiment", "SummarizedExperiment", "S4Vectors"), verbose = FALSE)
+  rctd_require_namespaces(c("SpatialExperiment", "SummarizedExperiment", "S4Vectors"))
   spatial_coldata <- S4Vectors::DataFrame(nUMI = st_numi)
   rownames(spatial_coldata) <- colnames(st_counts)
   reference_coldata <- S4Vectors::DataFrame(cell_type = ref_labels, nUMI = ref_numi)
@@ -745,6 +745,17 @@ rctd_run_spacexr_new <- function(
     metadata = metadata,
     object = result
   )
+}
+
+rctd_require_namespaces <- function(pkgs) {
+  available <- vapply(pkgs, requireNamespace, logical(1), quietly = TRUE)
+  if (!all(available)) {
+    log_message(
+      "Please install required package(s) before running {.fn RunRCTD}: {.val {paste(pkgs[!available], collapse = ', ')}}",
+      message_type = "error"
+    )
+  }
+  invisible(TRUE)
 }
 
 rctd_run_spacexr_old <- function(

--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -42,20 +42,63 @@
 #'
 #' @examples
 #' \dontrun{
+#' library(scop)
+#'
 #' data(visium_human_pancreas_sub)
 #' data(panc8_sub)
 #'
+#' drop_celltypes <- c(
+#'   "epsilon",
+#'   "macrophage",
+#'   "mast",
+#'   "quiescent-stellate",
+#'   "schwann"
+#' )
+#'
+#' panc8_rctd <- subset(
+#'   panc8_sub,
+#'   subset = !celltype %in% drop_celltypes
+#' )
+#'
+#' table(panc8_sub$celltype)
+#' table(panc8_rctd$celltype)
+#'
 #' spatial <- RunRCTD(
-#'   visium_human_pancreas_sub,
-#'   reference = panc8_sub,
+#'   srt = visium_human_pancreas_sub,
+#'   reference = panc8_rctd,
 #'   reference_label = "celltype",
+#'   assay = "Spatial",
+#'   reference_assay = "RNA",
+#'   layer = "counts",
+#'   reference_layer = "counts",
 #'   rctd_mode = "full",
-#'   max_cores = 1
+#'   max_cores = 1,
+#'   prefix = "RCTD"
 #' )
 #'
 #' rctd_cols <- grep("^RCTD_prop_", colnames(spatial@meta.data), value = TRUE)
-#' SpatialSpotPlot(spatial, group.by = rctd_cols[1:4])
-#' SpatialSpotPlot(spatial, group.by = rctd_cols, plot_type = "pie")
+#' head(spatial@meta.data[, c("RCTD_dominant_type", "RCTD_max_prop", rctd_cols[1:3])])
+#'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "RCTD_dominant_type",
+#'   theme_use = "theme_scop"
+#' )
+#'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = rctd_cols[1:min(4, length(rctd_cols))],
+#'   palette = "Spectral",
+#'   theme_use = "theme_scop"
+#' )
+#'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = rctd_cols,
+#'   plot_type = "pie",
+#'   pie.radius.scale = 0.45,
+#'   theme_use = "theme_scop"
+#' )
 #' }
 RunRCTD <- function(
   srt,

--- a/R/SpatialSpotPlot.R
+++ b/R/SpatialSpotPlot.R
@@ -76,7 +76,7 @@ SpatialSpotPlot <- function(
   stroke = 0.1,
   jitter_width = 0.25,
   jitter_height = 0.25,
-  palette = ifelse(is.null(features), "Chinese", "Spectral"),
+  palette = "Spectral",
   palcolor = NULL,
   bg_color = "grey20",
   legend.position = "right",

--- a/man/RunRCTD.Rd
+++ b/man/RunRCTD.Rd
@@ -88,19 +88,62 @@ using a single-cell \code{Seurat} reference and \code{spacexr} RCTD.
 }
 \examples{
 \dontrun{
+library(scop)
+
 data(visium_human_pancreas_sub)
 data(panc8_sub)
 
+drop_celltypes <- c(
+  "epsilon",
+  "macrophage",
+  "mast",
+  "quiescent-stellate",
+  "schwann"
+)
+
+panc8_rctd <- subset(
+  panc8_sub,
+  subset = !celltype \%in\% drop_celltypes
+)
+
+table(panc8_sub$celltype)
+table(panc8_rctd$celltype)
+
 spatial <- RunRCTD(
-  visium_human_pancreas_sub,
-  reference = panc8_sub,
+  srt = visium_human_pancreas_sub,
+  reference = panc8_rctd,
   reference_label = "celltype",
+  assay = "Spatial",
+  reference_assay = "RNA",
+  layer = "counts",
+  reference_layer = "counts",
   rctd_mode = "full",
-  max_cores = 1
+  max_cores = 1,
+  prefix = "RCTD"
 )
 
 rctd_cols <- grep("^RCTD_prop_", colnames(spatial@meta.data), value = TRUE)
-SpatialSpotPlot(spatial, group.by = rctd_cols[1:4])
-SpatialSpotPlot(spatial, group.by = rctd_cols, plot_type = "pie")
+head(spatial@meta.data[, c("RCTD_dominant_type", "RCTD_max_prop", rctd_cols[1:3])])
+
+SpatialSpotPlot(
+  spatial,
+  group.by = "RCTD_dominant_type",
+  theme_use = "theme_scop"
+)
+
+SpatialSpotPlot(
+  spatial,
+  group.by = rctd_cols[1:min(4, length(rctd_cols))],
+  palette = "Spectral",
+  theme_use = "theme_scop"
+)
+
+SpatialSpotPlot(
+  spatial,
+  group.by = rctd_cols,
+  plot_type = "pie",
+  pie.radius.scale = 0.45,
+  theme_use = "theme_scop"
+)
 }
 }

--- a/man/SpatialSpotPlot.Rd
+++ b/man/SpatialSpotPlot.Rd
@@ -32,7 +32,7 @@ SpatialSpotPlot(
   stroke = 0.1,
   jitter_width = 0.25,
   jitter_height = 0.25,
-  palette = ifelse(is.null(features), "Chinese", "Spectral"),
+  palette = "Spectral",
   palcolor = NULL,
   bg_color = "grey20",
   legend.position = "right",


### PR DESCRIPTION
## Summary
- Set the default SpatialSpotPlot palette to Spectral while keeping point plots as the default behavior.
- Expand the RunRCTD roxygen example with the built-in pancreas spatial/reference datasets and low-count reference cell type filtering.
- Keep the expensive RunRCTD example inside dontrun for pkgdown and example checks.
- Replace RunRCTD optional dependency checks with requireNamespace so the function does not auto-trigger pak installs during runtime.

## Validation
- devtools::document('D:/scop-dev/scop')
- Old spacexr API smoke test with visium_human_pancreas_sub + filtered panc8_sub: RunRCTD full mode returned metadata proportions summing to 1 and SpatialSpotPlot point/pie ggplot objects.
- New spacexr API source install from ggrajeda/spacexr 1.1.1 into a temporary library succeeded; RunRCTD reached createRctd/runRctd, then failed inside spacexr while downloading its external Q_mat_1.rds resource from mghp.osn.xsede.org. This validates the wrapper dispatch/build path, but the full new-API result matrix could not be completed on this machine due the upstream external download failure.
- R CMD check scop_0.8.9.tar.gz --no-manual --no-examples (_R_CHECK_FORCE_SUGGESTS_=false): 0 errors, existing 1 warning / 1 note.