### PR TITLE
Add RCTD native helpers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -124,6 +124,7 @@ Suggests:
     SpatialExperiment,
     spacexr,
     tensorflow,
+    testthat (>= 3.0.0),
     tibble,
     tricycle,
     umap,

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -121,6 +121,22 @@ pseudotime_velocity_gradient <- function(x_emb, pseudotime, neighbors, smooth = 
     .Call(`_scop_pseudotime_velocity_gradient`, x_emb, pseudotime, neighbors, smooth, normalize)
 }
 
+rctd_sparse_quality_cpp <- function(st_counts, ref_counts) {
+    .Call(`_scop_rctd_sparse_quality_cpp`, st_counts, ref_counts)
+}
+
+rctd_normalize_weights_cpp <- function(weights) {
+    .Call(`_scop_rctd_normalize_weights_cpp`, weights)
+}
+
+rctd_metadata_cpp <- function(weights, all_spots) {
+    .Call(`_scop_rctd_metadata_cpp`, weights, all_spots)
+}
+
+rctd_finalize_weights_cpp <- function(weights, all_spots) {
+    .Call(`_scop_rctd_finalize_weights_cpp`, weights, all_spots)
+}
+
 grnboost_tree <- function(expr, regulator_idx, target_idx, n_rounds = 5000L, learning_rate = 0.01, max_edges_per_target = 0L, max_depth = 3L, max_features = 0.1, subsample = 0.9, early_stop_window_length = 25L, random_seed = 1234L, exclude_self = TRUE) {
     .Call(`_scop_grnboost_tree`, expr, regulator_idx, target_idx, n_rounds, learning_rate, max_edges_per_target, max_depth, max_features, subsample, early_stop_window_length, random_seed, exclude_self)
 }

--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -215,10 +215,11 @@ RunRCTD <- function(
     round_counts = round_counts,
     verbose = verbose
   )
