### PR TITLE
Support RCTD dominant-type pie plots

### DIFF
--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -94,7 +94,7 @@
 #'
 #' SpatialSpotPlot(
 #'   spatial,
-#'   group.by = rctd_cols,
+#'   group.by = "RCTD_dominant_type",
 #'   plot_type = "pie",
 #'   pie.radius.scale = 0.45,
 #'   theme_use = "theme_scop"

--- a/R/SpatialSpotPlot.R
+++ b/R/SpatialSpotPlot.R
@@ -11,7 +11,10 @@
 #' Row names or vector names must match spatial spot names.
 #' @param plot_type Plot type. `"point"` keeps the default spot plot behavior.
 #' `"pie"` draws spot-level pies from numeric metadata columns supplied to
-#' `group.by` or from a numeric matrix/data.frame supplied to `values`.
+#' `group.by` or from a numeric matrix/data.frame supplied to `values`. When
+#' `group.by` is a single `"<prefix>_dominant_type"` column, matching
+#' `"<prefix>_prop_*"` or `"<prefix>_frac_*"` numeric metadata columns are used
+#' automatically.
 #' @param plot.data Optional long-format data.frame for plotting repeated
 #' spatial points, such as cell-to-spot assignments.
 #' @param spot.by Column in `plot.data` containing spot names.
@@ -592,7 +595,11 @@ spatial_dim_pie_values <- function(srt, group.by = NULL, values = NULL, cells) {
         message_type = "error"
       )
     }
-    mat <- srt@meta.data[cells, group.by, drop = FALSE]
+    mat <- spatial_dim_pie_metadata(
+      srt = srt,
+      group.by = group.by,
+      cells = cells
+    )
   }
   if (ncol(mat) == 0L) {
     log_message(
@@ -602,12 +609,53 @@ spatial_dim_pie_values <- function(srt, group.by = NULL, values = NULL, cells) {
   }
   is_numeric <- vapply(mat, is.numeric, logical(1))
   if (!all(is_numeric)) {
+    non_numeric <- colnames(mat)[!is_numeric]
     log_message(
-      "All pie columns must be numeric",
+      paste(
+        "All pie columns must be numeric. Non-numeric column(s):",
+        "{.val {non_numeric}}.",
+        "For RCTD pies, use {.arg group.by} with {.val RCTD_prop_*}",
+        "columns, or use {.val RCTD_dominant_type} when matching",
+        "{.val RCTD_prop_*} columns are present."
+      ),
       message_type = "error"
     )
   }
   as.matrix(mat)
+}
+
+spatial_dim_pie_metadata <- function(srt, group.by, cells) {
+  mat <- srt@meta.data[cells, group.by, drop = FALSE]
+  is_numeric <- vapply(mat, is.numeric, logical(1))
+  if (all(is_numeric)) {
+    return(mat)
+  }
+  inferred_cols <- spatial_dim_infer_pie_columns(srt, group.by)
+  if (length(inferred_cols) > 0L) {
+    return(srt@meta.data[cells, inferred_cols, drop = FALSE])
+  }
+  mat
+}
+
+spatial_dim_infer_pie_columns <- function(srt, group.by) {
+  if (length(group.by) != 1L || !grepl("_dominant_type$", group.by)) {
+    return(character())
+  }
+  prefix <- sub("_dominant_type$", "", group.by)
+  meta_cols <- colnames(srt@meta.data)
+  candidates <- meta_cols[
+    startsWith(meta_cols, paste0(prefix, "_prop_")) |
+      startsWith(meta_cols, paste0(prefix, "_frac_"))
+  ]
+  if (length(candidates) == 0L) {
+    return(character())
+  }
+  is_numeric <- vapply(
+    srt@meta.data[, candidates, drop = FALSE],
+    is.numeric,
+    logical(1)
+  )
+  candidates[is_numeric]
 }
 
 spatial_dim_pie_radius <- function(coords, radius = NULL, scale = 0.45) {

--- a/R/standard_scop.R
+++ b/R/standard_scop.R
@@ -270,7 +270,7 @@
 #' )
 #' SpatialSpotPlot(
 #'   spatial_rctd,
-#'   group.by = rctd_cols,
+#'   group.by = "RCTD_dominant_type",
 #'   plot_type = "pie"
 #' )
 #' }

--- a/man/RunRCTD.Rd
+++ b/man/RunRCTD.Rd
@@ -140,7 +140,7 @@ SpatialSpotPlot(
 
 SpatialSpotPlot(
   spatial,
-  group.by = rctd_cols,
+  group.by = "RCTD_dominant_type",
   plot_type = "pie",
   pie.radius.scale = 0.45,
   theme_use = "theme_scop"

--- a/man/SpatialSpotPlot.Rd
+++ b/man/SpatialSpotPlot.Rd
@@ -63,7 +63,10 @@ Row names or vector names must match spatial spot names.}
 
 \item{plot_type}{Plot type. \code{"point"} keeps the default spot plot behavior.
 \code{"pie"} draws spot-level pies from numeric metadata columns supplied to
-\code{group.by} or from a numeric matrix/data.frame supplied to \code{values}.}
+\code{group.by} or from a numeric matrix/data.frame supplied to \code{values}. When
+\code{group.by} is a single \code{"<prefix>_dominant_type"} column, matching
+\code{"<prefix>_prop_*"} or \code{"<prefix>_frac_*"} numeric metadata columns are used
+automatically.}
 
 \item{plot.data}{Optional long-format data.frame for plotting repeated
 spatial points, such as cell-to-spot assignments.}

--- a/man/standard_scop.Rd
+++ b/man/standard_scop.Rd
@@ -365,7 +365,7 @@ SpatialSpotPlot(
 )
 SpatialSpotPlot(
   spatial_rctd,
-  group.by = rctd_cols,
+  group.by = "RCTD_dominant_type",
   plot_type = "pie"
 )
 }


### PR DESCRIPTION
## Summary

Allows RCTD pie visualization to be called with `group.by = "RCTD_dominant_type"`.

## Changes

- `SpatialSpotPlot(plot_type = "pie")` now detects a single `"<prefix>_dominant_type"` metadata column and automatically uses matching `"<prefix>_prop_*"` or `"<prefix>_frac_*"` numeric columns.
- RCTD examples now show the dominant-type pie call directly while still supporting explicit `RCTD_prop_*` columns.
- The pie error message now points users toward the correct RCTD proportion columns when non-numeric columns are supplied.

## Validation

- Parsed modified R files with R 4.5.2.
- Ran whitespace checks.
- Smoke tested both `group.by = "RCTD_dominant_type"` and explicit `RCTD_prop_*` pie plotting on `visium_human_pancreas_sub` with simulated RCTD metadata.