-  nonzero_features <- rctd_nonzero_shared_features(
+  count_quality <- rctd_sparse_quality_cpp(
     st_counts = st_counts,
     ref_counts = ref_counts
   )
+  nonzero_features <- rownames(st_counts)[count_quality$keep_features]
   if (length(nonzero_features) == 0L) {
     log_message(
       "No shared features have non-zero counts in both spatial and reference data",
@@ -234,7 +235,8 @@ RunRCTD <- function(
   st_counts <- st_counts[nonzero_features, , drop = FALSE]
   ref_counts <- ref_counts[nonzero_features, , drop = FALSE]
 
-  ref_numi <- Matrix::colSums(ref_counts)
+  ref_numi <- count_quality$ref_numi
+  names(ref_numi) <- colnames(ref_counts)
   keep_ref_numi <- is.finite(ref_numi) & ref_numi > 0
   if (!all(keep_ref_numi)) {
     log_message(
@@ -266,7 +268,8 @@ RunRCTD <- function(
     )
   }
 
-  st_numi <- Matrix::colSums(st_counts)
+  st_numi <- count_quality$st_numi
+  names(st_numi) <- colnames(st_counts)
   keep_spots <- is.finite(st_numi) & st_numi > 0
   if (!all(keep_spots)) {
     log_message(
@@ -317,8 +320,17 @@ RunRCTD <- function(
     spot_ids = colnames(st_counts),
     label_map = label_map
   )
-  weights <- rctd_normalize_weights(weights)
-  srt <- rctd_add_metadata(srt, weights = weights, prefix = prefix)
+  weight_summary <- rctd_finalize_weights_cpp(
+    weights = weights,
+    all_spots = colnames(srt)
+  )
+  weights <- weight_summary$weights
+  srt <- rctd_add_metadata(
+    srt,
+    weights = weights,
+    prefix = prefix,
+    metadata = weight_summary
+  )
 
   if (isTRUE(store_results)) {
     srt@tools[["RCTD"]] <- list(
@@ -505,6 +517,9 @@ rctd_get_count_matrix <- function(
   if (!inherits(mat, "Matrix")) {
     mat <- Matrix::Matrix(as.matrix(mat), sparse = TRUE)
   }
+  if (!inherits(mat, "dgCMatrix")) {
+    mat <- methods::as(mat, "dgCMatrix")
+  }
   mat@x[!is.finite(mat@x) | mat@x < 0] <- 0
   non_integer <- abs(mat@x - round(mat@x)) > sqrt(.Machine$double.eps)
   if (any(non_integer)) {
@@ -527,8 +542,10 @@ rctd_get_count_matrix <- function(
 }
 
 rctd_nonzero_shared_features <- function(st_counts, ref_counts) {
-  keep <- Matrix::rowSums(st_counts) > 0 & Matrix::rowSums(ref_counts) > 0
-  rownames(st_counts)[keep]
+  st_counts <- methods::as(st_counts, "dgCMatrix")
+  ref_counts <- methods::as(ref_counts, "dgCMatrix")
+  quality <- rctd_sparse_quality_cpp(st_counts, ref_counts)
+  rownames(st_counts)[quality$keep_features]
 }
 
 rctd_get_spatial_coords <- function(
@@ -835,24 +852,17 @@ rctd_orient_weights <- function(weights, spot_ids, label_map) {
 
 rctd_normalize_weights <- function(weights) {
   weights <- as.matrix(weights)
-  weights[!is.finite(weights) | weights < 0] <- 0
-  totals <- rowSums(weights)
-  keep <- is.finite(totals) & totals > 0
-  weights[keep, ] <- sweep(weights[keep, , drop = FALSE], 1, totals[keep], "/")
-  weights[!keep, ] <- 0
-  weights
+  rctd_normalize_weights_cpp(weights)
 }
 
-rctd_add_metadata <- function(srt, weights, prefix = "RCTD") {
+rctd_add_metadata <- function(srt, weights, prefix = "RCTD", metadata = NULL) {
   all_spots <- colnames(srt)
-  full_weights <- matrix(
-    NA_real_,
-    nrow = length(all_spots),
-    ncol = ncol(weights),
-    dimnames = list(all_spots, colnames(weights))
-  )
-  common <- intersect(all_spots, rownames(weights))
-  full_weights[common, ] <- weights[common, , drop = FALSE]
+  if (is.null(metadata)) {
+    metadata <- rctd_metadata_cpp(as.matrix(weights), all_spots)
+    full_weights <- metadata$weights
+  } else {
+    full_weights <- metadata$full_weights
+  }
   meta <- as.data.frame(full_weights, check.names = FALSE)
   prop_cols <- paste0(
     prefix,
@@ -861,22 +871,7 @@ rctd_add_metadata <- function(srt, weights, prefix = "RCTD") {
   )
   colnames(meta) <- prop_cols
 
-  dominant <- rep(NA_character_, nrow(full_weights))
-  max_prop <- rep(NA_real_, nrow(full_weights))
-  row_has_value <- rowSums(!is.na(full_weights)) > 0
-  if (any(row_has_value)) {
-    mat <- full_weights[row_has_value, , drop = FALSE]
-    mat[is.na(mat)] <- 0
-    max_idx <- max.col(mat, ties.method = "first")
-    row_max <- mat[cbind(seq_len(nrow(mat)), max_idx)]
-    dominant[row_has_value] <- ifelse(
-      row_max > 0,
-      colnames(full_weights)[max_idx],
-      NA_character_
-    )
-    max_prop[row_has_value] <- row_max
-  }
-  meta[[paste0(prefix, "_dominant_type")]] <- dominant
-  meta[[paste0(prefix, "_max_prop")]] <- max_prop
+  meta[[paste0(prefix, "_dominant_type")]] <- metadata$dominant
+  meta[[paste0(prefix, "_max_prop")]] <- metadata$max_prop
   Seurat::AddMetaData(srt, metadata = meta)
 }

--- a/src/RCTD.cpp
+++ b/src/RCTD.cpp
@@ -158,18 +158,23 @@ List metadata_from_weights(NumericMatrix weights, CharacterVector all_spots) {
     const int source_row = hit->second;
     double row_max = -std::numeric_limits<double>::infinity();
     int max_index = 0;
+    bool row_has_value = false;
     for (int col = 0; col < n_types; ++col) {
       const double value = weights(source_row, col);
       full_weights(spot, col) = value;
-      const double comparable = (std::isfinite(value) && value > 0.0) ? value : 0.0;
+      const bool is_missing = NumericVector::is_na(value);
+      const double comparable = is_missing ? 0.0 : value;
+      row_has_value = row_has_value || !is_missing;
       if (col == 0 || comparable > row_max) {
         row_max = comparable;
         max_index = col;
       }
     }
-    max_prop[spot] = row_max;
-    if (row_max > 0.0) {
-      dominant[spot] = cell_types[max_index];
+    if (row_has_value) {
+      max_prop[spot] = row_max;
+      if (row_max > 0.0) {
+        dominant[spot] = cell_types[max_index];
+      }
     }
   }
 

--- a/src/RCTD.cpp
+++ b/src/RCTD.cpp
@@ -1,0 +1,235 @@
+// [[Rcpp::depends(RcppArmadillo)]]
+#include <RcppArmadillo.h>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace Rcpp;
+
+namespace {
+
+struct DgCSlots {
+  int n_rows;
+  int n_cols;
+  IntegerVector row_idx;
+  IntegerVector col_ptr;
+  NumericVector values;
+};
+
+DgCSlots get_dgc_slots(S4 mat, const char* arg_name) {
+  IntegerVector dims = mat.slot("Dim");
+  IntegerVector row_idx = mat.slot("i");
+  IntegerVector col_ptr = mat.slot("p");
+  NumericVector values = mat.slot("x");
+  if (dims.size() != 2) {
+    stop("%s must have two dimensions.", arg_name);
+  }
+  if (col_ptr.size() != dims[1] + 1) {
+    stop("%s must be a valid dgCMatrix.", arg_name);
+  }
+  if (row_idx.size() != values.size()) {
+    stop("%s has inconsistent sparse matrix slots.", arg_name);
+  }
+  return DgCSlots{
+    dims[0],
+    dims[1],
+    row_idx,
+    col_ptr,
+    values
+  };
+}
+
+inline bool is_positive_count(double value) {
+  return std::isfinite(value) && value > 0.0;
+}
+
+void mark_positive_rows(const DgCSlots& mat, std::vector<unsigned char>& has_value) {
+  for (int col = 0; col < mat.n_cols; ++col) {
+    if ((col & 1023) == 0) {
+      Rcpp::checkUserInterrupt();
+    }
+    for (int ptr = mat.col_ptr[col]; ptr < mat.col_ptr[col + 1]; ++ptr) {
+      const int row = mat.row_idx[ptr];
+      if (row < 0 || row >= mat.n_rows) {
+        stop("dgCMatrix row index is out of bounds.");
+      }
+      if (is_positive_count(mat.values[ptr])) {
+        has_value[static_cast<std::size_t>(row)] = 1;
+      }
+    }
+  }
+}
+
+NumericVector kept_column_sums(const DgCSlots& mat, const LogicalVector& keep_rows) {
+  NumericVector sums(mat.n_cols);
+  for (int col = 0; col < mat.n_cols; ++col) {
+    if ((col & 1023) == 0) {
+      Rcpp::checkUserInterrupt();
+    }
+    double total = 0.0;
+    for (int ptr = mat.col_ptr[col]; ptr < mat.col_ptr[col + 1]; ++ptr) {
+      const int row = mat.row_idx[ptr];
+      if (keep_rows[row] && is_positive_count(mat.values[ptr])) {
+        total += mat.values[ptr];
+      }
+    }
+    sums[col] = total;
+  }
+  return sums;
+}
+
+NumericMatrix normalize_weights_copy(NumericMatrix weights) {
+  NumericMatrix out = clone(weights);
+  const int n_rows = out.nrow();
+  const int n_cols = out.ncol();
+
+  for (int row = 0; row < n_rows; ++row) {
+    double total = 0.0;
+    for (int col = 0; col < n_cols; ++col) {
+      double value = out(row, col);
+      if (!std::isfinite(value) || value < 0.0) {
+        value = 0.0;
+        out(row, col) = 0.0;
+      }
+      total += value;
+    }
+    if (std::isfinite(total) && total > 0.0) {
+      for (int col = 0; col < n_cols; ++col) {
+        out(row, col) /= total;
+      }
+    } else {
+      for (int col = 0; col < n_cols; ++col) {
+        out(row, col) = 0.0;
+      }
+    }
+  }
+
+  out.attr("dimnames") = weights.attr("dimnames");
+  return out;
+}
+
+List metadata_from_weights(NumericMatrix weights, CharacterVector all_spots) {
+  List dimnames = weights.attr("dimnames");
+  if (dimnames.size() < 2 || dimnames[0] == R_NilValue || dimnames[1] == R_NilValue) {
+    stop("weights must have row and column names.");
+  }
+  CharacterVector weight_spots = dimnames[0];
+  CharacterVector cell_types = dimnames[1];
+  const int n_spots = all_spots.size();
+  const int n_types = weights.ncol();
+  if (n_types == 0) {
+    stop("weights must contain at least one cell type.");
+  }
+
+  std::unordered_map<std::string, int> weight_index;
+  weight_index.reserve(static_cast<std::size_t>(weight_spots.size()));
+  for (int row = 0; row < weight_spots.size(); ++row) {
+    if (CharacterVector::is_na(weight_spots[row])) {
+      continue;
+    }
+    std::string key = as<std::string>(weight_spots[row]);
+    if (weight_index.find(key) == weight_index.end()) {
+      weight_index[key] = row;
+    }
+  }
+
+  NumericMatrix full_weights(n_spots, n_types);
+  std::fill(full_weights.begin(), full_weights.end(), NA_REAL);
+  CharacterVector dominant(n_spots);
+  NumericVector max_prop(n_spots, NA_REAL);
+  for (int spot = 0; spot < n_spots; ++spot) {
+    dominant[spot] = NA_STRING;
+  }
+
+  for (int spot = 0; spot < n_spots; ++spot) {
+    if (CharacterVector::is_na(all_spots[spot])) {
+      continue;
+    }
+    const std::string key = as<std::string>(all_spots[spot]);
+    const std::unordered_map<std::string, int>::const_iterator hit =
+      weight_index.find(key);
+    if (hit == weight_index.end()) {
+      continue;
+    }
+
+    const int source_row = hit->second;
+    double row_max = -std::numeric_limits<double>::infinity();
+    int max_index = 0;
+    for (int col = 0; col < n_types; ++col) {
+      const double value = weights(source_row, col);
+      full_weights(spot, col) = value;
+      const double comparable = (std::isfinite(value) && value > 0.0) ? value : 0.0;
+      if (col == 0 || comparable > row_max) {
+        row_max = comparable;
+        max_index = col;
+      }
+    }
+    max_prop[spot] = row_max;
+    if (row_max > 0.0) {
+      dominant[spot] = cell_types[max_index];
+    }
+  }
+
+  full_weights.attr("dimnames") = List::create(all_spots, cell_types);
+  return List::create(
+    _["weights"] = full_weights,
+    _["dominant"] = dominant,
+    _["max_prop"] = max_prop
+  );
+}
+
+} // namespace
+
+// [[Rcpp::export]]
+List rctd_sparse_quality_cpp(S4 st_counts, S4 ref_counts) {
+  DgCSlots st = get_dgc_slots(st_counts, "st_counts");
+  DgCSlots ref = get_dgc_slots(ref_counts, "ref_counts");
+  if (st.n_rows != ref.n_rows) {
+    stop("st_counts and ref_counts must have the same number of rows.");
+  }
+
+  std::vector<unsigned char> st_has(static_cast<std::size_t>(st.n_rows), 0);
+  std::vector<unsigned char> ref_has(static_cast<std::size_t>(ref.n_rows), 0);
+  mark_positive_rows(st, st_has);
+  mark_positive_rows(ref, ref_has);
+
+  LogicalVector keep_features(st.n_rows);
+  for (int row = 0; row < st.n_rows; ++row) {
+    keep_features[row] = st_has[static_cast<std::size_t>(row)] &&
+      ref_has[static_cast<std::size_t>(row)];
+  }
+
+  return List::create(
+    _["keep_features"] = keep_features,
+    _["st_numi"] = kept_column_sums(st, keep_features),
+    _["ref_numi"] = kept_column_sums(ref, keep_features)
+  );
+}
+
+// [[Rcpp::export]]
+NumericMatrix rctd_normalize_weights_cpp(NumericMatrix weights) {
+  return normalize_weights_copy(weights);
+}
+
+// [[Rcpp::export]]
+List rctd_metadata_cpp(NumericMatrix weights, CharacterVector all_spots) {
+  return metadata_from_weights(weights, all_spots);
+}
+
+// [[Rcpp::export]]
+List rctd_finalize_weights_cpp(NumericMatrix weights, CharacterVector all_spots) {
+  NumericMatrix normalized = normalize_weights_copy(weights);
+  List metadata = metadata_from_weights(normalized, all_spots);
+  NumericMatrix full_weights = metadata["weights"];
+  CharacterVector dominant = metadata["dominant"];
+  NumericVector max_prop = metadata["max_prop"];
+  return List::create(
+    _["weights"] = normalized,
+    _["full_weights"] = full_weights,
+    _["dominant"] = dominant,
+    _["max_prop"] = max_prop
+  );
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -446,6 +446,53 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// rctd_sparse_quality_cpp
+List rctd_sparse_quality_cpp(S4 st_counts, S4 ref_counts);
+RcppExport SEXP _scop_rctd_sparse_quality_cpp(SEXP st_countsSEXP, SEXP ref_countsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< S4 >::type st_counts(st_countsSEXP);
+    Rcpp::traits::input_parameter< S4 >::type ref_counts(ref_countsSEXP);
+    rcpp_result_gen = Rcpp::wrap(rctd_sparse_quality_cpp(st_counts, ref_counts));
+    return rcpp_result_gen;
+END_RCPP
+}
+// rctd_normalize_weights_cpp
+NumericMatrix rctd_normalize_weights_cpp(NumericMatrix weights);
+RcppExport SEXP _scop_rctd_normalize_weights_cpp(SEXP weightsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type weights(weightsSEXP);
+    rcpp_result_gen = Rcpp::wrap(rctd_normalize_weights_cpp(weights));
+    return rcpp_result_gen;
+END_RCPP
+}
+// rctd_metadata_cpp
+List rctd_metadata_cpp(NumericMatrix weights, CharacterVector all_spots);
+RcppExport SEXP _scop_rctd_metadata_cpp(SEXP weightsSEXP, SEXP all_spotsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< CharacterVector >::type all_spots(all_spotsSEXP);
+    rcpp_result_gen = Rcpp::wrap(rctd_metadata_cpp(weights, all_spots));
+    return rcpp_result_gen;
+END_RCPP
+}
+// rctd_finalize_weights_cpp
+List rctd_finalize_weights_cpp(NumericMatrix weights, CharacterVector all_spots);
+RcppExport SEXP _scop_rctd_finalize_weights_cpp(SEXP weightsSEXP, SEXP all_spotsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< NumericMatrix >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< CharacterVector >::type all_spots(all_spotsSEXP);
+    rcpp_result_gen = Rcpp::wrap(rctd_finalize_weights_cpp(weights, all_spots));
+    return rcpp_result_gen;
+END_RCPP
+}
 // grnboost_tree
 DataFrame grnboost_tree(NumericMatrix expr, IntegerVector regulator_idx, IntegerVector target_idx, int n_rounds, double learning_rate, int max_edges_per_target, int max_depth, double max_features, double subsample, int early_stop_window_length, int random_seed, bool exclude_self);
 RcppExport SEXP _scop_grnboost_tree(SEXP exprSEXP, SEXP regulator_idxSEXP, SEXP target_idxSEXP, SEXP n_roundsSEXP, SEXP learning_rateSEXP, SEXP max_edges_per_targetSEXP, SEXP max_depthSEXP, SEXP max_featuresSEXP, SEXP subsampleSEXP, SEXP early_stop_window_lengthSEXP, SEXP random_seedSEXP, SEXP exclude_selfSEXP) {
@@ -1241,6 +1288,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_scop_proportion_bootstrap_stats", (DL_FUNC) &_scop_proportion_bootstrap_stats, 5},
     {"_scop_pseudotime_velocity_knn", (DL_FUNC) &_scop_pseudotime_velocity_knn, 4},
     {"_scop_pseudotime_velocity_gradient", (DL_FUNC) &_scop_pseudotime_velocity_gradient, 5},
+    {"_scop_rctd_sparse_quality_cpp", (DL_FUNC) &_scop_rctd_sparse_quality_cpp, 2},
+    {"_scop_rctd_normalize_weights_cpp", (DL_FUNC) &_scop_rctd_normalize_weights_cpp, 1},
+    {"_scop_rctd_metadata_cpp", (DL_FUNC) &_scop_rctd_metadata_cpp, 2},
+    {"_scop_rctd_finalize_weights_cpp", (DL_FUNC) &_scop_rctd_finalize_weights_cpp, 2},
     {"_scop_grnboost_tree", (DL_FUNC) &_scop_grnboost_tree, 12},
     {"_scop_scenic_ctx_recovery", (DL_FUNC) &_scop_scenic_ctx_recovery, 3},
     {"_scop_scenic_ctx_auc_nes", (DL_FUNC) &_scop_scenic_ctx_auc_nes, 3},

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(scop)
+
+test_check("scop")

--- a/tests/testthat/test-rctd-cpp.R
+++ b/tests/testthat/test-rctd-cpp.R
@@ -1,0 +1,120 @@
+test_that("RCTD sparse quality helper matches R sparse summaries", {
+  st_dense <- matrix(
+    c(
+      1, 0, 2,
+      0, 0, 0,
+      3, 0, 0,
+      0, 5, 0,
+      0, 0, 0
+    ),
+    nrow = 5,
+    byrow = TRUE,
+    dimnames = list(paste0("Gene", 1:5), paste0("Spot", 1:3))
+  )
+  ref_dense <- matrix(
+    c(
+      0, 4, 0, 1,
+      2, 0, 0, 0,
+      0, 0, 0, 0,
+      1, 1, 0, 0,
+      0, 0, 7, 0
+    ),
+    nrow = 5,
+    byrow = TRUE,
+    dimnames = list(paste0("Gene", 1:5), paste0("Cell", 1:4))
+  )
+  st <- methods::as(Matrix::Matrix(st_dense, sparse = TRUE), "dgCMatrix")
+  ref <- methods::as(Matrix::Matrix(ref_dense, sparse = TRUE), "dgCMatrix")
+
+  out <- rctd_sparse_quality_cpp(st, ref)
+  keep <- Matrix::rowSums(st) > 0 & Matrix::rowSums(ref) > 0
+
+  expect_equal(out$keep_features, unname(keep))
+  expect_equal(
+    out$st_numi,
+    unname(Matrix::colSums(st[keep, , drop = FALSE]))
+  )
+  expect_equal(
+    out$ref_numi,
+    unname(Matrix::colSums(ref[keep, , drop = FALSE]))
+  )
+  expect_equal(rctd_nonzero_shared_features(st, ref), rownames(st)[keep])
+})
+
+test_that("RCTD weight normalization helper matches R behavior", {
+  weights <- matrix(
+    c(
+      1, 2, 3,
+      NA, -1, Inf,
+      0, 0, 0,
+      4, 0, 4
+    ),
+    nrow = 4,
+    byrow = TRUE,
+    dimnames = list(paste0("Spot", 1:4), paste0("Type", 1:3))
+  )
+  expected <- weights
+  expected[!is.finite(expected) | expected < 0] <- 0
+  totals <- rowSums(expected)
+  keep <- is.finite(totals) & totals > 0
+  expected[keep, ] <- sweep(expected[keep, , drop = FALSE], 1, totals[keep], "/")
+  expected[!keep, ] <- 0
+
+  out <- rctd_normalize_weights(weights)
+  expect_equal(out, expected)
+  expect_equal(rownames(out), rownames(weights))
+  expect_equal(colnames(out), colnames(weights))
+})
+
+test_that("RCTD metadata helper matches metadata fill and dominant summaries", {
+  weights <- matrix(
+    c(
+      0.25, 0.75,
+      0.00, 0.00,
+      0.60, 0.40
+    ),
+    nrow = 3,
+    byrow = TRUE,
+    dimnames = list(c("Spot1", "Spot3", "Spot4"), c("Alpha/Beta", "Delta"))
+  )
+  all_spots <- paste0("Spot", 1:5)
+  out <- rctd_metadata_cpp(weights, all_spots)
+
+  expected_weights <- matrix(
+    NA_real_,
+    nrow = length(all_spots),
+    ncol = ncol(weights),
+    dimnames = list(all_spots, colnames(weights))
+  )
+  expected_weights[rownames(weights), ] <- weights
+  expected_dominant <- c("Delta", NA, NA, "Alpha/Beta", NA)
+  expected_max <- c(0.75, NA, 0, 0.60, NA)
+
+  expect_equal(out$weights, expected_weights)
+  expect_equal(out$dominant, expected_dominant)
+  expect_equal(out$max_prop, expected_max)
+})
+
+test_that("RCTD finalize helper matches separate normalization and metadata helpers", {
+  weights <- matrix(
+    c(
+      1, 3, 0,
+      NA, -2, Inf,
+      0, 0, 0,
+      4, 1, 5
+    ),
+    nrow = 4,
+    byrow = TRUE,
+    dimnames = list(paste0("Spot", c(1, 3, 4, 6)), paste0("Type", 1:3))
+  )
+  all_spots <- paste0("Spot", 1:6)
+
+  expected_weights <- rctd_normalize_weights(weights)
+  expected_meta <- rctd_metadata_cpp(expected_weights, all_spots)
+  out <- rctd_finalize_weights_cpp(weights, all_spots)
+
+  expect_equal(out$weights, expected_weights)
+  expect_equal(out$full_weights, expected_meta$weights)
+  expect_equal(out$dominant, expected_meta$dominant)
+  expect_equal(out$max_prop, expected_meta$max_prop)
+})

--- a/tests/testthat/test-rctd-cpp.R
+++ b/tests/testthat/test-rctd-cpp.R
@@ -71,13 +71,18 @@ test_that("RCTD metadata helper matches metadata fill and dominant summaries", {
     c(
       0.25, 0.75,
       0.00, 0.00,
-      0.60, 0.40
+      0.60, 0.40,
+      NA, NA,
+      Inf, 1.00
     ),
-    nrow = 3,
+    nrow = 5,
     byrow = TRUE,
-    dimnames = list(c("Spot1", "Spot3", "Spot4"), c("Alpha/Beta", "Delta"))
+    dimnames = list(
+      c("Spot1", "Spot3", "Spot4", "Spot5", "Spot6"),
+      c("Alpha/Beta", "Delta")
+    )
   )
-  all_spots <- paste0("Spot", 1:5)
+  all_spots <- paste0("Spot", 1:7)
   out <- rctd_metadata_cpp(weights, all_spots)
 
   expected_weights <- matrix(
@@ -87,8 +92,8 @@ test_that("RCTD metadata helper matches metadata fill and dominant summaries", {
     dimnames = list(all_spots, colnames(weights))
   )
   expected_weights[rownames(weights), ] <- weights
-  expected_dominant <- c("Delta", NA, NA, "Alpha/Beta", NA)
-  expected_max <- c(0.75, NA, 0, 0.60, NA)
+  expected_dominant <- c("Delta", NA, NA, "Alpha/Beta", NA, "Alpha/Beta", NA)
+  expected_max <- c(0.75, NA, 0, 0.60, NA, Inf, NA)
 
   expect_equal(out$weights, expected_weights)
   expect_equal(out$dominant, expected_dominant)


### PR DESCRIPTION
## Summary
- add native RCTD helper routines for sparse shared-feature summaries and weight metadata preparation
- route RunRCTD preprocessing and result metadata handling through the helper routines
- add focused testthat coverage comparing the native helpers with the previous R behavior, including missing-value metadata edge cases

## Validation
- R CMD INSTALL --library=D:\scop-dev\r-tmp\scop-rctd-pr-lib --no-multiarch --with-keep.source .
- testthat::test_dir("tests/testthat", env = asNamespace("scop"), reporter = "summary")
- R CMD check --no-examples --no-manual --no-build-vignettes with _R_CHECK_FORCE_SUGGESTS_=false

## Notes
- Full examples still depend on optional packages not installed locally; with examples skipped, package checks pass aside from the existing Signac::ATACqc warning.