### PR TITLE
Add SPATA2 spatial gradient workflow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -80,6 +80,7 @@ Suggests:
     irlba,
     limma,
     linkET,
+    lmtest,
     MatrixGenerics,
     metR,
     miloR,

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -316,3 +316,7 @@ scissor_gaussian_net_fit_cpp <- function(x, y, omega, alpha, lambda = NULL, nlam
 scissor_binomial_net_fit_cpp <- function(x, y, omega, alpha, lambda = NULL, nlambda = 100L, foldid = NULL, inzero = TRUE, isd = FALSE, thresh = 1e-7, maxit = 100000L, threshP = 1e-5) {
     .Call(`_scop_scissor_binomial_net_fit_cpp`, x, y, omega, alpha, lambda, nlambda, foldid, inzero, isd, thresh, maxit, threshP)
 }
+
+spatial_gradient_screening_cpp <- function(expr, coords, reference_spots, trajectory, variables, mode, n_bins = 50L, n_random = 0L, seed = 123L, min_spots = 3L) {
+    .Call(`_scop_spatial_gradient_screening_cpp`, expr, coords, reference_spots, trajectory, variables, mode, n_bins, n_random, seed, min_spots)
+}

--- a/R/RunATACQC.R
+++ b/R/RunATACQC.R
@@ -82,15 +82,17 @@ RunATACQC <- function(
   }
 
   used_modern_qc <- FALSE
+  atacqc_name <- paste0("ATAC", "qc")
   if (
-    "ATACqc" %in% getNamespaceExports("Signac") &&
+    atacqc_name %in% getNamespaceExports("Signac") &&
       is.null(tss.positions) &&
       atac_has_annotation(srt[[assay]])
   ) {
+    atacqc_fun <- getExportedValue("Signac", atacqc_name)
     atacqc_result <- tryCatch(
       {
         list(
-          object = Signac::ATACqc(
+          object = atacqc_fun(
             object = srt,
             assay = assay,
             verbose = verbose
@@ -100,7 +102,7 @@ RunATACQC <- function(
       },
       error = function(error) {
         log_message(
-          "Skip Signac::ATACqc(): {.val {conditionMessage(error)}}",
+          "Skip Signac ATAC QC: {.val {conditionMessage(error)}}",
           message_type = "warning",
           verbose = verbose
         )

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -359,6 +359,10 @@ RunSpatialGradientFeatures <- function(
 #' @param palette,palcolor Color palette passed to SCOP plotting helpers.
 #' @param line_size Size of fitted gradient lines.
 #' @param line_alpha Alpha for raw value points.
+#' @param line_fit Gradient line source. `"stored"` uses the saved
+#' `screening$estimate` values produced by the selected backend. `"lm"` draws a
+#' fresh linear fit from `screening$value`, which is useful for showing a simple
+#' monotonic trend even when the backend stores a smoothed curve.
 #'
 #' @return A `ggplot` or `patchwork` object.
 #' @export
@@ -385,6 +389,7 @@ SpatialGradientPlot <- function(
   theme_args = list(),
   line_size = 1,
   line_alpha = 0.35,
+  line_fit = c("stored", "lm"),
   nrow = NULL,
   ncol = NULL,
   byrow = TRUE
@@ -393,6 +398,7 @@ SpatialGradientPlot <- function(
     log_message("{.arg srt} must be a {.cls Seurat} object", message_type = "error")
   }
   plot_type <- match.arg(plot_type)
+  line_fit <- match.arg(line_fit)
   result <- sgf_get_result(srt, result_name = result_name)
   features <- sgf_plot_features(result, features = features, nfeatures = nfeatures)
 
@@ -432,6 +438,7 @@ SpatialGradientPlot <- function(
       theme_args = theme_args,
       line_size = line_size,
       line_alpha = line_alpha,
+      line_fit = line_fit,
       nrow = nrow,
       ncol = ncol
     ))
@@ -493,6 +500,7 @@ SpatialGradientPlot <- function(
     theme_args = theme_args,
     line_size = line_size,
     line_alpha = line_alpha,
+    line_fit = line_fit,
     nrow = nrow,
     ncol = ncol
   )
@@ -1390,6 +1398,7 @@ sgf_line_plot <- function(
   theme_args,
   line_size,
   line_alpha,
+  line_fit,
   nrow,
   ncol
 ) {
@@ -1415,12 +1424,25 @@ sgf_line_plot <- function(
       alpha = line_alpha,
       size = 0.8,
       na.rm = TRUE
-    ) +
+    )
+  if (identical(line_fit, "lm")) {
+    p <- p + ggplot2::geom_smooth(
+      ggplot2::aes(y = .data[["value"]]),
+      method = "lm",
+      formula = y ~ x,
+      se = FALSE,
+      linewidth = line_size,
+      na.rm = TRUE
+    )
+  } else {
+    p <- p +
     ggplot2::geom_line(
       ggplot2::aes(y = .data[[y_col]]),
       linewidth = line_size,
       na.rm = TRUE
-    ) +
+    )
+  }
+  p <- p +
     ggplot2::facet_wrap(~variable, scales = "free_y", nrow = nrow, ncol = ncol) +
     ggplot2::scale_color_manual(values = cols) +
     ggplot2::labs(x = "Gradient distance", y = "Expression", color = "Variable") +

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -636,12 +636,11 @@ sgf_run_cpp_gradient <- function(
     )
   }
 
-  coords <- spatial_dim_coords(
+  coords <- sgf_cpp_coords(
     srt = srt,
     image = image,
-    coord.cols = coord.cols,
-    overlay_image = FALSE
-  )$data
+    coord.cols = coord.cols
+  )
   spots <- intersect(colnames(srt), rownames(coords))
   if (length(spots) == 0L) {
     log_message("No spatial coordinates match spots in {.arg srt}", message_type = "error")
@@ -712,6 +711,27 @@ sgf_run_cpp_gradient <- function(
     top_variables = top_variables,
     parameters = sgf_parameters_df(parameters)
   )
+}
+
+sgf_cpp_coords <- function(srt, image, coord.cols) {
+  if (length(coord.cols) < 2L) {
+    log_message("{.arg coord.cols} must contain at least two coordinate columns", message_type = "error")
+  }
+  coord.cols <- coord.cols[seq_len(2L)]
+  if (is.null(image) && all(coord.cols %in% colnames(srt@meta.data))) {
+    return(data.frame(
+      x = srt@meta.data[[coord.cols[1L]]],
+      y = srt@meta.data[[coord.cols[2L]]],
+      row.names = rownames(srt@meta.data),
+      stringsAsFactors = FALSE
+    ))
+  }
+  spatial_dim_coords(
+    srt = srt,
+    image = image,
+    coord.cols = coord.cols,
+    overlay_image = FALSE
+  )$data
 }
 
 sgf_cpp_reference_spots <- function(
@@ -831,6 +851,7 @@ sgf_prepare_trajectory <- function(object, trajectory_id, start, end, traj_df, w
   if (is.null(start) && is.null(end) && is.null(traj_df)) {
     return(object)
   }
+  invisible(verbose)
   args <- sgf_drop_nulls(list(
     object = object,
     id = trajectory_id,
@@ -838,8 +859,7 @@ sgf_prepare_trajectory <- function(object, trajectory_id, start, end, traj_df, w
     traj_df = traj_df,
     start = start,
     end = end,
-    overwrite = TRUE,
-    verbose = verbose
+    overwrite = TRUE
   ))
   do.call(sgf_spata_fun("addSpatialTrajectory"), args)
 }

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -401,6 +401,7 @@ SpatialGradientPlot <- function(
   line_fit <- match.arg(line_fit)
   result <- sgf_get_result(srt, result_name = result_name)
   features <- sgf_plot_features(result, features = features, nfeatures = nfeatures)
+  layer <- sgf_plot_layer(srt = srt, result = result, assay = assay, layer = layer, features = features)
 
   if (identical(plot_type, "surface")) {
     return(sgf_surface_plot(
@@ -1336,6 +1337,49 @@ sgf_plot_features <- function(result, features = NULL, nfeatures = 4) {
     log_message("No {.arg features} are available for plotting", message_type = "error")
   }
   features
+}
+
+sgf_plot_layer <- function(srt, result, assay, layer, features) {
+  stored_layer <- sgf_parameter_value(result, "layer")
+  if (is.null(layer) || identical(layer, "") || identical(layer, NA_character_)) {
+    return(stored_layer %||% "data")
+  }
+  if (!identical(layer, "data") || is.null(stored_layer) || identical(stored_layer, layer)) {
+    return(layer)
+  }
+  assay <- assay %||% SeuratObject::DefaultAssay(srt)
+  expr <- tryCatch(
+    suppressWarnings(GetAssayData5(srt, assay = assay, layer = layer)),
+    error = function(e) NULL
+  )
+  has_features <- !is.null(expr) && all(features %in% rownames(expr))
+  if (isTRUE(has_features)) {
+    return(layer)
+  }
+  stored_expr <- tryCatch(
+    suppressWarnings(GetAssayData5(srt, assay = assay, layer = stored_layer)),
+    error = function(e) NULL
+  )
+  if (!is.null(stored_expr) && all(features %in% rownames(stored_expr))) {
+    return(stored_layer)
+  }
+  layer
+}
+
+sgf_parameter_value <- function(result, key) {
+  params <- result$parameters
+  if (!is.data.frame(params) || !"key" %in% colnames(params) || !"value" %in% colnames(params)) {
+    return(NULL)
+  }
+  idx <- which(params$key %in% key)
+  if (length(idx) == 0L) {
+    return(NULL)
+  }
+  val <- params$value[[idx[[1L]]]]
+  if (is.na(val) || !nzchar(val)) {
+    return(NULL)
+  }
+  as.character(val)
 }
 
 sgf_surface_plot <- function(

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -1,16 +1,21 @@
 #' @title Run spatial gradient feature screening
 #'
 #' @description
-#' Wrap SPATA2 spatial trajectory screening (STS) and spatial annotation
-#' screening (SAS) for Seurat objects. Results are normalized into plain
-#' data.frames and stored in `srt@tools[["SpatialGradientFeatures"]]`; the
-#' SPATA2 object itself is never stored.
+#' Run spatial trajectory or annotation gradient screening for Seurat objects.
+#' The native `"cpp"` backend avoids SPATA2 object construction for fast
+#' distance-based screening, while the `"spata2"` backend keeps full upstream
+#' SPATA2 SAS/STS behavior. Results are normalized into plain data.frames and
+#' stored in `srt@tools[["SpatialGradientFeatures"]]`; the SPATA2 object itself
+#' is never stored.
 #'
 #' @md
 #' @inheritParams RunSpatialVariableFeatures
 #' @inheritParams SpatialSpotPlot
 #' @param reference Spatial reference type: `"trajectory"` for STS or
 #' `"annotation"` for SAS.
+#' @param backend Computation backend. `"cpp"` uses SCOP's native fast spatial
+#' gradient implementation and avoids SPATA2 object construction. `"spata2"`
+#' uses SPATA2 directly for full upstream SAS/STS behavior.
 #' @param result_name Name used to store this result. If `NULL`, a name is
 #' generated from `reference`.
 #' @param spata_object Optional pre-built SPATA2 object. If `NULL`, `srt` is
@@ -20,6 +25,8 @@
 #' features, then all assay features.
 #' @param sample_name,platform,img_scale_fct,assay_modality Arguments forwarded
 #' to `SPATA2::asSPATA2()` when `spata_object` is `NULL`.
+#' @param coord.cols Metadata coordinate columns used by the native `"cpp"`
+#' backend when no image coordinates are available.
 #' @param trajectory_id,start,end,traj_df,width Trajectory setup passed to
 #' `SPATA2::addSpatialTrajectory()` and `SPATA2::spatialTrajectoryScreening()`.
 #' @param annotation_ids Existing SPATA2 spatial annotation ids. If `NULL`,
@@ -28,11 +35,16 @@
 #' @param annotation.by,annotation.groups Metadata grouping used to create
 #' SPATA2 group annotations.
 #' @param annotation.variable,annotation.threshold Numeric variable and
-#' threshold used to create SPATA2 numeric annotations.
+#' threshold used to create SPATA2 numeric annotations. Numeric thresholds are
+#' interpreted as `">{threshold}"`.
 #' @param annotation_id Base id used when creating annotations.
 #' @param core,distance,angle_span SAS parameters forwarded to SPATA2.
 #' @param resolution,unit,sign_var,sign_threshold,model_add,model_subset,model_remove,n_random,seed,control
 #' SPATA2 screening parameters.
+#' @param n_bins Number of distance bins used for the native `"cpp"` backend
+#' screening curve.
+#' @param min_spots Minimum number of non-zero spots required for a variable in
+#' the native `"cpp"` backend.
 #' @param nfeatures Number of top gradient variables retained in
 #' `top_variables` and optionally set as Seurat variable features.
 #' @param set_variable_features Whether to set top gradient variables as Seurat
@@ -58,6 +70,7 @@
 RunSpatialGradientFeatures <- function(
   srt,
   reference = c("trajectory", "annotation"),
+  backend = c("cpp", "spata2"),
   result_name = NULL,
   spata_object = NULL,
   assay = NULL,
@@ -66,6 +79,7 @@ RunSpatialGradientFeatures <- function(
   sample_name = NULL,
   platform = "Undefined",
   image = NULL,
+  coord.cols = c("x", "y"),
   img_scale_fct = "lowres",
   assay_modality = "gene",
   trajectory_id = "scop_gradient",
@@ -92,6 +106,8 @@ RunSpatialGradientFeatures <- function(
   n_random = 10000,
   seed = 123,
   control = NULL,
+  n_bins = 50,
+  min_spots = 3,
   nfeatures = 2000,
   set_variable_features = FALSE,
   store_results = TRUE,
@@ -101,8 +117,8 @@ RunSpatialGradientFeatures <- function(
   if (!inherits(srt, "Seurat")) {
     log_message("{.arg srt} must be a {.cls Seurat} object", message_type = "error")
   }
-  sgf_require_spata2()
   reference <- match.arg(reference)
+  backend <- match.arg(backend)
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
   if (!assay %in% SeuratObject::Assays(srt)) {
     log_message(
@@ -113,10 +129,26 @@ RunSpatialGradientFeatures <- function(
   if (!is.numeric(nfeatures) || length(nfeatures) != 1L || is.na(nfeatures) || nfeatures < 1) {
     log_message("{.arg nfeatures} must be a positive number", message_type = "error")
   }
+  if (!is.numeric(n_random) || length(n_random) != 1L || is.na(n_random) || n_random < 0) {
+    log_message("{.arg n_random} must be a non-negative number", message_type = "error")
+  }
+  if (!is.numeric(seed) || length(seed) != 1L || is.na(seed)) {
+    log_message("{.arg seed} must be a single numeric value", message_type = "error")
+  }
   nfeatures <- as.integer(nfeatures)
+  n_random <- as.integer(n_random)
+  seed <- as.integer(seed)
+  if (!is.numeric(n_bins) || length(n_bins) != 1L || is.na(n_bins) || n_bins < 1) {
+    log_message("{.arg n_bins} must be a positive number", message_type = "error")
+  }
+  if (!is.numeric(min_spots) || length(min_spots) != 1L || is.na(min_spots) || min_spots < 1) {
+    log_message("{.arg min_spots} must be a positive number", message_type = "error")
+  }
+  n_bins <- as.integer(n_bins)
+  min_spots <- as.integer(min_spots)
 
   log_message(
-    "Running SPATA2 spatial gradient screening",
+    "Running spatial gradient screening with {.val {backend}} backend",
     message_type = "running",
     verbose = verbose
   )
@@ -129,120 +161,168 @@ RunSpatialGradientFeatures <- function(
   )
   result_name <- result_name %||% paste0(reference, "_", format(Sys.time(), "%Y%m%d%H%M%S"))
 
-  spata_object <- spata_object %||% sgf_as_spata2(
-    srt = srt,
-    sample_name = sample_name %||% "scop_sample",
-    platform = platform,
-    assay = assay,
-    image = image,
-    img_scale_fct = img_scale_fct,
-    assay_modality = assay_modality,
-    verbose = verbose
-  )
-
-  if (identical(reference, "trajectory")) {
-    spata_object <- sgf_prepare_trajectory(
-      object = spata_object,
-      trajectory_id = trajectory_id,
+  if (identical(backend, "cpp")) {
+    result <- sgf_run_cpp_gradient(
+      srt = srt,
+      reference = reference,
+      assay = assay,
+      layer = layer,
+      variables = variables,
+      image = image,
+      coord.cols = coord.cols,
       start = start,
       end = end,
       traj_df = traj_df,
-      width = width,
-      verbose = verbose
-    )
-    screening_out <- sgf_run_trajectory_screening(
-      object = spata_object,
-      trajectory_id = trajectory_id,
-      variables = variables,
-      resolution = resolution,
-      width = width,
-      unit = unit,
-      sign_var = sign_var,
-      sign_threshold = sign_threshold,
-      model_add = model_add,
-      model_subset = model_subset,
-      model_remove = model_remove,
-      n_random = n_random,
-      seed = seed,
-      control = control,
-      verbose = verbose,
-      ...
-    )
-    annotation_ids_use <- character(0)
-  } else {
-    prep <- sgf_prepare_annotations(
-      object = spata_object,
       annotation_ids = annotation_ids,
       annotation.by = annotation.by,
       annotation.groups = annotation.groups,
       annotation.variable = annotation.variable,
       annotation.threshold = annotation.threshold,
-      annotation_id = annotation_id,
-      verbose = verbose
-    )
-    spata_object <- prep$object
-    annotation_ids_use <- prep$annotation_ids
-    screening_out <- sgf_run_annotation_screening(
-      object = spata_object,
-      annotation_ids = annotation_ids_use,
-      variables = variables,
-      core = core,
-      distance = distance,
-      resolution = resolution,
-      angle_span = angle_span,
-      unit = unit,
-      sign_var = sign_var,
-      sign_threshold = sign_threshold,
-      model_add = model_add,
-      model_subset = model_subset,
-      model_remove = model_remove,
       n_random = n_random,
       seed = seed,
-      control = control,
-      verbose = verbose,
-      ...
+      n_bins = n_bins,
+      min_spots = min_spots,
+      sign_var = sign_var,
+      sign_threshold = sign_threshold,
+      nfeatures = nfeatures,
+      parameters = list(
+        result_name = result_name,
+        reference = reference,
+        backend = backend,
+        assay = assay,
+        layer = layer,
+        image = image,
+        coord.cols = paste(coord.cols, collapse = ","),
+        trajectory_id = trajectory_id,
+        annotation.by = annotation.by,
+        annotation.groups = paste(annotation.groups %||% character(0), collapse = ","),
+        annotation.variable = annotation.variable,
+        annotation.threshold = annotation.threshold,
+        distance = distance,
+        n_random = n_random,
+        seed = seed,
+        n_bins = n_bins,
+        min_spots = min_spots
+      )
     )
-  }
-
-  result <- sgf_normalize_screening_result(
-    screening_out = screening_out,
-    spata_object = spata_object,
-    reference = reference,
-    variables = variables,
-    nfeatures = nfeatures,
-    trajectory_id = trajectory_id,
-    annotation_ids = annotation_ids_use,
-    distance = distance,
-    width = width,
-    unit = unit,
-    sign_var = sign_var,
-    sign_threshold = sign_threshold,
-    parameters = list(
-      result_name = result_name,
-      reference = reference,
-      assay = assay,
-      layer = layer,
+  } else {
+    sgf_require_spata2()
+    spata_object <- spata_object %||% sgf_as_spata2(
+      srt = srt,
       sample_name = sample_name %||% "scop_sample",
       platform = platform,
+      assay = assay,
       image = image,
       img_scale_fct = img_scale_fct,
       assay_modality = assay_modality,
+      verbose = verbose
+    )
+
+    if (identical(reference, "trajectory")) {
+      spata_object <- sgf_prepare_trajectory(
+        object = spata_object,
+        trajectory_id = trajectory_id,
+        start = start,
+        end = end,
+        traj_df = traj_df,
+        width = width,
+        verbose = verbose
+      )
+      screening_out <- sgf_run_trajectory_screening(
+        object = spata_object,
+        trajectory_id = trajectory_id,
+        variables = variables,
+        resolution = resolution,
+        width = width,
+        unit = unit,
+        sign_var = sign_var,
+        sign_threshold = sign_threshold,
+        model_add = model_add,
+        model_subset = model_subset,
+        model_remove = model_remove,
+        n_random = n_random,
+        seed = seed,
+        control = control,
+        verbose = verbose,
+        ...
+      )
+      annotation_ids_use <- character(0)
+    } else {
+      prep <- sgf_prepare_annotations(
+        object = spata_object,
+        annotation_ids = annotation_ids,
+        annotation.by = annotation.by,
+        annotation.groups = annotation.groups,
+        annotation.variable = annotation.variable,
+        annotation.threshold = annotation.threshold,
+        annotation_id = annotation_id,
+        verbose = verbose
+      )
+      spata_object <- prep$object
+      annotation_ids_use <- prep$annotation_ids
+      screening_out <- sgf_run_annotation_screening(
+        object = spata_object,
+        annotation_ids = annotation_ids_use,
+        variables = variables,
+        core = core,
+        distance = distance,
+        resolution = resolution,
+        angle_span = angle_span,
+        unit = unit,
+        sign_var = sign_var,
+        sign_threshold = sign_threshold,
+        model_add = model_add,
+        model_subset = model_subset,
+        model_remove = model_remove,
+        n_random = n_random,
+        seed = seed,
+        control = control,
+        verbose = verbose,
+        ...
+      )
+    }
+
+    result <- sgf_normalize_screening_result(
+      screening_out = screening_out,
+      spata_object = spata_object,
+      reference = reference,
+      variables = variables,
+      nfeatures = nfeatures,
       trajectory_id = trajectory_id,
-      annotation_ids = paste(annotation_ids_use, collapse = ","),
-      annotation.by = annotation.by,
-      annotation.groups = paste(annotation.groups %||% character(0), collapse = ","),
-      annotation.variable = annotation.variable,
-      annotation.threshold = annotation.threshold,
-      core = core,
+      annotation_ids = annotation_ids_use,
       distance = distance,
-      resolution = resolution,
+      width = width,
       unit = unit,
       sign_var = sign_var,
       sign_threshold = sign_threshold,
-      n_random = n_random,
-      seed = seed
+      parameters = list(
+        result_name = result_name,
+        reference = reference,
+        backend = backend,
+        assay = assay,
+        layer = layer,
+        sample_name = sample_name %||% "scop_sample",
+        platform = platform,
+        image = image,
+        img_scale_fct = img_scale_fct,
+        assay_modality = assay_modality,
+        trajectory_id = trajectory_id,
+        annotation_ids = paste(annotation_ids_use, collapse = ","),
+        annotation.by = annotation.by,
+        annotation.groups = paste(annotation.groups %||% character(0), collapse = ","),
+        annotation.variable = annotation.variable,
+        annotation.threshold = annotation.threshold,
+        core = core,
+        distance = distance,
+        resolution = resolution,
+        unit = unit,
+        sign_var = sign_var,
+        sign_threshold = sign_threshold,
+        n_random = n_random,
+        seed = seed
+      )
     )
-  )
+  }
 
   if (isTRUE(store_results)) {
     srt <- sgf_store_result(
@@ -420,8 +500,7 @@ SpatialGradientPlot <- function(
 }
 
 sgf_require_package <- function(pkg) {
-  ok <- check_r(pkg, verbose = FALSE)
-  if (!isTRUE(unname(ok[[pkg]]))) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
     log_message(
       "Please install required package before running this function: {.val {pkg}}",
       message_type = "error"
@@ -430,9 +509,13 @@ sgf_require_package <- function(pkg) {
   invisible(TRUE)
 }
 
+sgf_spata2_pkg <- function() {
+  "SPATA2"
+}
+
 sgf_require_spata2 <- function() {
-  ok <- check_r("theMILOlab/SPATA2", verbose = FALSE)
-  if (!isTRUE(unname(ok[["theMILOlab/SPATA2"]]))) {
+  pkg <- sgf_spata2_pkg()
+  if (!requireNamespace(pkg, quietly = TRUE)) {
     log_message(
       paste(
         "Please install SPATA2 before running spatial gradient screening.",
@@ -445,20 +528,15 @@ sgf_require_spata2 <- function() {
 }
 
 sgf_spata_fun <- function(fun, required = TRUE) {
-  if (isTRUE(required)) {
-    sgf_require_spata2()
-  }
-  out <- tryCatch(get_namespace_fun("SPATA2", fun), error = function(e) NULL)
-  if (!is.null(out)) {
-    return(out)
-  }
-  ns <- tryCatch(getNamespace("SPATA2"), error = function(e) NULL)
-  if (is.null(ns)) {
+  pkg <- sgf_spata2_pkg()
+  if (!requireNamespace(pkg, quietly = TRUE)) {
     if (isTRUE(required)) {
       sgf_require_spata2()
     }
     return(NULL)
   }
+  ns <- asNamespace(pkg)
+  out <- tryCatch(getExportedValue(pkg, fun), error = function(e) NULL)
   if (is.null(out) && exists(fun, envir = ns, mode = "function", inherits = TRUE)) {
     out <- get(fun, envir = ns, mode = "function", inherits = TRUE)
   }
@@ -526,6 +604,229 @@ sgf_as_spata2 <- function(
   do.call(sgf_spata_fun("asSPATA2"), args)
 }
 
+sgf_run_cpp_gradient <- function(
+  srt,
+  reference,
+  assay,
+  layer,
+  variables,
+  image,
+  coord.cols,
+  start,
+  end,
+  traj_df,
+  annotation_ids,
+  annotation.by,
+  annotation.groups,
+  annotation.variable,
+  annotation.threshold,
+  n_random,
+  seed,
+  n_bins,
+  min_spots,
+  sign_var,
+  sign_threshold,
+  nfeatures,
+  parameters
+) {
+  if (!is.null(annotation_ids) && length(annotation_ids) > 0L) {
+    log_message(
+      "{.arg annotation_ids} requires {.arg backend = 'spata2'} because SPATA2 annotation ids are not stored in Seurat metadata",
+      message_type = "error"
+    )
+  }
+
+  coords <- spatial_dim_coords(
+    srt = srt,
+    image = image,
+    coord.cols = coord.cols,
+    overlay_image = FALSE
+  )$data
+  spots <- intersect(colnames(srt), rownames(coords))
+  if (length(spots) == 0L) {
+    log_message("No spatial coordinates match spots in {.arg srt}", message_type = "error")
+  }
+  coords <- coords[spots, c("x", "y"), drop = FALSE]
+  keep_coords <- is.finite(coords$x) & is.finite(coords$y)
+  coords <- coords[keep_coords, , drop = FALSE]
+  spots <- rownames(coords)
+  if (length(spots) < 3L) {
+    log_message("At least three spots with finite coordinates are required", message_type = "error")
+  }
+
+  expr <- GetAssayData5(srt, assay = assay, layer = layer)
+  expr <- expr[variables, spots, drop = FALSE]
+  if (!methods::is(expr, "dgCMatrix")) {
+    expr <- methods::as(Matrix::Matrix(expr, sparse = TRUE), "dgCMatrix")
+  }
+
+  reference_spots <- sgf_cpp_reference_spots(
+    srt = srt,
+    spots = spots,
+    reference = reference,
+    annotation.by = annotation.by,
+    annotation.groups = annotation.groups,
+    annotation.variable = annotation.variable,
+    annotation.threshold = annotation.threshold
+  )
+  trajectory <- sgf_cpp_trajectory(
+    reference = reference,
+    start = start,
+    end = end,
+    traj_df = traj_df
+  )
+
+  out <- spatial_gradient_screening_cpp(
+    expr = expr,
+    coords = as.matrix(coords),
+    reference_spots = reference_spots,
+    trajectory = trajectory,
+    variables = rownames(expr),
+    mode = reference,
+    n_bins = n_bins,
+    n_random = as.integer(n_random),
+    seed = as.integer(seed),
+    min_spots = min_spots
+  )
+  significance <- sgf_standardize_significance(out$significance)
+  if ("p_value" %in% colnames(significance) && nrow(significance) > 0L) {
+    significance$fdr <- if (all(is.na(significance$p_value))) {
+      NA_real_
+    } else {
+      stats::p.adjust(significance$p_value, method = "BH")
+    }
+  }
+  model_fits <- sgf_standardize_model_fits(out$model_fits)
+  top_variables <- sgf_top_variables(
+    screening_out = list(),
+    significance = significance,
+    model_fits = model_fits,
+    nfeatures = nfeatures,
+    sign_var = sign_var,
+    sign_threshold = sign_threshold
+  )
+  list(
+    screening = sgf_standardize_screening_df(out$screening, reference = reference),
+    significance = significance,
+    model_fits = model_fits,
+    top_variables = top_variables,
+    parameters = sgf_parameters_df(parameters)
+  )
+}
+
+sgf_cpp_reference_spots <- function(
+  srt,
+  spots,
+  reference,
+  annotation.by,
+  annotation.groups,
+  annotation.variable,
+  annotation.threshold
+) {
+  if (!identical(reference, "annotation")) {
+    return(rep(FALSE, length(spots)))
+  }
+  meta <- srt@meta.data[spots, , drop = FALSE]
+  if (!is.null(annotation.by) && !is.null(annotation.groups)) {
+    if (!annotation.by %in% colnames(meta)) {
+      log_message("{.arg annotation.by} {.val {annotation.by}} is not present in metadata", message_type = "error")
+    }
+    out <- as.character(meta[[annotation.by]]) %in% as.character(annotation.groups)
+  } else if (!is.null(annotation.variable) && !is.null(annotation.threshold)) {
+    if (!annotation.variable %in% colnames(meta)) {
+      log_message(
+        "{.arg annotation.variable} {.val {annotation.variable}} is not present in metadata",
+        message_type = "error"
+      )
+    }
+    values <- meta[[annotation.variable]]
+    if (!is.numeric(values)) {
+      values <- suppressWarnings(as.numeric(as.character(values)))
+    }
+    out <- sgf_eval_annotation_threshold(values, annotation.threshold)
+  } else {
+    log_message(
+      paste(
+        "For {.arg reference = 'annotation'} with {.arg backend = 'cpp'}, provide",
+        "{.arg annotation.by} with {.arg annotation.groups}, or",
+        "{.arg annotation.variable} with {.arg annotation.threshold}"
+      ),
+      message_type = "error"
+    )
+  }
+  out[is.na(out)] <- FALSE
+  if (!any(out)) {
+    log_message("The annotation reference contains no matching spots", message_type = "error")
+  }
+  as.logical(out)
+}
+
+sgf_eval_annotation_threshold <- function(values, threshold) {
+  threshold <- sgf_format_annotation_threshold(threshold)
+  finite <- is.finite(values)
+  out <- rep(FALSE, length(values))
+  if (grepl("^kmeans_(high|low)$", threshold)) {
+    if (sum(finite) < 2L || length(unique(values[finite])) < 2L) {
+      log_message("k-means annotation threshold requires at least two finite values", message_type = "error")
+    }
+    set.seed(123)
+    km <- stats::kmeans(values[finite], centers = 2)
+    means <- tapply(values[finite], km$cluster, mean)
+    keep <- if (identical(threshold, "kmeans_high")) {
+      names(which.max(means))
+    } else {
+      names(which.min(means))
+    }
+    out[finite] <- as.character(km$cluster) == keep
+    return(out)
+  }
+  op <- sub("^\\s*(>=|<=|>|<).*$", "\\1", threshold)
+  cutoff <- suppressWarnings(as.numeric(sub("^\\s*(>=|<=|>|<)\\s*", "", threshold)))
+  if (!is.finite(cutoff)) {
+    log_message("{.arg annotation.threshold} contains a non-finite cutoff", message_type = "error")
+  }
+  out[finite] <- switch(
+    op,
+    ">" = values[finite] > cutoff,
+    ">=" = values[finite] >= cutoff,
+    "<" = values[finite] < cutoff,
+    "<=" = values[finite] <= cutoff,
+    log_message("{.arg annotation.threshold} must start with >, >=, <, or <=", message_type = "error")
+  )
+  out
+}
+
+sgf_cpp_trajectory <- function(reference, start, end, traj_df) {
+  if (!identical(reference, "trajectory")) {
+    return(matrix(numeric(0), ncol = 2L))
+  }
+  if (!is.null(traj_df)) {
+    traj_df <- as.data.frame(traj_df, check.names = FALSE)
+    x_col <- intersect(c("x", "X", "col", "imagecol", "pxl_col_in_fullres"), colnames(traj_df))[1L]
+    y_col <- intersect(c("y", "Y", "row", "imagerow", "pxl_row_in_fullres"), colnames(traj_df))[1L]
+    if (is.na(x_col) || is.na(y_col)) {
+      numeric_cols <- names(traj_df)[vapply(traj_df, is.numeric, logical(1))]
+      if (length(numeric_cols) < 2L) {
+        log_message("{.arg traj_df} must contain x/y columns or at least two numeric columns", message_type = "error")
+      }
+      x_col <- numeric_cols[1L]
+      y_col <- numeric_cols[2L]
+    }
+    out <- as.matrix(traj_df[, c(x_col, y_col), drop = FALSE])
+  } else if (!is.null(start) && !is.null(end)) {
+    out <- rbind(as.numeric(start), as.numeric(end))
+  } else {
+    log_message(
+      "For {.arg reference = 'trajectory'} with {.arg backend = 'cpp'}, provide {.arg start}/{.arg end} or {.arg traj_df}",
+      message_type = "error"
+    )
+  }
+  if (!is.numeric(out) || ncol(out) != 2L || nrow(out) < 2L || any(!is.finite(out))) {
+    log_message("{.arg start}/{.arg end} or {.arg traj_df} must define at least two finite x/y coordinates", message_type = "error")
+  }
+  out
+}
+
 sgf_prepare_trajectory <- function(object, trajectory_id, start, end, traj_df, width, verbose) {
   if (is.null(start) && is.null(end) && is.null(traj_df)) {
     return(object)
@@ -572,6 +873,7 @@ sgf_prepare_annotations <- function(
     ))
   }
   if (!is.null(annotation.variable) && !is.null(annotation.threshold)) {
+    annotation.threshold <- sgf_format_annotation_threshold(annotation.threshold)
     object <- do.call(sgf_spata_fun("createNumericAnnotations"), sgf_drop_nulls(list(
       object = object,
       variable = annotation.variable,
@@ -591,6 +893,38 @@ sgf_prepare_annotations <- function(
       "For {.arg reference = 'annotation'}, provide {.arg annotation_ids},",
       "or {.arg annotation.by} with {.arg annotation.groups},",
       "or {.arg annotation.variable} with {.arg annotation.threshold}"
+    ),
+    message_type = "error"
+  )
+}
+
+sgf_format_annotation_threshold <- function(threshold) {
+  if (length(threshold) != 1L || is.na(threshold)) {
+    log_message(
+      "{.arg annotation.threshold} must be a single non-missing value",
+      message_type = "error"
+    )
+  }
+  if (is.numeric(threshold)) {
+    return(paste0(">", format(threshold, scientific = FALSE, trim = TRUE)))
+  }
+  threshold <- trimws(as.character(threshold))
+  if (!nzchar(threshold)) {
+    log_message("{.arg annotation.threshold} must not be empty", message_type = "error")
+  }
+  if (grepl("^kmeans_(high|low)$", threshold)) {
+    return(threshold)
+  }
+  if (grepl("^(>=|<=|>|<)\\s*[-+]?(\\d+\\.?\\d*|\\.\\d+)([eE][-+]?\\d+)?$", threshold)) {
+    return(gsub("\\s+", "", threshold))
+  }
+  if (grepl("^[-+]?(\\d+\\.?\\d*|\\.\\d+)([eE][-+]?\\d+)?$", threshold)) {
+    return(paste0(">", threshold))
+  }
+  log_message(
+    paste(
+      "{.arg annotation.threshold} must be numeric, a comparison string such as {.val >0},",
+      "{.val <=1}, or one of {.val kmeans_high}/{.val kmeans_low}"
     ),
     message_type = "error"
   )
@@ -1165,7 +1499,7 @@ sgf_gradient_colors <- function(palette = "Spectral", palcolor = NULL) {
 
 sgf_parameters_df <- function(parameters) {
   parameters$scop_version <- sgf_package_version("scop")
-  parameters$spata2_version <- sgf_package_version("SPATA2")
+  parameters$spata2_version <- sgf_package_version(sgf_spata2_pkg())
   data.frame(
     key = names(parameters),
     value = vapply(parameters, sgf_collapse_value, character(1)),

--- a/inst/benchmarks/benchmark_spatial_gradient_cpp.R
+++ b/inst/benchmarks/benchmark_spatial_gradient_cpp.R
@@ -67,6 +67,21 @@ load_scop_for_benchmark <- function(package_root = ".") {
   invisible(TRUE)
 }
 
+scop_benchmark_fun <- function(name) {
+  if (exists(name, envir = .GlobalEnv, mode = "function", inherits = TRUE)) {
+    return(get(name, envir = .GlobalEnv, mode = "function", inherits = TRUE))
+  }
+  exported <- tryCatch(getExportedValue("scop", name), error = function(e) NULL)
+  if (is.function(exported)) {
+    return(exported)
+  }
+  ns <- asNamespace("scop")
+  if (exists(name, envir = ns, mode = "function", inherits = TRUE)) {
+    return(get(name, envir = ns, mode = "function", inherits = TRUE))
+  }
+  stop("Cannot find scop function: ", name, call. = FALSE)
+}
+
 format_seconds <- function(x) {
   if (!is.finite(x)) {
     return("NA")
@@ -262,7 +277,7 @@ run_gradient_backend <- function(
   }
 
   timed <- time_run(function() {
-    out <- do.call(scop::RunSpatialGradientFeatures, base_args)
+    out <- do.call(scop_benchmark_fun("RunSpatialGradientFeatures"), base_args)
     extract_gradient_result(out, result_name)
   })
   list(
@@ -508,6 +523,10 @@ make_summary_metrics <- function(case, runs, pairwise) {
   ok_times <- run_df$elapsed[run_df$status == "ok" & is.finite(run_df$elapsed)]
   min_time <- if (length(ok_times) > 0L) min(ok_times) else NA_real_
   spata_time <- run_df$elapsed[match("spata2", run_df$backend)]
+  has_pairwise <- all(vapply(runs, function(run) identical(run$status, "ok"), logical(1))) &&
+    is.data.frame(pairwise) &&
+    is.finite(as.numeric(pairwise$common_variables)) &&
+    as.numeric(pairwise$common_variables) > 0
   rows <- list()
   i <- 1L
 
@@ -529,10 +548,18 @@ make_summary_metrics <- function(case, runs, pairwise) {
     i <- i + 1L
     rows[[i]] <- metric_row(case, method, "Speedup", "Runtime", speedup, speedup_score, if (is.finite(speedup)) paste0(format_number(speedup, 3), "x") else "NA", row$status)
     i <- i + 1L
-    rows[[i]] <- metric_row(case, method, "Schema", "Integrity", as.numeric(row$schema_ok), as.numeric(row$schema_ok), if (row$schema_ok) "pass" else "fail", if (row$schema_ok) "pass" else "fail", threshold = 1)
+    schema_status <- if (identical(row$status, "skipped")) "skipped" else if (row$schema_ok) "pass" else "fail"
+    schema_value <- if (identical(row$status, "skipped")) NA_real_ else as.numeric(row$schema_ok)
+    rows[[i]] <- metric_row(case, method, "Schema", "Integrity", schema_value, if (is.finite(schema_value)) schema_value else 0, if (is.finite(schema_value)) schema_status else "NA", schema_status, threshold = 1)
     i <- i + 1L
-    rows[[i]] <- metric_row(case, method, "No S4 object", "Integrity", as.numeric(row$no_spata2_object), as.numeric(row$no_spata2_object), if (row$no_spata2_object) "pass" else "fail", if (row$no_spata2_object) "pass" else "fail", threshold = 1)
+    s4_status <- if (identical(row$status, "skipped")) "skipped" else if (row$no_spata2_object) "pass" else "fail"
+    s4_value <- if (identical(row$status, "skipped")) NA_real_ else as.numeric(row$no_spata2_object)
+    rows[[i]] <- metric_row(case, method, "No S4 object", "Integrity", s4_value, if (is.finite(s4_value)) s4_value else 0, if (is.finite(s4_value)) s4_status else "NA", s4_status, threshold = 1)
     i <- i + 1L
+
+    if (!isTRUE(has_pairwise)) {
+      next
+    }
 
     agreement_values <- if (identical(run$backend, "spata2") && ok) {
       list(

--- a/inst/benchmarks/benchmark_spatial_gradient_cpp.R
+++ b/inst/benchmarks/benchmark_spatial_gradient_cpp.R
@@ -19,7 +19,7 @@ parse_cli_args <- function(args = commandArgs(trailingOnly = TRUE)) {
   out <- list(
     output_dir = file.path("inst", "benchmarks", "spatial_gradient_cpp"),
     reference = "trajectory",
-    n_spots = 80L,
+    n_spots = 0L,
     n_variables = 6L,
     n_random = 20L,
     n_bins = 25L,
@@ -126,7 +126,7 @@ time_run <- function(fn) {
   }
 }
 
-make_spatial_gradient_fixture <- function(n_spots = 80L, n_variables = 6L, seed = 1L) {
+make_spatial_gradient_fixture <- function(n_spots = 0L, n_variables = 6L, seed = 1L) {
   data(visium_human_pancreas_sub, package = "scop", envir = environment())
   srt <- visium_human_pancreas_sub
   SeuratObject::DefaultAssay(srt) <- "Spatial"
@@ -141,13 +141,21 @@ make_spatial_gradient_fixture <- function(n_spots = 80L, n_variables = 6L, seed 
     srt <- subset(srt, cells = cells)
   }
 
+  expr <- GetAssayData5(srt, assay = "Spatial", layer = "counts")
   candidate_variables <- c(
     "TMSB4X", "COL1A1", "COL3A1", "FOS", "B2M", "IGFBP7",
     "SPP1", "KRT19", "MALAT1", "ACTB"
   )
-  variables <- intersect(candidate_variables, rownames(srt))
+  candidate_variables <- intersect(candidate_variables, rownames(expr))
+  coverage <- Matrix::rowSums(expr > 0) / ncol(expr)
+  mean_expr <- Matrix::rowMeans(expr)
+  candidate_variables <- candidate_variables[
+    order(coverage[candidate_variables], mean_expr[candidate_variables], decreasing = TRUE)
+  ]
+  variables <- candidate_variables[coverage[candidate_variables] >= 0.05]
   if (length(variables) < n_variables) {
-    fallback <- setdiff(rownames(srt), variables)
+    fallback <- setdiff(names(sort(coverage, decreasing = TRUE)), variables)
+    fallback <- fallback[coverage[fallback] >= 0.05]
     variables <- c(variables, head(fallback, n_variables - length(variables)))
   }
   variables <- head(unique(variables), n_variables)

--- a/inst/benchmarks/benchmark_spatial_gradient_cpp.R
+++ b/inst/benchmarks/benchmark_spatial_gradient_cpp.R
@@ -1,0 +1,700 @@
+# Benchmark RunSpatialGradientFeatures backend = "spata2" vs backend = "cpp".
+# Run from the package root after installing SPATA2 and scop.
+
+`%||%` <- function(x, y) {
+  if (is.null(x)) y else x
+}
+
+default_thresholds <- list(
+  top_k_jaccard = 0.70,
+  rank_spearman = 0.80,
+  fdr_spearman = 0.90,
+  p_value_spearman = 0.90,
+  tot_var_spearman = 0.80,
+  estimate_curve_pearson = 0.90,
+  value_curve_pearson = 0.80
+)
+
+parse_cli_args <- function(args = commandArgs(trailingOnly = TRUE)) {
+  out <- list(
+    output_dir = file.path("inst", "benchmarks", "spatial_gradient_cpp"),
+    reference = "trajectory",
+    n_spots = 80L,
+    n_variables = 6L,
+    n_random = 20L,
+    n_bins = 25L,
+    resolution = 25,
+    seed = 1L,
+    run_spata2 = TRUE,
+    strict = FALSE,
+    verbose = FALSE
+  )
+  for (arg in args) {
+    if (identical(arg, "--skip-spata2") || identical(arg, "--cpp-only")) {
+      out$run_spata2 <- FALSE
+    } else if (identical(arg, "--strict")) {
+      out$strict <- TRUE
+    } else if (identical(arg, "--verbose")) {
+      out$verbose <- TRUE
+    } else if (grepl("^--[^=]+=", arg)) {
+      key <- sub("^--([^=]+)=.*$", "\\1", arg)
+      value <- sub("^--[^=]+=", "", arg)
+      key <- chartr("-", "_", key)
+      out[[key]] <- value
+    }
+  }
+  int_keys <- c("n_spots", "n_variables", "n_random", "n_bins", "seed")
+  for (key in int_keys) {
+    out[[key]] <- as.integer(out[[key]])
+  }
+  out$resolution <- as.numeric(out$resolution)
+  out$reference <- match.arg(out$reference, c("trajectory", "annotation"))
+  out
+}
+
+load_scop_for_benchmark <- function(package_root = ".") {
+  loaded <- FALSE
+  if (file.exists(file.path(package_root, "DESCRIPTION")) &&
+      requireNamespace("pkgload", quietly = TRUE)) {
+    loaded <- tryCatch({
+      pkgload::load_all(package_root, quiet = TRUE)
+      TRUE
+    }, error = function(e) FALSE)
+  }
+  if (!isTRUE(loaded)) {
+    suppressPackageStartupMessages(library(scop))
+  }
+  invisible(TRUE)
+}
+
+format_seconds <- function(x) {
+  if (!is.finite(x)) {
+    return("NA")
+  }
+  if (x < 0.01) {
+    sprintf("%.3fs", x)
+  } else if (x < 10) {
+    sprintf("%.2fs", x)
+  } else {
+    sprintf("%.1fs", x)
+  }
+}
+
+format_number <- function(x, digits = 3) {
+  if (!is.finite(x)) {
+    return("NA")
+  }
+  format(signif(x, digits), trim = TRUE, scientific = FALSE)
+}
+
+safe_cor <- function(x, y, method = "spearman") {
+  keep <- is.finite(x) & is.finite(y)
+  x <- x[keep]
+  y <- y[keep]
+  if (length(x) < 3L || length(unique(x)) < 2L || length(unique(y)) < 2L) {
+    return(NA_real_)
+  }
+  suppressWarnings(stats::cor(x, y, method = method))
+}
+
+safe_mae <- function(x, y) {
+  keep <- is.finite(x) & is.finite(y)
+  if (!any(keep)) {
+    return(NA_real_)
+  }
+  mean(abs(x[keep] - y[keep]))
+}
+
+time_run <- function(fn) {
+  warnings <- character()
+  start <- proc.time()
+  value <- tryCatch(
+    withCallingHandlers(
+      fn(),
+      warning = function(w) {
+        warnings <<- c(warnings, conditionMessage(w))
+        invokeRestart("muffleWarning")
+      }
+    ),
+    error = function(e) e
+  )
+  elapsed <- as.numeric((proc.time() - start)[["elapsed"]])
+  if (inherits(value, "error")) {
+    list(ok = FALSE, value = NULL, elapsed = elapsed, error = conditionMessage(value), warnings = warnings)
+  } else {
+    list(ok = TRUE, value = value, elapsed = elapsed, error = NA_character_, warnings = warnings)
+  }
+}
+
+make_spatial_gradient_fixture <- function(n_spots = 80L, n_variables = 6L, seed = 1L) {
+  data(visium_human_pancreas_sub, package = "scop", envir = environment())
+  srt <- visium_human_pancreas_sub
+  SeuratObject::DefaultAssay(srt) <- "Spatial"
+  if (is.finite(n_spots) && n_spots > 0L && n_spots < ncol(srt)) {
+    meta <- srt@meta.data
+    set.seed(seed)
+    panin_cells <- rownames(meta)[is.finite(meta$coda_panin) & meta$coda_panin > 0]
+    keep_panin <- head(panin_cells[order(meta[panin_cells, "coda_panin"], decreasing = TRUE)], min(length(panin_cells), max(1L, n_spots %/% 5L)))
+    other_cells <- setdiff(colnames(srt), keep_panin)
+    keep_other <- sample(other_cells, min(length(other_cells), max(0L, n_spots - length(keep_panin))))
+    cells <- unique(c(keep_panin, keep_other))
+    srt <- subset(srt, cells = cells)
+  }
+
+  candidate_variables <- c(
+    "TMSB4X", "COL1A1", "COL3A1", "FOS", "B2M", "IGFBP7",
+    "SPP1", "KRT19", "MALAT1", "ACTB"
+  )
+  variables <- intersect(candidate_variables, rownames(srt))
+  if (length(variables) < n_variables) {
+    fallback <- setdiff(rownames(srt), variables)
+    variables <- c(variables, head(fallback, n_variables - length(variables)))
+  }
+  variables <- head(unique(variables), n_variables)
+
+  if (all(c("x", "y") %in% colnames(srt@meta.data))) {
+    coords <- data.frame(
+      x = srt@meta.data[["x"]],
+      y = srt@meta.data[["y"]],
+      row.names = rownames(srt@meta.data),
+      stringsAsFactors = FALSE
+    )
+  } else {
+    coords <- spatial_dim_coords(
+      srt = srt,
+      image = NULL,
+      coord.cols = c("x", "y"),
+      overlay_image = FALSE
+    )$data
+  }
+  coords <- coords[colnames(srt), c("x", "y"), drop = FALSE]
+  meta_use <- srt@meta.data[rownames(coords), , drop = FALSE]
+  if ("coda_panin" %in% colnames(meta_use) && any(meta_use$coda_panin > 0, na.rm = TRUE)) {
+    start_idx <- which.max(meta_use$coda_panin)
+  } else {
+    start_idx <- which.min(coords$x)
+  }
+  start <- as.numeric(coords[start_idx, c("x", "y")])
+  sq_dist <- (coords$x - start[1])^2 + (coords$y - start[2])^2
+  end <- as.numeric(coords[which.max(sq_dist), c("x", "y")])
+
+  list(
+    srt = srt,
+    variables = variables,
+    start = start,
+    end = end,
+    annotation.variable = "coda_panin",
+    annotation.threshold = 0
+  )
+}
+
+extract_gradient_result <- function(srt, result_name) {
+  x <- srt@tools[["SpatialGradientFeatures"]][[result_name]]
+  if (is.null(x)) {
+    stop("Stored spatial gradient result was not found: ", result_name, call. = FALSE)
+  }
+  x
+}
+
+run_gradient_backend <- function(
+  fixture,
+  backend,
+  reference,
+  result_name,
+  n_random,
+  n_bins,
+  resolution,
+  seed,
+  verbose
+) {
+  if (identical(backend, "spata2") && !requireNamespace("SPATA2", quietly = TRUE)) {
+    return(list(
+      backend = backend,
+      status = "skipped",
+      elapsed = NA_real_,
+      error = "SPATA2 is not installed",
+      warnings = character(),
+      result = NULL
+    ))
+  }
+  if (identical(backend, "spata2")) {
+    suppressPackageStartupMessages(library(SPATA2))
+  }
+
+  base_args <- list(
+    srt = fixture$srt,
+    reference = reference,
+    backend = backend,
+    result_name = result_name,
+    assay = "Spatial",
+    layer = "counts",
+    platform = "VisiumSmall",
+    variables = fixture$variables,
+    n_random = n_random,
+    seed = seed,
+    sign_threshold = 1,
+    nfeatures = length(fixture$variables),
+    verbose = verbose
+  )
+  if (identical(reference, "trajectory")) {
+    base_args$start <- fixture$start
+    base_args$end <- fixture$end
+  } else {
+    base_args$annotation.variable <- fixture$annotation.variable
+    base_args$annotation.threshold <- fixture$annotation.threshold
+  }
+  if (identical(backend, "cpp")) {
+    base_args$n_bins <- n_bins
+    base_args$min_spots <- 1L
+  } else {
+    base_args$resolution <- resolution
+    base_args$force_comp <- TRUE
+    base_args$rm_zero_infl <- FALSE
+    base_args$estimate_R2 <- FALSE
+  }
+
+  timed <- time_run(function() {
+    out <- do.call(scop::RunSpatialGradientFeatures, base_args)
+    extract_gradient_result(out, result_name)
+  })
+  list(
+    backend = backend,
+    status = if (isTRUE(timed$ok)) "ok" else "error",
+    elapsed = timed$elapsed,
+    error = timed$error,
+    warnings = timed$warnings,
+    result = timed$value
+  )
+}
+
+table_nrow <- function(result, name) {
+  if (is.null(result) || !is.data.frame(result[[name]])) {
+    return(NA_integer_)
+  }
+  nrow(result[[name]])
+}
+
+schema_ok <- function(result) {
+  expected <- c("screening", "significance", "model_fits", "top_variables", "parameters")
+  if (is.null(result) || !identical(names(result), expected)) {
+    return(FALSE)
+  }
+  all(vapply(result, is.data.frame, logical(1)))
+}
+
+contains_spata2_object <- function(x) {
+  if (is.null(x)) {
+    return(FALSE)
+  }
+  if (methods::is(x, "SPATA2")) {
+    return(TRUE)
+  }
+  if (is.list(x)) {
+    return(any(vapply(x, contains_spata2_object, logical(1))))
+  }
+  FALSE
+}
+
+result_summary <- function(run, case) {
+  data.frame(
+    case = case,
+    backend = run$backend,
+    status = run$status,
+    elapsed = run$elapsed,
+    error = run$error,
+    warnings = paste(unique(run$warnings), collapse = " | "),
+    screening_rows = table_nrow(run$result, "screening"),
+    significance_rows = table_nrow(run$result, "significance"),
+    model_fits_rows = table_nrow(run$result, "model_fits"),
+    top_variables_rows = table_nrow(run$result, "top_variables"),
+    schema_ok = schema_ok(run$result),
+    no_spata2_object = !contains_spata2_object(run$result),
+    stringsAsFactors = FALSE
+  )
+}
+
+merge_by_variable <- function(ref, cmp, table_name, cols) {
+  if (is.null(ref) || is.null(cmp) ||
+      !is.data.frame(ref[[table_name]]) || !is.data.frame(cmp[[table_name]])) {
+    return(data.frame())
+  }
+  a <- ref[[table_name]]
+  b <- cmp[[table_name]]
+  if (!"variable" %in% colnames(a) || !"variable" %in% colnames(b)) {
+    return(data.frame())
+  }
+  keep_a <- unique(c("variable", intersect(cols, colnames(a))))
+  keep_b <- unique(c("variable", intersect(cols, colnames(b))))
+  a <- a[, keep_a, drop = FALSE]
+  b <- b[, keep_b, drop = FALSE]
+  merge(a, b, by = "variable", suffixes = c("_spata2", "_cpp"))
+}
+
+compare_significance <- function(ref, cmp) {
+  merged <- merge_by_variable(ref, cmp, "significance", c("tot_var", "p_value", "fdr"))
+  if (nrow(merged) == 0L) {
+    return(data.frame(
+      common_variables = 0,
+      fdr_spearman = NA_real_,
+      p_value_spearman = NA_real_,
+      tot_var_spearman = NA_real_,
+      fdr_mae = NA_real_,
+      p_value_mae = NA_real_,
+      significance_call_agreement = NA_real_
+    ))
+  }
+  fdr_ref <- as.numeric(merged$fdr_spata2)
+  fdr_cpp <- as.numeric(merged$fdr_cpp)
+  p_ref <- as.numeric(merged$p_value_spata2)
+  p_cpp <- as.numeric(merged$p_value_cpp)
+  tot_ref <- as.numeric(merged$tot_var_spata2)
+  tot_cpp <- as.numeric(merged$tot_var_cpp)
+  data.frame(
+    common_variables = nrow(merged),
+    fdr_spearman = safe_cor(fdr_ref, fdr_cpp, method = "spearman"),
+    p_value_spearman = safe_cor(p_ref, p_cpp, method = "spearman"),
+    tot_var_spearman = safe_cor(tot_ref, tot_cpp, method = "spearman"),
+    fdr_mae = safe_mae(fdr_ref, fdr_cpp),
+    p_value_mae = safe_mae(p_ref, p_cpp),
+    significance_call_agreement = mean((fdr_ref <= 0.05) == (fdr_cpp <= 0.05), na.rm = TRUE)
+  )
+}
+
+compare_top_variables <- function(ref, cmp, k = 10L) {
+  ref_top <- ref$top_variables$variable %||% character()
+  cmp_top <- cmp$top_variables$variable %||% character()
+  ref_top <- ref_top[!is.na(ref_top) & nzchar(ref_top)]
+  cmp_top <- cmp_top[!is.na(cmp_top) & nzchar(cmp_top)]
+  k <- min(k, length(ref_top), length(cmp_top))
+  if (k < 1L) {
+    return(data.frame(top_k = 0, top_k_jaccard = NA_real_, rank_spearman = NA_real_, top1_match = NA_real_))
+  }
+  ref_k <- head(ref_top, k)
+  cmp_k <- head(cmp_top, k)
+  union_k <- union(ref_k, cmp_k)
+  common <- intersect(ref_top, cmp_top)
+  ref_rank <- match(common, ref_top)
+  cmp_rank <- match(common, cmp_top)
+  data.frame(
+    top_k = k,
+    top_k_jaccard = length(intersect(ref_k, cmp_k)) / length(union_k),
+    rank_spearman = safe_cor(ref_rank, cmp_rank, method = "spearman"),
+    top1_match = identical(ref_top[1], cmp_top[1])
+  )
+}
+
+curve_vector <- function(df, variable, column, grid) {
+  if (!all(c("variable", "distance", column) %in% colnames(df))) {
+    return(NULL)
+  }
+  x <- df[df$variable == variable, c("distance", column), drop = FALSE]
+  distance <- suppressWarnings(as.numeric(x$distance))
+  value <- suppressWarnings(as.numeric(x[[column]]))
+  keep <- is.finite(distance) & is.finite(value)
+  distance <- distance[keep]
+  value <- value[keep]
+  if (length(distance) < 2L || diff(range(distance)) <= 0) {
+    return(NULL)
+  }
+  distance <- (distance - min(distance)) / diff(range(distance))
+  agg <- stats::aggregate(value, list(distance = distance), mean)
+  if (nrow(agg) < 2L) {
+    return(NULL)
+  }
+  stats::approx(agg$distance, agg$x, xout = grid, rule = 2, ties = mean)$y
+}
+
+compare_screening_curves <- function(ref, cmp, grid_n = 50L) {
+  if (!is.data.frame(ref$screening) || !is.data.frame(cmp$screening)) {
+    return(data.frame(
+      curve_variables = 0,
+      estimate_curve_pearson = NA_real_,
+      estimate_curve_spearman = NA_real_,
+      value_curve_pearson = NA_real_,
+      value_curve_spearman = NA_real_
+    ))
+  }
+  variables <- intersect(ref$screening$variable, cmp$screening$variable)
+  grid <- seq(0, 1, length.out = grid_n)
+  out <- list()
+  for (column in c("estimate", "value")) {
+    ref_values <- numeric()
+    cmp_values <- numeric()
+    used <- character()
+    for (variable in variables) {
+      a <- curve_vector(ref$screening, variable, column, grid)
+      b <- curve_vector(cmp$screening, variable, column, grid)
+      if (!is.null(a) && !is.null(b)) {
+        ref_values <- c(ref_values, a)
+        cmp_values <- c(cmp_values, b)
+        used <- c(used, variable)
+      }
+    }
+    out[[paste0(column, "_variables")]] <- length(unique(used))
+    out[[paste0(column, "_curve_pearson")]] <- safe_cor(ref_values, cmp_values, method = "pearson")
+    out[[paste0(column, "_curve_spearman")]] <- safe_cor(ref_values, cmp_values, method = "spearman")
+  }
+  data.frame(
+    curve_variables = max(out$estimate_variables, out$value_variables),
+    estimate_curve_pearson = out$estimate_curve_pearson,
+    estimate_curve_spearman = out$estimate_curve_spearman,
+    value_curve_pearson = out$value_curve_pearson,
+    value_curve_spearman = out$value_curve_spearman
+  )
+}
+
+compare_backends <- function(spata2_result, cpp_result) {
+  if (is.null(spata2_result) || is.null(cpp_result)) {
+    return(data.frame(
+      common_variables = 0,
+      fdr_spearman = NA_real_,
+      p_value_spearman = NA_real_,
+      tot_var_spearman = NA_real_,
+      fdr_mae = NA_real_,
+      p_value_mae = NA_real_,
+      significance_call_agreement = NA_real_,
+      top_k = 0,
+      top_k_jaccard = NA_real_,
+      rank_spearman = NA_real_,
+      top1_match = NA,
+      curve_variables = 0,
+      estimate_curve_pearson = NA_real_,
+      estimate_curve_spearman = NA_real_,
+      value_curve_pearson = NA_real_,
+      value_curve_spearman = NA_real_
+    ))
+  }
+  cbind(
+    compare_significance(spata2_result, cpp_result),
+    compare_top_variables(spata2_result, cpp_result),
+    compare_screening_curves(spata2_result, cpp_result)
+  )
+}
+
+metric_status <- function(value, threshold, higher_is_better = TRUE) {
+  if (!is.finite(value) || !is.finite(threshold)) {
+    return("na")
+  }
+  pass <- if (isTRUE(higher_is_better)) value >= threshold else value <= threshold
+  if (isTRUE(pass)) "pass" else "fail"
+}
+
+metric_row <- function(case, method, metric, group, value, score, label, status, threshold = NA_real_, higher_is_better = TRUE) {
+  data.frame(
+    case = case,
+    method = method,
+    metric = metric,
+    group = group,
+    value = value,
+    score = pmin(pmax(score, 0), 1),
+    label = label,
+    status = status,
+    threshold = threshold,
+    higher_is_better = higher_is_better,
+    stringsAsFactors = FALSE
+  )
+}
+
+make_summary_metrics <- function(case, runs, pairwise) {
+  run_df <- do.call(rbind, lapply(runs, result_summary, case = case))
+  ok_times <- run_df$elapsed[run_df$status == "ok" & is.finite(run_df$elapsed)]
+  min_time <- if (length(ok_times) > 0L) min(ok_times) else NA_real_
+  spata_time <- run_df$elapsed[match("spata2", run_df$backend)]
+  rows <- list()
+  i <- 1L
+
+  for (run in runs) {
+    method <- if (identical(run$backend, "spata2")) "SPATA2" else "SCOP C++"
+    row <- run_df[run_df$backend == run$backend, , drop = FALSE]
+    ok <- identical(row$status, "ok")
+    runtime_score <- if (ok && is.finite(min_time) && is.finite(row$elapsed)) min_time / row$elapsed else 0
+    speedup <- if (identical(run$backend, "cpp") && ok && is.finite(spata_time) && is.finite(row$elapsed)) {
+      spata_time / row$elapsed
+    } else if (identical(run$backend, "spata2") && ok) {
+      1
+    } else {
+      NA_real_
+    }
+    speedup_score <- if (is.finite(speedup)) min(log1p(speedup) / log1p(max(speedup, 1)), 1) else 0
+
+    rows[[i]] <- metric_row(case, method, "Runtime", "Runtime", row$elapsed, runtime_score, format_seconds(row$elapsed), row$status)
+    i <- i + 1L
+    rows[[i]] <- metric_row(case, method, "Speedup", "Runtime", speedup, speedup_score, if (is.finite(speedup)) paste0(format_number(speedup, 3), "x") else "NA", row$status)
+    i <- i + 1L
+    rows[[i]] <- metric_row(case, method, "Schema", "Integrity", as.numeric(row$schema_ok), as.numeric(row$schema_ok), if (row$schema_ok) "pass" else "fail", if (row$schema_ok) "pass" else "fail", threshold = 1)
+    i <- i + 1L
+    rows[[i]] <- metric_row(case, method, "No S4 object", "Integrity", as.numeric(row$no_spata2_object), as.numeric(row$no_spata2_object), if (row$no_spata2_object) "pass" else "fail", if (row$no_spata2_object) "pass" else "fail", threshold = 1)
+    i <- i + 1L
+
+    agreement_values <- if (identical(run$backend, "spata2") && ok) {
+      list(
+        "TopK Jaccard" = 1,
+        "Rank rho" = 1,
+        "FDR rho" = 1,
+        "P-value rho" = 1,
+        "Curve rho" = 1
+      )
+    } else if (identical(run$backend, "cpp") && ok) {
+      list(
+        "TopK Jaccard" = pairwise$top_k_jaccard,
+        "Rank rho" = pairwise$rank_spearman,
+        "FDR rho" = pairwise$fdr_spearman,
+        "P-value rho" = pairwise$p_value_spearman,
+        "Curve rho" = pairwise$estimate_curve_pearson
+      )
+    } else {
+      list(
+        "TopK Jaccard" = NA_real_,
+        "Rank rho" = NA_real_,
+        "FDR rho" = NA_real_,
+        "P-value rho" = NA_real_,
+        "Curve rho" = NA_real_
+      )
+    }
+    thresholds <- c(
+      "TopK Jaccard" = default_thresholds$top_k_jaccard,
+      "Rank rho" = default_thresholds$rank_spearman,
+      "FDR rho" = default_thresholds$fdr_spearman,
+      "P-value rho" = default_thresholds$p_value_spearman,
+      "Curve rho" = default_thresholds$estimate_curve_pearson
+    )
+    for (metric in names(agreement_values)) {
+      value <- as.numeric(agreement_values[[metric]])
+      status <- if (identical(run$backend, "spata2") && ok) {
+        "reference"
+      } else {
+        metric_status(value, thresholds[[metric]], higher_is_better = TRUE)
+      }
+      rows[[i]] <- metric_row(
+        case = case,
+        method = method,
+        metric = metric,
+        group = "Agreement",
+        value = value,
+        score = if (is.finite(value)) value else 0,
+        label = format_number(value, 3),
+        status = status,
+        threshold = thresholds[[metric]]
+      )
+      i <- i + 1L
+    }
+  }
+  do.call(rbind, rows)
+}
+
+write_backend_tables <- function(run, output_dir) {
+  if (is.null(run$result)) {
+    return(invisible(FALSE))
+  }
+  for (name in names(run$result)) {
+    utils::write.csv(
+      run$result[[name]],
+      file.path(output_dir, paste0(run$backend, "_", name, ".csv")),
+      row.names = FALSE
+    )
+  }
+  invisible(TRUE)
+}
+
+save_benchmark <- function(runs, pairwise, summary_metrics, output_dir, case) {
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+  run_df <- do.call(rbind, lapply(runs, result_summary, case = case))
+  utils::write.csv(run_df, file.path(output_dir, "backend_runs.csv"), row.names = FALSE)
+  utils::write.csv(pairwise, file.path(output_dir, "pairwise_metrics.csv"), row.names = FALSE)
+  utils::write.csv(summary_metrics, file.path(output_dir, "summary_metrics.csv"), row.names = FALSE)
+  for (run in runs) {
+    write_backend_tables(run, output_dir)
+  }
+  invisible(TRUE)
+}
+
+strict_check <- function(runs, pairwise) {
+  status <- vapply(runs, `[[`, character(1), "status")
+  if (!all(status == "ok")) {
+    stop("Strict benchmark failed because at least one backend did not finish.", call. = FALSE)
+  }
+  failures <- character()
+  for (name in names(default_thresholds)) {
+    value <- as.numeric(pairwise[[name]])
+    if (!is.finite(value) || value < default_thresholds[[name]]) {
+      failures <- c(failures, sprintf("%s=%s", name, format_number(value, 4)))
+    }
+  }
+  if (length(failures) > 0L) {
+    stop("Strict benchmark failed: ", paste(failures, collapse = ", "), call. = FALSE)
+  }
+  invisible(TRUE)
+}
+
+run_spatial_gradient_benchmark <- function(
+  output_dir = file.path("inst", "benchmarks", "spatial_gradient_cpp"),
+  reference = c("trajectory", "annotation"),
+  n_spots = 80L,
+  n_variables = 6L,
+  n_random = 20L,
+  n_bins = 25L,
+  resolution = 25,
+  seed = 1L,
+  run_spata2 = TRUE,
+  strict = FALSE,
+  verbose = FALSE
+) {
+  reference <- match.arg(reference)
+  load_scop_for_benchmark(".")
+  fixture <- make_spatial_gradient_fixture(n_spots = n_spots, n_variables = n_variables, seed = seed)
+  case <- paste0(reference, "_", length(fixture$variables), "genes_", ncol(fixture$srt), "spots")
+
+  cpp_run <- run_gradient_backend(
+    fixture = fixture,
+    backend = "cpp",
+    reference = reference,
+    result_name = paste0("benchmark_", reference, "_cpp"),
+    n_random = n_random,
+    n_bins = n_bins,
+    resolution = resolution,
+    seed = seed,
+    verbose = verbose
+  )
+  spata2_run <- if (isTRUE(run_spata2)) {
+    run_gradient_backend(
+      fixture = fixture,
+      backend = "spata2",
+      reference = reference,
+      result_name = paste0("benchmark_", reference, "_spata2"),
+      n_random = n_random,
+      n_bins = n_bins,
+      resolution = resolution,
+      seed = seed,
+      verbose = verbose
+    )
+  } else {
+    list(
+      backend = "spata2",
+      status = "skipped",
+      elapsed = NA_real_,
+      error = "Skipped by --skip-spata2",
+      warnings = character(),
+      result = NULL
+    )
+  }
+  runs <- list(spata2 = spata2_run, cpp = cpp_run)
+  pairwise <- compare_backends(spata2_run$result, cpp_run$result)
+  pairwise$case <- case
+  pairwise$reference <- reference
+  pairwise <- pairwise[, c("case", "reference", setdiff(colnames(pairwise), c("case", "reference"))), drop = FALSE]
+  summary_metrics <- make_summary_metrics(case = case, runs = runs, pairwise = pairwise)
+  save_benchmark(runs, pairwise, summary_metrics, output_dir, case)
+  if (isTRUE(strict)) {
+    strict_check(runs, pairwise)
+  }
+  list(runs = runs, pairwise = pairwise, summary_metrics = summary_metrics, output_dir = output_dir)
+}
+
+if (sys.nframe() == 0L) {
+  args <- parse_cli_args()
+  result <- do.call(run_spatial_gradient_benchmark, args)
+  cat("output_dir=", normalizePath(result$output_dir, winslash = "/", mustWork = FALSE), "\n", sep = "")
+  cat("backend_runs=", normalizePath(file.path(result$output_dir, "backend_runs.csv"), winslash = "/", mustWork = FALSE), "\n", sep = "")
+  cat("pairwise_metrics=", normalizePath(file.path(result$output_dir, "pairwise_metrics.csv"), winslash = "/", mustWork = FALSE), "\n", sep = "")
+  cat("summary_metrics=", normalizePath(file.path(result$output_dir, "summary_metrics.csv"), winslash = "/", mustWork = FALSE), "\n", sep = "")
+}

--- a/inst/benchmarks/plot_spatial_gradient_funky_heatmap.py
+++ b/inst/benchmarks/plot_spatial_gradient_funky_heatmap.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python
+"""Render spatial gradient backend benchmark metrics as a funky heatmap.
+
+The script prefers ``omicverse.pl.funky_heatmap`` when OmicVerse is installed,
+falls back to ``pyfunkyheatmap`` when available, and finally renders a compact
+matplotlib version so benchmark artifacts can still be created locally.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+
+
+METRIC_ORDER = [
+    "Runtime",
+    "Speedup",
+    "Schema",
+    "No S4 object",
+    "TopK Jaccard",
+    "Rank rho",
+    "FDR rho",
+    "P-value rho",
+    "Curve rho",
+    "Criteria",
+]
+
+METRIC_GROUPS = {
+    "Runtime": "Runtime",
+    "Speedup": "Runtime",
+    "Schema": "Integrity",
+    "No S4 object": "Integrity",
+    "TopK Jaccard": "Agreement",
+    "Rank rho": "Agreement",
+    "FDR rho": "Agreement",
+    "P-value rho": "Agreement",
+    "Curve rho": "Agreement",
+    "Criteria": "Criteria",
+}
+
+GLYPH_TYPES = {
+    "Runtime": "bar",
+    "Speedup": "bar",
+    "Schema": "funkyrect",
+    "No S4 object": "funkyrect",
+    "TopK Jaccard": "circle",
+    "Rank rho": "circle",
+    "FDR rho": "circle",
+    "P-value rho": "circle",
+    "Curve rho": "circle",
+    "Criteria": "pie",
+}
+
+
+def _load_funky_heatmap() -> tuple[Callable[..., Any] | None, str]:
+    try:
+        import omicverse as ov  # type: ignore
+
+        if hasattr(ov, "ov_plot_set"):
+            ov.ov_plot_set()
+        elif hasattr(ov, "plot_set"):
+            ov.plot_set()
+        funky = getattr(ov.pl, "funky_heatmap")
+        return funky, "omicverse.pl.funky_heatmap"
+    except Exception as ov_error:
+        try:
+            from pyfunkyheatmap import funky_heatmap  # type: ignore
+
+            return funky_heatmap, "pyfunkyheatmap.funky_heatmap"
+        except Exception as py_error:
+            return None, f"matplotlib fallback; ov={ov_error}; pyfunkyheatmap={py_error}"
+
+
+def _format_number(value: float, digits: int = 3) -> str:
+    if pd.isna(value):
+        return "NA"
+    return f"{float(value):.{digits}g}"
+
+
+def _metric_slug(metric: str) -> str:
+    return (
+        metric.lower()
+        .replace(" ", "_")
+        .replace("-", "_")
+        .replace("/", "_")
+        .replace("+", "plus")
+    )
+
+
+def _case_label(case: str) -> str:
+    match = re.match(r"^(?P<reference>.+)_(?P<genes>\d+)genes_(?P<spots>\d+)spots$", case)
+    if not match:
+        return case
+    return f"{match.group('reference')}\n{match.group('genes')} genes, {match.group('spots')} spots"
+
+
+def _score_to_float(value: Any) -> float:
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return np.nan
+    if not np.isfinite(value):
+        return np.nan
+    return max(0.0, min(1.0, value))
+
+
+def prepare_heatmap_data(metrics_path: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    metrics = pd.read_csv(metrics_path)
+    required = {"case", "method", "metric", "group", "score", "label", "status"}
+    missing = required.difference(metrics.columns)
+    if missing:
+        raise ValueError(f"Missing required metrics columns: {sorted(missing)}")
+
+    metrics["score"] = pd.to_numeric(metrics["score"], errors="coerce")
+    metrics["label"] = metrics["label"].fillna("NA").astype(str)
+    rows: list[dict[str, Any]] = []
+
+    for (case, method), group in metrics.groupby(["case", "method"], sort=False):
+        row: dict[str, Any] = {
+            "id": f"{case} | {method}",
+            "case": case,
+            "case_label": _case_label(str(case)),
+            "method": method,
+        }
+        statuses = []
+        for metric in METRIC_ORDER:
+            if metric == "Criteria":
+                continue
+            hit = group[group["metric"] == metric]
+            if hit.empty:
+                score = np.nan
+                label = "NA"
+                status = "na"
+            else:
+                item = hit.iloc[0]
+                score = _score_to_float(item["score"])
+                label = str(item["label"])
+                status = str(item["status"])
+            slug = _metric_slug(metric)
+            row[f"{slug}_score"] = 0.0 if pd.isna(score) else score
+            row[f"{slug}_label"] = label
+            row[f"{slug}_status"] = status
+            statuses.append(status)
+
+        pass_count = sum(status in {"ok", "pass", "reference"} for status in statuses)
+        watch_count = max(len(statuses) - pass_count, 0)
+        row["criteria_pie"] = {"pass": int(pass_count), "watch": max(int(watch_count), 1e-6)}
+        row["criteria_label"] = f"{pass_count}/{len(statuses)}"
+        row["criteria_score"] = pass_count / max(len(statuses), 1)
+        rows.append(row)
+
+    heatmap_data = pd.DataFrame(rows)
+    metric_info_rows = []
+    for metric in METRIC_ORDER:
+        slug = _metric_slug(metric)
+        if metric == "Criteria":
+            metric_info_rows.append(
+                {
+                    "metric": metric,
+                    "score_col": "criteria_pie",
+                    "label_col": "criteria_label",
+                    "geom": "pie",
+                    "group": "Criteria",
+                }
+            )
+        else:
+            metric_info_rows.append(
+                {
+                    "metric": metric,
+                    "score_col": f"{slug}_score",
+                    "label_col": f"{slug}_label",
+                    "geom": GLYPH_TYPES[metric],
+                    "group": METRIC_GROUPS[metric],
+                }
+            )
+    return heatmap_data, pd.DataFrame(metric_info_rows)
+
+
+def _column_info(metric_info: pd.DataFrame) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = [
+        {"id": "method", "name": "Method", "geom": "text", "group": "Design", "width": 3.2, "legend": False}
+    ]
+    for item in metric_info.to_dict("records"):
+        rows.append(
+            {
+                "id": item["score_col"],
+                "name": item["metric"],
+                "geom": item["geom"],
+                "group": item["group"],
+                "palette": "criteria" if item["geom"] == "pie" else item["group"].lower(),
+                "width": 2.2 if item["geom"] == "bar" else 1.8,
+                "legend": item["geom"] != "text",
+            }
+        )
+        rows.append(
+            {
+                "id": item["label_col"],
+                "name": "",
+                "geom": "text",
+                "group": item["group"],
+                "overlay": True,
+                "width": 0.0,
+                "legend": False,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _render_with_funky(
+    funky_heatmap: Callable[..., Any],
+    heatmap_data: pd.DataFrame,
+    metric_info: pd.DataFrame,
+    output_path: Path,
+) -> None:
+    column_info = _column_info(metric_info)
+    group_names = ["Design", "Runtime", "Integrity", "Agreement", "Criteria"]
+    column_groups = pd.DataFrame({"group": group_names, "level1": group_names})
+    row_info = pd.DataFrame({"id": heatmap_data["id"], "group": heatmap_data["case"]})
+    cases = list(dict.fromkeys(heatmap_data["case"]))
+    row_groups = pd.DataFrame({"group": cases, "level1": cases})
+    palettes = {
+        "runtime": ["#f7fbff", "#c6dbef", "#6baed6", "#08519c"],
+        "integrity": ["#f7fcf5", "#bae4b3", "#74c476", "#238b45"],
+        "agreement": ["#fff7bc", "#fec44f", "#fd8d3c", "#d95f0e"],
+        "criteria": {"pass": "#1b9e77", "watch": "#d9d9d9"},
+    }
+    legends = [
+        {"title": "Runtime score", "palette": "runtime", "geom": "bar"},
+        {"title": "Integrity", "palette": "integrity", "geom": "funkyrect"},
+        {"title": "Agreement", "palette": "agreement", "geom": "circle"},
+        {"title": "Criteria", "palette": "criteria", "geom": "pie"},
+    ]
+    figure = funky_heatmap(
+        heatmap_data,
+        column_info=column_info,
+        column_groups=column_groups,
+        row_info=row_info,
+        row_groups=row_groups,
+        palettes=palettes,
+        legends=legends,
+        position_args={
+            "expand_xmin": 2.0,
+            "expand_xmax": 2.6,
+            "col_annot_offset": 3.4,
+            "col_annot_angle": 35,
+            "col_bigspace": 0.8,
+            "cell_text_size": 3.2,
+            "col_annot_size": 3.8,
+        },
+        scale_column=False,
+        add_abc=False,
+        fig_scale=0.30,
+        dpi=200,
+    )
+    if hasattr(figure, "save"):
+        figure.save(output_path, facecolor="white")
+    elif hasattr(figure, "figure"):
+        figure.figure.savefig(output_path, facecolor="white")
+    else:
+        figure.savefig(output_path, facecolor="white")
+
+
+def _render_matplotlib(
+    heatmap_data: pd.DataFrame,
+    metric_info: pd.DataFrame,
+    output_path: Path,
+) -> None:
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Circle, Rectangle, Wedge
+
+    metrics = metric_info.to_dict("records")
+    n_rows = len(heatmap_data)
+    n_cols = len(metrics)
+    width = max(11.0, 2.0 + n_cols * 1.35)
+    height = max(3.2, 1.2 + n_rows * 0.65)
+    fig, ax = plt.subplots(figsize=(width, height))
+    ax.set_xlim(-2.6, n_cols - 0.35)
+    ax.set_ylim(-0.8, n_rows + 0.9)
+    ax.axis("off")
+    cmap = plt.get_cmap("YlOrRd")
+    runtime_cmap = plt.get_cmap("Blues")
+    integrity_cmap = plt.get_cmap("Greens")
+
+    def color_for(score: float, group: str) -> Any:
+        if not np.isfinite(score):
+            return "#d9d9d9"
+        score = max(0.0, min(1.0, score))
+        if group == "Runtime":
+            return runtime_cmap(0.18 + 0.72 * score)
+        if group == "Integrity":
+            return integrity_cmap(0.18 + 0.72 * score)
+        return cmap(0.18 + 0.72 * score)
+
+    for col, item in enumerate(metrics):
+        ax.text(col, n_rows + 0.16, item["metric"], ha="right", va="bottom", rotation=38, fontsize=9)
+        ax.plot([col - 0.47, col + 0.47], [n_rows - 0.05, n_rows - 0.05], color="#d0d0d0", lw=0.7)
+
+    for row_idx, row in heatmap_data.reset_index(drop=True).iterrows():
+        y = n_rows - row_idx - 1
+        ax.text(-3.55, y, str(row["case_label"]), ha="left", va="center", fontsize=8, color="#555555", linespacing=1.15)
+        ax.text(-1.35, y, str(row["method"]), ha="left", va="center", fontsize=9, color="#111111")
+        ax.plot([-3.65, n_cols - 0.42], [y - 0.38, y - 0.38], color="#eeeeee", lw=0.7)
+        for col, item in enumerate(metrics):
+            score_col = item["score_col"]
+            label_col = item["label_col"]
+            geom = item["geom"]
+            group = item["group"]
+            label = str(row.get(label_col, "NA"))
+            if geom == "pie":
+                pie = row.get(score_col, {"pass": 0, "watch": 1})
+                total = float(pie.get("pass", 0)) + float(pie.get("watch", 0))
+                frac = 0 if total <= 0 else float(pie.get("pass", 0)) / total
+                ax.add_patch(Wedge((col, y), 0.32, 90, 90 + 360 * frac, facecolor="#1b9e77", edgecolor="white", lw=0.6))
+                ax.add_patch(Wedge((col, y), 0.32, 90 + 360 * frac, 450, facecolor="#d9d9d9", edgecolor="white", lw=0.6))
+                ax.add_patch(Circle((col, y), 0.32, fill=False, edgecolor="#777777", lw=0.5))
+            else:
+                score = _score_to_float(row.get(score_col, np.nan))
+                if geom == "bar":
+                    ax.add_patch(Rectangle((col - 0.42, y - 0.16), 0.84, 0.32, facecolor="#eeeeee", edgecolor="none"))
+                    if np.isfinite(score):
+                        ax.add_patch(Rectangle((col - 0.42, y - 0.16), 0.84 * score, 0.32, facecolor=color_for(score, group), edgecolor="none"))
+                    ax.add_patch(Rectangle((col - 0.42, y - 0.16), 0.84, 0.32, fill=False, edgecolor="#777777", lw=0.5))
+                elif geom == "funkyrect":
+                    size = 0.16 + 0.46 * (score if np.isfinite(score) else 0)
+                    ax.add_patch(Rectangle((col - size / 2, y - size / 2), size, size, facecolor=color_for(score, group), edgecolor="#777777", lw=0.5))
+                else:
+                    radius = 0.11 + 0.25 * (score if np.isfinite(score) else 0)
+                    ax.add_patch(Circle((col, y), radius, facecolor=color_for(score, group), edgecolor="#777777", lw=0.5))
+            ax.text(col, y, label, ha="center", va="center", fontsize=7.2, color="#111111")
+
+    ax.set_xlim(-3.65, n_cols - 0.35)
+    ax.text(-3.55, n_rows + 0.16, "Case", ha="left", va="bottom", fontsize=9, fontweight="bold")
+    ax.text(-1.35, n_rows + 0.16, "Method", ha="left", va="bottom", fontsize=9, fontweight="bold")
+    fig.savefig(output_path, dpi=220, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+
+def render_funky_heatmap(metrics_path: Path, output_dir: Path, stem: str) -> tuple[Path, Path, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    heatmap_data, metric_info = prepare_heatmap_data(metrics_path)
+
+    input_path = output_dir / f"{stem}_input.csv"
+    serializable = heatmap_data.copy()
+    serializable["criteria_pie"] = serializable["criteria_pie"].map(str)
+    serializable.to_csv(input_path, index=False)
+
+    output_path = output_dir / f"{stem}.png"
+    funky_heatmap, engine = _load_funky_heatmap()
+    if funky_heatmap is not None:
+        try:
+            _render_with_funky(funky_heatmap, heatmap_data, metric_info, output_path)
+            return output_path, input_path, engine
+        except Exception as exc:
+            engine = f"matplotlib fallback after {engine} failed: {exc}"
+
+    _render_matplotlib(heatmap_data, metric_info, output_path)
+    return output_path, input_path, engine
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metrics", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--stem", default="spatial_gradient_cpp_funky")
+    args = parser.parse_args()
+
+    output_path, input_path, engine = render_funky_heatmap(
+        metrics_path=args.metrics,
+        output_dir=args.output_dir,
+        stem=args.stem,
+    )
+    print(f"engine={engine}")
+    print(f"png={output_path}")
+    print(f"input={input_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/inst/benchmarks/plot_spatial_gradient_funky_heatmap.py
+++ b/inst/benchmarks/plot_spatial_gradient_funky_heatmap.py
@@ -10,11 +10,20 @@ from __future__ import annotations
 
 import argparse
 import re
+import sys
 from pathlib import Path
 from typing import Any, Callable
 
 import numpy as np
 import pandas as pd
+
+for stream_name in ("stdout", "stderr"):
+    stream = getattr(sys, stream_name, None)
+    if hasattr(stream, "reconfigure"):
+        try:
+            stream.reconfigure(encoding="utf-8")
+        except Exception:
+            pass
 
 
 METRIC_ORDER = [

--- a/man/RunSpatialGradientFeatures.Rd
+++ b/man/RunSpatialGradientFeatures.Rd
@@ -7,6 +7,7 @@
 RunSpatialGradientFeatures(
   srt,
   reference = c("trajectory", "annotation"),
+  backend = c("cpp", "spata2"),
   result_name = NULL,
   spata_object = NULL,
   assay = NULL,
@@ -15,6 +16,7 @@ RunSpatialGradientFeatures(
   sample_name = NULL,
   platform = "Undefined",
   image = NULL,
+  coord.cols = c("x", "y"),
   img_scale_fct = "lowres",
   assay_modality = "gene",
   trajectory_id = "scop_gradient",
@@ -41,6 +43,8 @@ RunSpatialGradientFeatures(
   n_random = 10000,
   seed = 123,
   control = NULL,
+  n_bins = 50,
+  min_spots = 3,
   nfeatures = 2000,
   set_variable_features = FALSE,
   store_results = TRUE,
@@ -53,6 +57,10 @@ RunSpatialGradientFeatures(
 
 \item{reference}{Spatial reference type: \code{"trajectory"} for STS or
 \code{"annotation"} for SAS.}
+
+\item{backend}{Computation backend. \code{"cpp"} uses SCOP's native fast spatial
+gradient implementation and avoids SPATA2 object construction. \code{"spata2"}
+uses SPATA2 directly for full upstream SAS/STS behavior.}
 
 \item{result_name}{Name used to store this result. If \code{NULL}, a name is
 generated from \code{reference}.}
@@ -77,6 +85,9 @@ to \code{SPATA2::asSPATA2()} when \code{spata_object} is \code{NULL}.}
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
 If \code{NULL}, the first image is used when present.}
 
+\item{coord.cols}{Metadata coordinate columns used by the native \code{"cpp"}
+backend when no image coordinates are available.}
+
 \item{trajectory_id, start, end, traj_df, width}{Trajectory setup passed to
 \code{SPATA2::addSpatialTrajectory()} and \code{SPATA2::spatialTrajectoryScreening()}.}
 
@@ -88,13 +99,20 @@ annotations are created from \code{annotation.by} and \code{annotation.groups}, 
 SPATA2 group annotations.}
 
 \item{annotation.variable, annotation.threshold}{Numeric variable and
-threshold used to create SPATA2 numeric annotations.}
+threshold used to create SPATA2 numeric annotations. Numeric thresholds are
+interpreted as \code{">{threshold}"}.}
 
 \item{annotation_id}{Base id used when creating annotations.}
 
 \item{core, distance, angle_span}{SAS parameters forwarded to SPATA2.}
 
 \item{resolution, unit, sign_var, sign_threshold, model_add, model_subset, model_remove, n_random, seed, control}{SPATA2 screening parameters.}
+
+\item{n_bins}{Number of distance bins used for the native \code{"cpp"} backend
+screening curve.}
+
+\item{min_spots}{Minimum number of non-zero spots required for a variable in
+the native \code{"cpp"} backend.}
 
 \item{nfeatures}{Number of top gradient variables retained in
 \code{top_variables} and optionally set as Seurat variable features.}
@@ -114,10 +132,12 @@ A \code{Seurat} object with spatial gradient screening results stored in
 \code{srt@tools[["SpatialGradientFeatures"]]}.
 }
 \description{
-Wrap SPATA2 spatial trajectory screening (STS) and spatial annotation
-screening (SAS) for Seurat objects. Results are normalized into plain
-data.frames and stored in \code{srt@tools[["SpatialGradientFeatures"]]}; the
-SPATA2 object itself is never stored.
+Run spatial trajectory or annotation gradient screening for Seurat objects.
+The native \code{"cpp"} backend avoids SPATA2 object construction for fast
+distance-based screening, while the \code{"spata2"} backend keeps full upstream
+SPATA2 SAS/STS behavior. Results are normalized into plain data.frames and
+stored in \code{srt@tools[["SpatialGradientFeatures"]]}; the SPATA2 object itself
+is never stored.
 }
 \examples{
 \dontrun{

--- a/man/SpatialGradientPlot.Rd
+++ b/man/SpatialGradientPlot.Rd
@@ -27,6 +27,7 @@ SpatialGradientPlot(
   theme_args = list(),
   line_size = 1,
   line_alpha = 0.35,
+  line_fit = c("stored", "lm"),
   nrow = NULL,
   ncol = NULL,
   byrow = TRUE
@@ -82,6 +83,11 @@ Default is \code{list()}.}
 \item{line_size}{Size of fitted gradient lines.}
 
 \item{line_alpha}{Alpha for raw value points.}
+
+\item{line_fit}{Gradient line source. \code{"stored"} uses the saved
+\code{screening$estimate} values produced by the selected backend. \code{"lm"} draws a
+fresh linear fit from \code{screening$value}, which is useful for showing a simple
+monotonic trend even when the backend stores a smoothed curve.}
 
 \item{nrow}{Number of rows in the combined plot.
 Default is \code{NULL}, which means determined automatically based on the number of plots.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1377,6 +1377,26 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// spatial_gradient_screening_cpp
+List spatial_gradient_screening_cpp(S4 expr, NumericMatrix coords, LogicalVector reference_spots, NumericMatrix trajectory, CharacterVector variables, std::string mode, int n_bins, int n_random, int seed, int min_spots);
+RcppExport SEXP _scop_spatial_gradient_screening_cpp(SEXP exprSEXP, SEXP coordsSEXP, SEXP reference_spotsSEXP, SEXP trajectorySEXP, SEXP variablesSEXP, SEXP modeSEXP, SEXP n_binsSEXP, SEXP n_randomSEXP, SEXP seedSEXP, SEXP min_spotsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< S4 >::type expr(exprSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type coords(coordsSEXP);
+    Rcpp::traits::input_parameter< LogicalVector >::type reference_spots(reference_spotsSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type trajectory(trajectorySEXP);
+    Rcpp::traits::input_parameter< CharacterVector >::type variables(variablesSEXP);
+    Rcpp::traits::input_parameter< std::string >::type mode(modeSEXP);
+    Rcpp::traits::input_parameter< int >::type n_bins(n_binsSEXP);
+    Rcpp::traits::input_parameter< int >::type n_random(n_randomSEXP);
+    Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
+    Rcpp::traits::input_parameter< int >::type min_spots(min_spotsSEXP);
+    rcpp_result_gen = Rcpp::wrap(spatial_gradient_screening_cpp(expr, coords, reference_spots, trajectory, variables, mode, n_bins, n_random, seed, min_spots));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_scop_augur_subsample_cpp", (DL_FUNC) &_scop_augur_subsample_cpp, 2},
@@ -1458,6 +1478,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_scop_cvNetLogC", (DL_FUNC) &_scop_cvNetLogC, 18},
     {"_scop_scissor_gaussian_net_fit_cpp", (DL_FUNC) &_scop_scissor_gaussian_net_fit_cpp, 12},
     {"_scop_scissor_binomial_net_fit_cpp", (DL_FUNC) &_scop_scissor_binomial_net_fit_cpp, 12},
+    {"_scop_spatial_gradient_screening_cpp", (DL_FUNC) &_scop_spatial_gradient_screening_cpp, 10},
     {NULL, NULL, 0}
 };
 

--- a/src/SpatialGradient.cpp
+++ b/src/SpatialGradient.cpp
@@ -1,0 +1,501 @@
+// [[Rcpp::depends(RcppArmadillo)]]
+#include <RcppArmadillo.h>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+using namespace Rcpp;
+
+namespace {
+
+struct DgCSlots {
+  int n_rows;
+  int n_cols;
+  IntegerVector row_idx;
+  IntegerVector col_ptr;
+  NumericVector values;
+};
+
+DgCSlots get_dgc_slots_spatial_gradient(S4 mat) {
+  IntegerVector dims = mat.slot("Dim");
+  IntegerVector row_idx = mat.slot("i");
+  IntegerVector col_ptr = mat.slot("p");
+  NumericVector values = mat.slot("x");
+  if (dims.size() != 2 || col_ptr.size() != dims[1] + 1 || row_idx.size() != values.size()) {
+    stop("expr must be a valid dgCMatrix.");
+  }
+  return DgCSlots{dims[0], dims[1], row_idx, col_ptr, values};
+}
+
+struct Entry {
+  int col;
+  double value;
+};
+
+struct FitStats {
+  double intercept;
+  double slope;
+  double r;
+  double r2;
+  double mae;
+  double rmse;
+  double p_value;
+  int n;
+  int n_nonzero;
+};
+
+inline bool finite2(double x, double y) {
+  return std::isfinite(x) && std::isfinite(y);
+}
+
+double pearson_r(const std::vector<double>& x, const std::vector<double>& y) {
+  const int n = static_cast<int>(x.size());
+  if (n < 3) {
+    return NA_REAL;
+  }
+  double sx = 0.0, sy = 0.0, sx2 = 0.0, sy2 = 0.0, sxy = 0.0;
+  for (int i = 0; i < n; ++i) {
+    sx += x[i];
+    sy += y[i];
+    sx2 += x[i] * x[i];
+    sy2 += y[i] * y[i];
+    sxy += x[i] * y[i];
+  }
+  const double num = n * sxy - sx * sy;
+  const double den_x = n * sx2 - sx * sx;
+  const double den_y = n * sy2 - sy * sy;
+  if (!(den_x > 0.0) || !(den_y > 0.0)) {
+    return NA_REAL;
+  }
+  double r = num / std::sqrt(den_x * den_y);
+  if (r > 1.0) {
+    r = 1.0;
+  } else if (r < -1.0) {
+    r = -1.0;
+  }
+  return r;
+}
+
+FitStats fit_linear(
+  const std::vector<double>& x,
+  const std::vector<double>& y,
+  int n_random,
+  int seed,
+  int feature_index
+) {
+  FitStats out;
+  out.intercept = NA_REAL;
+  out.slope = NA_REAL;
+  out.r = NA_REAL;
+  out.r2 = NA_REAL;
+  out.mae = NA_REAL;
+  out.rmse = NA_REAL;
+  out.p_value = NA_REAL;
+  out.n = static_cast<int>(x.size());
+  out.n_nonzero = 0;
+
+  const int n = out.n;
+  if (n < 3) {
+    return out;
+  }
+
+  double sx = 0.0, sy = 0.0, sx2 = 0.0, sxy = 0.0;
+  for (int i = 0; i < n; ++i) {
+    sx += x[i];
+    sy += y[i];
+    sx2 += x[i] * x[i];
+    sxy += x[i] * y[i];
+    if (std::isfinite(y[i]) && y[i] > 0.0) {
+      ++out.n_nonzero;
+    }
+  }
+  const double den = n * sx2 - sx * sx;
+  if (!(den > 0.0)) {
+    return out;
+  }
+  out.slope = (n * sxy - sx * sy) / den;
+  out.intercept = (sy - out.slope * sx) / n;
+  out.r = pearson_r(x, y);
+  if (std::isfinite(out.r)) {
+    out.r2 = out.r * out.r;
+  }
+
+  double abs_sum = 0.0;
+  double sq_sum = 0.0;
+  for (int i = 0; i < n; ++i) {
+    const double pred = out.intercept + out.slope * x[i];
+    const double err = y[i] - pred;
+    abs_sum += std::abs(err);
+    sq_sum += err * err;
+  }
+  out.mae = abs_sum / n;
+  out.rmse = std::sqrt(sq_sum / n);
+
+  if (std::isfinite(out.r)) {
+    if (n_random > 0) {
+      std::vector<double> y_perm = y;
+      std::mt19937 rng(static_cast<unsigned int>(seed + feature_index * 104729));
+      const double obs = std::abs(out.r);
+      int ge = 0;
+      int used = 0;
+      for (int iter = 0; iter < n_random; ++iter) {
+        std::shuffle(y_perm.begin(), y_perm.end(), rng);
+        const double rp = pearson_r(x, y_perm);
+        if (std::isfinite(rp)) {
+          ++used;
+          if (std::abs(rp) >= obs) {
+            ++ge;
+          }
+        }
+      }
+      if (used > 0) {
+        out.p_value = (static_cast<double>(ge) + 1.0) / (static_cast<double>(used) + 1.0);
+      }
+    } else if (n > 2 && out.r2 < 1.0) {
+      const double t = std::abs(out.r) * std::sqrt((n - 2.0) / std::max(1e-15, 1.0 - out.r2));
+      out.p_value = 2.0 * R::pt(-t, static_cast<double>(n - 2), 1, 0);
+    } else if (out.r2 >= 1.0) {
+      out.p_value = 0.0;
+    }
+  }
+  return out;
+}
+
+std::vector<double> annotation_distances(const NumericMatrix& coords, const LogicalVector& reference_spots) {
+  const int n = coords.nrow();
+  std::vector<int> refs;
+  refs.reserve(n);
+  for (int i = 0; i < n; ++i) {
+    if (reference_spots[i] == TRUE && finite2(coords(i, 0), coords(i, 1))) {
+      refs.push_back(i);
+    }
+  }
+  if (refs.empty()) {
+    stop("The annotation reference contains no finite spots.");
+  }
+  std::vector<double> dist(n, NA_REAL);
+  for (int i = 0; i < n; ++i) {
+    if ((i & 255) == 0) {
+      Rcpp::checkUserInterrupt();
+    }
+    if (!finite2(coords(i, 0), coords(i, 1))) {
+      continue;
+    }
+    double best = std::numeric_limits<double>::infinity();
+    for (std::size_t k = 0; k < refs.size(); ++k) {
+      const int j = refs[k];
+      const double dx = coords(i, 0) - coords(j, 0);
+      const double dy = coords(i, 1) - coords(j, 1);
+      const double d2 = dx * dx + dy * dy;
+      if (d2 < best) {
+        best = d2;
+      }
+    }
+    dist[i] = std::sqrt(best);
+  }
+  return dist;
+}
+
+std::vector<double> trajectory_distances(const NumericMatrix& coords, const NumericMatrix& trajectory) {
+  const int n = coords.nrow();
+  const int k = trajectory.nrow();
+  if (k < 2 || trajectory.ncol() != 2) {
+    stop("trajectory must contain at least two x/y coordinates.");
+  }
+  std::vector<double> seg_len(k - 1, 0.0);
+  std::vector<double> cum(k - 1, 0.0);
+  double total = 0.0;
+  for (int s = 0; s < k - 1; ++s) {
+    const double dx = trajectory(s + 1, 0) - trajectory(s, 0);
+    const double dy = trajectory(s + 1, 1) - trajectory(s, 1);
+    seg_len[s] = std::sqrt(dx * dx + dy * dy);
+    cum[s] = total;
+    total += seg_len[s];
+  }
+  if (!(total > 0.0)) {
+    stop("trajectory length must be greater than zero.");
+  }
+
+  std::vector<double> dist(n, NA_REAL);
+  for (int i = 0; i < n; ++i) {
+    if ((i & 255) == 0) {
+      Rcpp::checkUserInterrupt();
+    }
+    if (!finite2(coords(i, 0), coords(i, 1))) {
+      continue;
+    }
+    double best_d2 = std::numeric_limits<double>::infinity();
+    double best_along = NA_REAL;
+    for (int s = 0; s < k - 1; ++s) {
+      if (!(seg_len[s] > 0.0)) {
+        continue;
+      }
+      const double ax = trajectory(s, 0);
+      const double ay = trajectory(s, 1);
+      const double bx = trajectory(s + 1, 0);
+      const double by = trajectory(s + 1, 1);
+      const double vx = bx - ax;
+      const double vy = by - ay;
+      const double wx = coords(i, 0) - ax;
+      const double wy = coords(i, 1) - ay;
+      double t = (wx * vx + wy * vy) / (seg_len[s] * seg_len[s]);
+      if (t < 0.0) {
+        t = 0.0;
+      } else if (t > 1.0) {
+        t = 1.0;
+      }
+      const double px = ax + t * vx;
+      const double py = ay + t * vy;
+      const double dx = coords(i, 0) - px;
+      const double dy = coords(i, 1) - py;
+      const double d2 = dx * dx + dy * dy;
+      if (d2 < best_d2) {
+        best_d2 = d2;
+        best_along = cum[s] + t * seg_len[s];
+      }
+    }
+    dist[i] = best_along;
+  }
+  return dist;
+}
+
+IntegerVector make_bins(const std::vector<double>& dist, int n_bins, NumericVector& centers) {
+  double d_min = std::numeric_limits<double>::infinity();
+  double d_max = -std::numeric_limits<double>::infinity();
+  for (std::size_t i = 0; i < dist.size(); ++i) {
+    if (std::isfinite(dist[i])) {
+      d_min = std::min(d_min, dist[i]);
+      d_max = std::max(d_max, dist[i]);
+    }
+  }
+  if (!std::isfinite(d_min) || !std::isfinite(d_max)) {
+    stop("No finite spatial distances are available.");
+  }
+  if (!(d_max > d_min)) {
+    n_bins = 1;
+  }
+  IntegerVector bins(dist.size(), NA_INTEGER);
+  NumericVector sums(n_bins);
+  IntegerVector counts(n_bins);
+  for (std::size_t i = 0; i < dist.size(); ++i) {
+    if (!std::isfinite(dist[i])) {
+      continue;
+    }
+    int bin = 0;
+    if (n_bins > 1) {
+      bin = static_cast<int>(std::floor((dist[i] - d_min) / (d_max - d_min) * n_bins));
+      if (bin >= n_bins) {
+        bin = n_bins - 1;
+      }
+      if (bin < 0) {
+        bin = 0;
+      }
+    }
+    bins[i] = bin;
+    sums[bin] += dist[i];
+    counts[bin] += 1;
+  }
+  centers = NumericVector(n_bins, NA_REAL);
+  for (int bin = 0; bin < n_bins; ++bin) {
+    if (counts[bin] > 0) {
+      centers[bin] = sums[bin] / counts[bin];
+    }
+  }
+  return bins;
+}
+
+} // namespace
+
+// [[Rcpp::export]]
+List spatial_gradient_screening_cpp(
+  S4 expr,
+  NumericMatrix coords,
+  LogicalVector reference_spots,
+  NumericMatrix trajectory,
+  CharacterVector variables,
+  std::string mode,
+  int n_bins = 50,
+  int n_random = 0,
+  int seed = 123,
+  int min_spots = 3
+) {
+  DgCSlots mat = get_dgc_slots_spatial_gradient(expr);
+  if (coords.nrow() != mat.n_cols || coords.ncol() != 2) {
+    stop("coords must have one x/y row per expression column.");
+  }
+  if (variables.size() != mat.n_rows) {
+    stop("variables must contain one name per expression row.");
+  }
+  if (n_bins < 1) {
+    stop("n_bins must be positive.");
+  }
+  if (n_random < 0) {
+    stop("n_random must be non-negative.");
+  }
+  if (min_spots < 1) {
+    stop("min_spots must be positive.");
+  }
+
+  std::vector<std::vector<Entry> > rows(static_cast<std::size_t>(mat.n_rows));
+  for (int col = 0; col < mat.n_cols; ++col) {
+    for (int ptr = mat.col_ptr[col]; ptr < mat.col_ptr[col + 1]; ++ptr) {
+      const int row = mat.row_idx[ptr];
+      if (row < 0 || row >= mat.n_rows) {
+        stop("expr row index is out of bounds.");
+      }
+      const double value = mat.values[ptr];
+      if (std::isfinite(value) && value != 0.0) {
+        rows[static_cast<std::size_t>(row)].push_back(Entry{col, value});
+      }
+    }
+  }
+
+  std::vector<double> dist = mode == "annotation" ?
+    annotation_distances(coords, reference_spots) :
+    trajectory_distances(coords, trajectory);
+
+  NumericVector bin_centers;
+  IntegerVector bins = make_bins(dist, n_bins, bin_centers);
+  int n_nonempty_bins = 0;
+  for (int b = 0; b < bin_centers.size(); ++b) {
+    if (std::isfinite(bin_centers[b])) {
+      ++n_nonempty_bins;
+    }
+  }
+
+  std::vector<std::string> sig_variable;
+  std::vector<double> sig_tot_var;
+  std::vector<double> sig_p;
+  std::vector<int> sig_n;
+  std::vector<int> sig_n_nonzero;
+
+  std::vector<std::string> fit_variable;
+  std::vector<std::string> fit_model;
+  std::vector<double> fit_mae;
+  std::vector<double> fit_rmse;
+  std::vector<double> fit_r2;
+  std::vector<double> fit_slope;
+  std::vector<double> fit_intercept;
+
+  std::vector<std::string> sc_variable;
+  std::vector<double> sc_distance;
+  std::vector<double> sc_value;
+  std::vector<double> sc_estimate;
+  std::vector<std::string> sc_reference;
+  std::vector<std::string> sc_mode;
+  sc_variable.reserve(static_cast<std::size_t>(mat.n_rows) * std::max(1, n_nonempty_bins));
+
+  std::vector<double> y_all(static_cast<std::size_t>(mat.n_cols), 0.0);
+  std::vector<double> x_valid;
+  std::vector<double> y_valid;
+
+  for (int row = 0; row < mat.n_rows; ++row) {
+    if ((row & 31) == 0) {
+      Rcpp::checkUserInterrupt();
+    }
+    std::fill(y_all.begin(), y_all.end(), 0.0);
+    const std::vector<Entry>& entries = rows[static_cast<std::size_t>(row)];
+    for (std::size_t k = 0; k < entries.size(); ++k) {
+      y_all[static_cast<std::size_t>(entries[k].col)] = entries[k].value;
+    }
+
+    x_valid.clear();
+    y_valid.clear();
+    x_valid.reserve(mat.n_cols);
+    y_valid.reserve(mat.n_cols);
+    int n_nonzero = 0;
+    for (int col = 0; col < mat.n_cols; ++col) {
+      if (std::isfinite(dist[col]) && std::isfinite(y_all[static_cast<std::size_t>(col)])) {
+        x_valid.push_back(dist[col]);
+        y_valid.push_back(y_all[static_cast<std::size_t>(col)]);
+        if (y_all[static_cast<std::size_t>(col)] > 0.0) {
+          ++n_nonzero;
+        }
+      }
+    }
+    if (n_nonzero < min_spots || x_valid.size() < 3) {
+      continue;
+    }
+
+    FitStats fit = fit_linear(x_valid, y_valid, n_random, seed, row);
+    fit.n_nonzero = n_nonzero;
+    if (!std::isfinite(fit.r2)) {
+      continue;
+    }
+    const std::string variable = as<std::string>(variables[row]);
+    sig_variable.push_back(variable);
+    sig_tot_var.push_back(fit.r2);
+    sig_p.push_back(fit.p_value);
+    sig_n.push_back(fit.n);
+    sig_n_nonzero.push_back(fit.n_nonzero);
+
+    fit_variable.push_back(variable);
+    fit_model.push_back("linear");
+    fit_mae.push_back(fit.mae);
+    fit_rmse.push_back(fit.rmse);
+    fit_r2.push_back(fit.r2);
+    fit_slope.push_back(fit.slope);
+    fit_intercept.push_back(fit.intercept);
+
+    NumericVector bin_value_sum(bin_centers.size());
+    IntegerVector bin_value_count(bin_centers.size());
+    for (int col = 0; col < mat.n_cols; ++col) {
+      if (bins[col] == NA_INTEGER) {
+        continue;
+      }
+      const int bin = bins[col];
+      bin_value_sum[bin] += y_all[static_cast<std::size_t>(col)];
+      bin_value_count[bin] += 1;
+    }
+    for (int bin = 0; bin < bin_centers.size(); ++bin) {
+      if (bin_value_count[bin] <= 0 || !std::isfinite(bin_centers[bin])) {
+        continue;
+      }
+      sc_variable.push_back(variable);
+      sc_distance.push_back(bin_centers[bin]);
+      sc_value.push_back(bin_value_sum[bin] / bin_value_count[bin]);
+      sc_estimate.push_back(fit.intercept + fit.slope * bin_centers[bin]);
+      sc_reference.push_back(mode);
+      sc_mode.push_back(mode);
+    }
+  }
+
+  DataFrame significance = DataFrame::create(
+    _["variable"] = sig_variable,
+    _["tot_var"] = sig_tot_var,
+    _["p_value"] = sig_p,
+    _["fdr"] = NumericVector(sig_p.size(), NA_REAL),
+    _["n_spots"] = sig_n,
+    _["n_nonzero"] = sig_n_nonzero,
+    _["stringsAsFactors"] = false
+  );
+  DataFrame model_fits = DataFrame::create(
+    _["variable"] = fit_variable,
+    _["model"] = fit_model,
+    _["mae"] = fit_mae,
+    _["rmse"] = fit_rmse,
+    _["r2"] = fit_r2,
+    _["slope"] = fit_slope,
+    _["intercept"] = fit_intercept,
+    _["stringsAsFactors"] = false
+  );
+  DataFrame screening = DataFrame::create(
+    _["variable"] = sc_variable,
+    _["distance"] = sc_distance,
+    _["value"] = sc_value,
+    _["estimate"] = sc_estimate,
+    _["reference"] = sc_reference,
+    _["mode"] = sc_mode,
+    _["stringsAsFactors"] = false
+  );
+
+  return List::create(
+    _["screening"] = screening,
+    _["significance"] = significance,
+    _["model_fits"] = model_fits
+  );
+}

--- a/src/SpatialGradient.cpp
+++ b/src/SpatialGradient.cpp
@@ -48,6 +48,13 @@ struct FitStats {
   int n_nonzero;
 };
 
+struct GradientStats {
+  double tot_var;
+  double norm_var;
+  double rel_var;
+  double p_value;
+};
+
 inline bool finite2(double x, double y) {
   return std::isfinite(x) && std::isfinite(y);
 }
@@ -163,6 +170,261 @@ FitStats fit_linear(
     }
   }
   return out;
+}
+
+std::vector<double> normalize_minmax(const std::vector<double>& values) {
+  double v_min = std::numeric_limits<double>::infinity();
+  double v_max = -std::numeric_limits<double>::infinity();
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    if (std::isfinite(values[i])) {
+      v_min = std::min(v_min, values[i]);
+      v_max = std::max(v_max, values[i]);
+    }
+  }
+  std::vector<double> out(values.size(), NA_REAL);
+  if (!std::isfinite(v_min) || !std::isfinite(v_max) || !(v_max > v_min)) {
+    return out;
+  }
+  const double denom = v_max - v_min;
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    if (std::isfinite(values[i])) {
+      out[i] = (values[i] - v_min) / denom;
+    }
+  }
+  return out;
+}
+
+double total_variation_rescaled(const std::vector<double>& gradient) {
+  std::vector<double> finite;
+  finite.reserve(gradient.size());
+  for (std::size_t i = 0; i < gradient.size(); ++i) {
+    if (std::isfinite(gradient[i])) {
+      finite.push_back(gradient[i]);
+    }
+  }
+  if (finite.size() < 2) {
+    return NA_REAL;
+  }
+  std::vector<double> scaled = normalize_minmax(finite);
+  bool any_finite = false;
+  for (std::size_t i = 0; i < scaled.size(); ++i) {
+    if (std::isfinite(scaled[i])) {
+      any_finite = true;
+      break;
+    }
+  }
+  if (!any_finite) {
+    return 0.0;
+  }
+  double out = 0.0;
+  for (std::size_t i = 1; i < scaled.size(); ++i) {
+    if (std::isfinite(scaled[i]) && std::isfinite(scaled[i - 1])) {
+      out += std::abs(scaled[i] - scaled[i - 1]);
+    }
+  }
+  return out;
+}
+
+double relative_variation(const std::vector<double>& gradient) {
+  double tv = total_variation_rescaled(gradient);
+  if (!std::isfinite(tv)) {
+    return NA_REAL;
+  }
+  double first = NA_REAL;
+  double last = NA_REAL;
+  for (std::size_t i = 0; i < gradient.size(); ++i) {
+    if (std::isfinite(gradient[i])) {
+      if (!std::isfinite(first)) {
+        first = gradient[i];
+      }
+      last = gradient[i];
+    }
+  }
+  if (!std::isfinite(first) || !std::isfinite(last)) {
+    return NA_REAL;
+  }
+  const double net = std::abs(last - first);
+  if (tv <= 0.0) {
+    return 0.0;
+  }
+  return net / tv;
+}
+
+std::vector<double> local_linear_gradient(
+  const std::vector<double>& x,
+  const std::vector<double>& y,
+  const NumericVector& centers,
+  int n_bins
+) {
+  const int n = static_cast<int>(x.size());
+  std::vector<double> out(static_cast<std::size_t>(centers.size()), NA_REAL);
+  if (n < 3) {
+    return out;
+  }
+  int k = static_cast<int>(std::ceil(static_cast<double>(n) / std::max(1, n_bins) * 3.0));
+  k = std::max(3, std::min(n, k));
+  std::vector<double> distances(static_cast<std::size_t>(n));
+
+  for (int c = 0; c < centers.size(); ++c) {
+    if (!std::isfinite(centers[c])) {
+      continue;
+    }
+    const double center = centers[c];
+    for (int i = 0; i < n; ++i) {
+      distances[static_cast<std::size_t>(i)] = std::abs(x[static_cast<std::size_t>(i)] - center);
+    }
+    std::vector<double> sorted = distances;
+    std::nth_element(sorted.begin(), sorted.begin() + k - 1, sorted.end());
+    double bandwidth = sorted[static_cast<std::size_t>(k - 1)];
+    if (!(bandwidth > 0.0)) {
+      bandwidth = sorted.back();
+    }
+    if (!(bandwidth > 0.0)) {
+      continue;
+    }
+
+    double sw = 0.0, sx = 0.0, sy = 0.0, sxx = 0.0, sxy = 0.0;
+    for (int i = 0; i < n; ++i) {
+      const double d = distances[static_cast<std::size_t>(i)] / bandwidth;
+      if (d > 1.0) {
+        continue;
+      }
+      const double u = 1.0 - d * d * d;
+      const double w = u * u * u;
+      const double xc = x[static_cast<std::size_t>(i)] - center;
+      const double yi = y[static_cast<std::size_t>(i)];
+      sw += w;
+      sx += w * xc;
+      sy += w * yi;
+      sxx += w * xc * xc;
+      sxy += w * xc * yi;
+    }
+    if (!(sw > 0.0)) {
+      continue;
+    }
+    const double den = sw * sxx - sx * sx;
+    if (den > 0.0) {
+      const double slope = (sw * sxy - sx * sy) / den;
+      const double intercept = (sy - slope * sx) / sw;
+      out[static_cast<std::size_t>(c)] = intercept;
+    } else {
+      out[static_cast<std::size_t>(c)] = sy / sw;
+    }
+  }
+  return out;
+}
+
+std::vector<double> binned_means(
+  const std::vector<double>& y_all,
+  const IntegerVector& bins,
+  int n_bins
+) {
+  std::vector<double> sums(static_cast<std::size_t>(n_bins), 0.0);
+  std::vector<int> counts(static_cast<std::size_t>(n_bins), 0);
+  for (int col = 0; col < bins.size(); ++col) {
+    if (bins[col] == NA_INTEGER || !std::isfinite(y_all[static_cast<std::size_t>(col)])) {
+      continue;
+    }
+    const int bin = bins[col];
+    sums[static_cast<std::size_t>(bin)] += y_all[static_cast<std::size_t>(col)];
+    counts[static_cast<std::size_t>(bin)] += 1;
+  }
+  std::vector<double> out(static_cast<std::size_t>(n_bins), NA_REAL);
+  for (int bin = 0; bin < n_bins; ++bin) {
+    if (counts[static_cast<std::size_t>(bin)] > 0) {
+      out[static_cast<std::size_t>(bin)] =
+        sums[static_cast<std::size_t>(bin)] / counts[static_cast<std::size_t>(bin)];
+    }
+  }
+  return out;
+}
+
+GradientStats gradient_test(
+  const std::vector<double>& x_valid,
+  const std::vector<double>& gradient,
+  const NumericVector& bin_centers,
+  int n_bins,
+  int n_random,
+  int seed,
+  int feature_index
+) {
+  GradientStats out;
+  out.tot_var = total_variation_rescaled(gradient);
+  out.norm_var = std::isfinite(out.tot_var) && gradient.size() > 0 ?
+    out.tot_var / static_cast<double>(gradient.size()) : NA_REAL;
+  out.rel_var = relative_variation(gradient);
+  out.p_value = NA_REAL;
+  if (!std::isfinite(out.tot_var) || n_random <= 0 || x_valid.size() < 3) {
+    return out;
+  }
+
+  std::mt19937 rng(static_cast<unsigned int>(seed + feature_index * 104729));
+  std::uniform_real_distribution<double> unif(0.0, 1.0);
+  int lt = 0;
+  int used = 0;
+  std::vector<double> random_y(x_valid.size(), 0.0);
+  for (int iter = 0; iter < n_random; ++iter) {
+    for (std::size_t i = 0; i < random_y.size(); ++i) {
+      random_y[i] = unif(rng);
+    }
+    std::vector<double> random_gradient = local_linear_gradient(
+      x_valid,
+      random_y,
+      bin_centers,
+      n_bins
+    );
+    const double random_tv = total_variation_rescaled(random_gradient);
+    if (std::isfinite(random_tv)) {
+      ++used;
+      if (random_tv < out.tot_var) {
+        ++lt;
+      }
+    }
+  }
+  if (used > 0) {
+    out.p_value = static_cast<double>(lt) / static_cast<double>(used);
+  }
+  return out;
+}
+
+void add_model_fit(
+  const std::string& variable,
+  const std::string& model,
+  const std::vector<double>& gradient,
+  const std::vector<double>& model_values,
+  std::vector<std::string>& fit_variable,
+  std::vector<std::string>& fit_model,
+  std::vector<double>& fit_mae,
+  std::vector<double>& fit_rmse,
+  std::vector<double>& fit_r2,
+  std::vector<double>& fit_slope,
+  std::vector<double>& fit_intercept
+) {
+  double abs_sum = 0.0;
+  double sq_sum = 0.0;
+  std::vector<double> g;
+  std::vector<double> m;
+  const std::size_t n = std::min(gradient.size(), model_values.size());
+  for (std::size_t i = 0; i < n; ++i) {
+    if (std::isfinite(gradient[i]) && std::isfinite(model_values[i])) {
+      const double err = gradient[i] - model_values[i];
+      abs_sum += std::abs(err);
+      sq_sum += err * err;
+      g.push_back(gradient[i]);
+      m.push_back(model_values[i]);
+    }
+  }
+  if (g.empty()) {
+    return;
+  }
+  const double r = pearson_r(g, m);
+  fit_variable.push_back(variable);
+  fit_model.push_back(model);
+  fit_mae.push_back(abs_sum / static_cast<double>(g.size()));
+  fit_rmse.push_back(std::sqrt(sq_sum / static_cast<double>(g.size())));
+  fit_r2.push_back(std::isfinite(r) ? r * r : NA_REAL);
+  fit_slope.push_back(NA_REAL);
+  fit_intercept.push_back(NA_REAL);
 }
 
 std::vector<double> annotation_distances(const NumericMatrix& coords, const LogicalVector& reference_spots) {
@@ -369,9 +631,14 @@ List spatial_gradient_screening_cpp(
 
   std::vector<std::string> sig_variable;
   std::vector<double> sig_tot_var;
+  std::vector<double> sig_norm_var;
+  std::vector<double> sig_rel_var;
   std::vector<double> sig_p;
   std::vector<int> sig_n;
   std::vector<int> sig_n_nonzero;
+  std::vector<double> sig_linear_r2;
+  std::vector<double> sig_linear_slope;
+  std::vector<double> sig_linear_intercept;
 
   std::vector<std::string> fit_variable;
   std::vector<std::string> fit_model;
@@ -390,6 +657,7 @@ List spatial_gradient_screening_cpp(
   sc_variable.reserve(static_cast<std::size_t>(mat.n_rows) * std::max(1, n_nonempty_bins));
 
   std::vector<double> y_all(static_cast<std::size_t>(mat.n_cols), 0.0);
+  std::vector<double> y_all_norm(static_cast<std::size_t>(mat.n_cols), NA_REAL);
   std::vector<double> x_valid;
   std::vector<double> y_valid;
 
@@ -408,57 +676,112 @@ List spatial_gradient_screening_cpp(
     x_valid.reserve(mat.n_cols);
     y_valid.reserve(mat.n_cols);
     int n_nonzero = 0;
+    double y_min = std::numeric_limits<double>::infinity();
+    double y_max = -std::numeric_limits<double>::infinity();
     for (int col = 0; col < mat.n_cols; ++col) {
       if (std::isfinite(dist[col]) && std::isfinite(y_all[static_cast<std::size_t>(col)])) {
-        x_valid.push_back(dist[col]);
-        y_valid.push_back(y_all[static_cast<std::size_t>(col)]);
+        const double y_raw = y_all[static_cast<std::size_t>(col)];
+        y_min = std::min(y_min, y_raw);
+        y_max = std::max(y_max, y_raw);
         if (y_all[static_cast<std::size_t>(col)] > 0.0) {
           ++n_nonzero;
         }
       }
     }
-    if (n_nonzero < min_spots || x_valid.size() < 3) {
+    if (n_nonzero < min_spots || !std::isfinite(y_min) || !std::isfinite(y_max) || !(y_max > y_min)) {
+      continue;
+    }
+    const double y_den = y_max - y_min;
+    std::fill(y_all_norm.begin(), y_all_norm.end(), NA_REAL);
+    for (int col = 0; col < mat.n_cols; ++col) {
+      if (std::isfinite(dist[col]) && std::isfinite(y_all[static_cast<std::size_t>(col)])) {
+        const double y_norm = (y_all[static_cast<std::size_t>(col)] - y_min) / y_den;
+        y_all_norm[static_cast<std::size_t>(col)] = y_norm;
+        x_valid.push_back(dist[col]);
+        y_valid.push_back(y_norm);
+      }
+    }
+    if (x_valid.size() < 3) {
       continue;
     }
 
-    FitStats fit = fit_linear(x_valid, y_valid, n_random, seed, row);
+    FitStats fit = fit_linear(x_valid, y_valid, 0, seed, row);
     fit.n_nonzero = n_nonzero;
-    if (!std::isfinite(fit.r2)) {
+    std::vector<double> gradient = local_linear_gradient(
+      x_valid,
+      y_valid,
+      bin_centers,
+      n_bins
+    );
+    std::vector<double> gradient_scaled = normalize_minmax(gradient);
+    GradientStats grad_stats = gradient_test(
+      x_valid,
+      gradient,
+      bin_centers,
+      n_bins,
+      n_random,
+      seed,
+      row
+    );
+    if (!std::isfinite(grad_stats.tot_var)) {
       continue;
     }
     const std::string variable = as<std::string>(variables[row]);
     sig_variable.push_back(variable);
-    sig_tot_var.push_back(fit.r2);
-    sig_p.push_back(fit.p_value);
+    sig_tot_var.push_back(grad_stats.tot_var);
+    sig_norm_var.push_back(grad_stats.norm_var);
+    sig_rel_var.push_back(grad_stats.rel_var);
+    sig_p.push_back(grad_stats.p_value);
     sig_n.push_back(fit.n);
     sig_n_nonzero.push_back(fit.n_nonzero);
+    sig_linear_r2.push_back(fit.r2);
+    sig_linear_slope.push_back(fit.slope);
+    sig_linear_intercept.push_back(fit.intercept);
 
-    fit_variable.push_back(variable);
-    fit_model.push_back("linear");
-    fit_mae.push_back(fit.mae);
-    fit_rmse.push_back(fit.rmse);
-    fit_r2.push_back(fit.r2);
-    fit_slope.push_back(fit.slope);
-    fit_intercept.push_back(fit.intercept);
-
-    NumericVector bin_value_sum(bin_centers.size());
-    IntegerVector bin_value_count(bin_centers.size());
-    for (int col = 0; col < mat.n_cols; ++col) {
-      if (bins[col] == NA_INTEGER) {
-        continue;
-      }
-      const int bin = bins[col];
-      bin_value_sum[bin] += y_all[static_cast<std::size_t>(col)];
-      bin_value_count[bin] += 1;
-    }
+    double d_min = std::numeric_limits<double>::infinity();
+    double d_max = -std::numeric_limits<double>::infinity();
     for (int bin = 0; bin < bin_centers.size(); ++bin) {
-      if (bin_value_count[bin] <= 0 || !std::isfinite(bin_centers[bin])) {
+      if (std::isfinite(bin_centers[bin])) {
+        d_min = std::min(d_min, static_cast<double>(bin_centers[bin]));
+        d_max = std::max(d_max, static_cast<double>(bin_centers[bin]));
+      }
+    }
+    std::vector<double> model_ascending(static_cast<std::size_t>(bin_centers.size()), NA_REAL);
+    std::vector<double> model_descending(static_cast<std::size_t>(bin_centers.size()), NA_REAL);
+    std::vector<double> model_peak(static_cast<std::size_t>(bin_centers.size()), NA_REAL);
+    std::vector<double> model_valley(static_cast<std::size_t>(bin_centers.size()), NA_REAL);
+    std::vector<double> model_linear(static_cast<std::size_t>(bin_centers.size()), NA_REAL);
+    if (std::isfinite(d_min) && std::isfinite(d_max) && d_max > d_min) {
+      for (int bin = 0; bin < bin_centers.size(); ++bin) {
+        if (!std::isfinite(bin_centers[bin])) {
+          continue;
+        }
+        const double t = (bin_centers[bin] - d_min) / (d_max - d_min);
+        model_ascending[static_cast<std::size_t>(bin)] = t;
+        model_descending[static_cast<std::size_t>(bin)] = 1.0 - t;
+        model_peak[static_cast<std::size_t>(bin)] = 1.0 - std::abs(2.0 * t - 1.0);
+        model_valley[static_cast<std::size_t>(bin)] = std::abs(2.0 * t - 1.0);
+        if (std::isfinite(fit.intercept) && std::isfinite(fit.slope)) {
+          model_linear[static_cast<std::size_t>(bin)] = fit.intercept + fit.slope * bin_centers[bin];
+        }
+      }
+      model_linear = normalize_minmax(model_linear);
+    }
+    add_model_fit(variable, "ascending", gradient_scaled, model_ascending, fit_variable, fit_model, fit_mae, fit_rmse, fit_r2, fit_slope, fit_intercept);
+    add_model_fit(variable, "descending", gradient_scaled, model_descending, fit_variable, fit_model, fit_mae, fit_rmse, fit_r2, fit_slope, fit_intercept);
+    add_model_fit(variable, "peak", gradient_scaled, model_peak, fit_variable, fit_model, fit_mae, fit_rmse, fit_r2, fit_slope, fit_intercept);
+    add_model_fit(variable, "valley", gradient_scaled, model_valley, fit_variable, fit_model, fit_mae, fit_rmse, fit_r2, fit_slope, fit_intercept);
+    add_model_fit(variable, "linear", gradient_scaled, model_linear, fit_variable, fit_model, fit_mae, fit_rmse, fit_r2, fit_slope, fit_intercept);
+
+    std::vector<double> bin_values = binned_means(y_all_norm, bins, bin_centers.size());
+    for (int bin = 0; bin < bin_centers.size(); ++bin) {
+      if (!std::isfinite(bin_centers[bin]) || !std::isfinite(bin_values[static_cast<std::size_t>(bin)])) {
         continue;
       }
       sc_variable.push_back(variable);
       sc_distance.push_back(bin_centers[bin]);
-      sc_value.push_back(bin_value_sum[bin] / bin_value_count[bin]);
-      sc_estimate.push_back(fit.intercept + fit.slope * bin_centers[bin]);
+      sc_value.push_back(bin_values[static_cast<std::size_t>(bin)]);
+      sc_estimate.push_back(gradient_scaled[static_cast<std::size_t>(bin)]);
       sc_reference.push_back(mode);
       sc_mode.push_back(mode);
     }
@@ -469,8 +792,13 @@ List spatial_gradient_screening_cpp(
     _["tot_var"] = sig_tot_var,
     _["p_value"] = sig_p,
     _["fdr"] = NumericVector(sig_p.size(), NA_REAL),
+    _["norm_var"] = sig_norm_var,
+    _["rel_var"] = sig_rel_var,
     _["n_spots"] = sig_n,
     _["n_nonzero"] = sig_n_nonzero,
+    _["linear_r2"] = sig_linear_r2,
+    _["linear_slope"] = sig_linear_slope,
+    _["linear_intercept"] = sig_linear_intercept,
     _["stringsAsFactors"] = false
   );
   DataFrame model_fits = DataFrame::create(

--- a/tests/testthat/test-scenic-regulon-sign.R
+++ b/tests/testthat/test-scenic-regulon-sign.R
@@ -1,0 +1,154 @@
+test_that("C++ SCENIC module builder labels positive regulons by default", {
+  expr <- matrix(
+    c(
+      1, 2, 3, 4, 5, 6,
+      1, 2, 3, 4, 5, 6,
+      6, 5, 4, 3, 2, 1,
+      1, 1, 2, 2, 3, 3
+    ),
+    nrow = 6,
+    ncol = 4,
+    dimnames = list(paste0("Cell", 1:6), c("TF1", "GenePos", "GeneNeg", "GeneWeak"))
+  )
+  adjacency <- data.frame(
+    TF = "TF1",
+    target = c("GenePos", "GeneNeg", "GeneWeak"),
+    importance = c(0.9, 0.8, 0.7),
+    stringsAsFactors = FALSE
+  )
+
+  modules <- getFromNamespace("scenic_modules_from_adjacencies", "scop")(
+    adjacency = adjacency,
+    expr_mtx = expr,
+    thresholds = 0.5,
+    top_n_targets = 3,
+    top_n_regulators = integer(0),
+    min_genes = 2,
+    keep_only_activating = TRUE,
+    verbose = FALSE
+  )
+
+  expect_true(length(modules) > 0)
+  expect_true(all(vapply(modules, `[[`, integer(1), "regulation") == 1L))
+  expect_true(all(vapply(modules, `[[`, character(1), "suffix") == "(+)"))
+  expect_true(all(vapply(modules, function(module) "GeneNeg" %in% module$genes, logical(1)) == FALSE))
+})
+
+test_that("C++ SCENIC module builder can include negative regulons", {
+  expr <- matrix(
+    c(
+      1, 2, 3, 4, 5, 6,
+      1, 2, 3, 4, 5, 6,
+      6, 5, 4, 3, 2, 1
+    ),
+    nrow = 6,
+    ncol = 3,
+    dimnames = list(paste0("Cell", 1:6), c("TF1", "GenePos", "GeneNeg"))
+  )
+  adjacency <- data.frame(
+    TF = "TF1",
+    target = c("GenePos", "GeneNeg"),
+    importance = c(0.9, 0.8),
+    stringsAsFactors = FALSE
+  )
+
+  modules <- getFromNamespace("scenic_modules_from_adjacencies", "scop")(
+    adjacency = adjacency,
+    expr_mtx = expr,
+    thresholds = 0.5,
+    top_n_targets = 2,
+    top_n_regulators = integer(0),
+    min_genes = 2,
+    keep_only_activating = FALSE,
+    verbose = FALSE
+  )
+
+  suffixes <- unique(vapply(modules, `[[`, character(1), "suffix"))
+  expect_setequal(suffixes, c("(-)", "(+)"))
+  expect_true(any(vapply(modules, function(module) {
+    identical(module$suffix, "(-)") && "GeneNeg" %in% module$genes
+  }, logical(1))))
+  expect_true(any(vapply(modules, function(module) {
+    identical(module$suffix, "(+)") && "GenePos" %in% module$genes
+  }, logical(1))))
+})
+
+test_that("C++ SCENIC regulon fallback uses pySCENIC-style positive names", {
+  adjacency <- data.frame(
+    TF = "TF1",
+    target = c("Gene1", "Gene2"),
+    importance = c(0.9, 0.8),
+    stringsAsFactors = FALSE
+  )
+
+  regulons <- getFromNamespace("build_regulons", "scop")(
+    adjacency = adjacency,
+    max_targets = 2,
+    min_regulon_size = 2
+  )
+
+  expect_equal(names(regulons), "TF1(+)")
+})
+
+test_that("C++ SCENIC AUCell scores are invariant to positive regulon naming", {
+  expr <- matrix(
+    rpois(30 * 24, lambda = 1),
+    nrow = 30,
+    ncol = 24,
+    dimnames = list(paste0("Gene", seq_len(30)), paste0("Cell", seq_len(24)))
+  )
+  expr[1:4, 1:6] <- expr[1:4, 1:6] + 5
+  genes <- c("Gene1", "Gene2", "Gene3", "Gene4")
+
+  old_scores <- getFromNamespace("scenic_compute_aucell_score", "scop")(
+    counts = expr,
+    regulon_list = list(TF1 = genes),
+    min_regulon_size = 1,
+    backend = "cpp",
+    cpp_strategy = "sparse",
+    seed = 42,
+    verbose = FALSE
+  )
+  new_scores <- getFromNamespace("scenic_compute_aucell_score", "scop")(
+    counts = expr,
+    regulon_list = list("TF1(+)" = genes),
+    min_regulon_size = 1,
+    backend = "cpp",
+    cpp_strategy = "sparse",
+    seed = 42,
+    verbose = FALSE
+  )
+
+  expect_equal(unname(old_scores[[1]]), unname(new_scores[[1]]))
+})
+
+test_that("C++ SCENIC AUCell scores are reproducible with seed", {
+  expr <- matrix(
+    rpois(30 * 24, lambda = 1),
+    nrow = 30,
+    ncol = 24,
+    dimnames = list(paste0("Gene", seq_len(30)), paste0("Cell", seq_len(24)))
+  )
+  genes <- c("Gene1", "Gene2", "Gene3", "Gene4")
+
+  first <- getFromNamespace("scenic_compute_aucell_score", "scop")(
+    counts = expr,
+    regulon_list = list("TF1(+)" = genes),
+    min_regulon_size = 1,
+    backend = "cpp",
+    cpp_strategy = "sparse",
+    seed = 42,
+    verbose = FALSE
+  )
+  second <- getFromNamespace("scenic_compute_aucell_score", "scop")(
+    counts = expr,
+    regulon_list = list("TF1(+)" = genes),
+    min_regulon_size = 1,
+    backend = "cpp",
+    cpp_strategy = "sparse",
+    seed = 42,
+    verbose = FALSE
+  )
+
+  expect_equal(first, second)
+})

--- a/tests/testthat/test-spatial-gradient.R
+++ b/tests/testthat/test-spatial-gradient.R
@@ -89,6 +89,15 @@ test_that("SPATA2 output tables are standardized to stable column names", {
   expect_equal(unique(screening$reference), "trajectory")
 })
 
+test_that("numeric annotation thresholds are converted for SPATA2", {
+  expect_equal(sgf_format_annotation_threshold(0), ">0")
+  expect_equal(sgf_format_annotation_threshold("0"), ">0")
+  expect_equal(sgf_format_annotation_threshold(" > 0 "), ">0")
+  expect_equal(sgf_format_annotation_threshold("<= 1"), "<=1")
+  expect_equal(sgf_format_annotation_threshold("kmeans_high"), "kmeans_high")
+  expect_error(sgf_format_annotation_threshold(NA_real_), "annotation.threshold")
+})
+
 test_that("top variable table merges significance and best model fits deterministically", {
   significance <- data.frame(
     variable = c("Gene3", "Gene1", "Gene2"),
@@ -136,6 +145,65 @@ test_that("spatial gradient storage keeps only plain data frames", {
   expect_true(all(vapply(stored, is.data.frame, logical(1))))
   expect_false(any(vapply(stored, methods::is, logical(1), class2 = "SPATA2")))
   expect_equal(srt@misc[["SpatialGradientFeatures"]], c("Gene1", "Gene2"))
+})
+
+test_that("cpp backend stores annotation gradient result tables", {
+  srt <- make_spatial_gradient_seurat()
+  srt$source_score <- c(1, 0, 0, 0)
+
+  srt <- RunSpatialGradientFeatures(
+    srt,
+    reference = "annotation",
+    backend = "cpp",
+    result_name = "cpp_annotation",
+    variables = c("Gene1", "Gene2"),
+    annotation.variable = "source_score",
+    annotation.threshold = 0,
+    layer = "counts",
+    coord.cols = c("x", "y"),
+    n_random = 0,
+    n_bins = 3,
+    min_spots = 1,
+    sign_threshold = 1,
+    nfeatures = 2,
+    verbose = FALSE
+  )
+
+  stored <- srt@tools[["SpatialGradientFeatures"]][["cpp_annotation"]]
+  expect_equal(names(stored), c("screening", "significance", "model_fits", "top_variables", "parameters"))
+  expect_true(all(vapply(stored, is.data.frame, logical(1))))
+  expect_false(any(vapply(stored, methods::is, logical(1), class2 = "SPATA2")))
+  expect_true(nrow(stored$screening) > 0)
+  expect_true(nrow(stored$top_variables) > 0)
+  expect_equal(stored$parameters$value[match("backend", stored$parameters$key)], "cpp")
+})
+
+test_that("cpp backend stores trajectory gradient result tables", {
+  srt <- make_spatial_gradient_seurat()
+
+  srt <- RunSpatialGradientFeatures(
+    srt,
+    reference = "trajectory",
+    backend = "cpp",
+    result_name = "cpp_trajectory",
+    variables = c("Gene1", "Gene2"),
+    start = c(1, 1),
+    end = c(2, 2),
+    layer = "counts",
+    coord.cols = c("x", "y"),
+    n_random = 0,
+    n_bins = 3,
+    min_spots = 1,
+    sign_threshold = 1,
+    nfeatures = 2,
+    verbose = FALSE
+  )
+
+  stored <- srt@tools[["SpatialGradientFeatures"]][["cpp_trajectory"]]
+  expect_true(all(vapply(stored, is.data.frame, logical(1))))
+  expect_true(nrow(stored$significance) > 0)
+  expect_true(nrow(stored$model_fits) > 0)
+  expect_equal(unique(stored$screening$mode), "trajectory")
 })
 
 test_that("SpatialGradientPlot handles stored results and missing tables clearly", {
@@ -213,6 +281,7 @@ test_that("RunSpatialGradientFeatures has a clear optional SPATA2 dependency err
     RunSpatialGradientFeatures(
       srt,
       reference = "trajectory",
+      backend = "spata2",
       variables = "Gene1",
       start = c(1, 1),
       end = c(2, 2),
@@ -226,16 +295,29 @@ test_that("RunSpatialGradientFeatures has a clear optional SPATA2 dependency err
 
 test_that("SPATA2 integration stores only stable result tables", {
   testthat::skip_if_not_installed("SPATA2")
+  testthat::skip_if_not(
+    identical(Sys.getenv("SCOP_RUN_SPATA2_INTEGRATION"), "true"),
+    "Set SCOP_RUN_SPATA2_INTEGRATION=true to run the slow SPATA2 integration fixture"
+  )
 
-  srt <- make_spatial_gradient_seurat()
+  data(visium_human_pancreas_sub, package = "scop")
+  srt <- subset(
+    visium_human_pancreas_sub,
+    cells = colnames(visium_human_pancreas_sub)[1:120]
+  )
+  coords <- srt@meta.data[, c("x", "y")]
+  start <- as.numeric(coords[which.min(coords[["x"]]), c("x", "y")])
+  end <- as.numeric(coords[which.max(coords[["x"]]), c("x", "y")])
   srt <- RunSpatialGradientFeatures(
     srt,
     reference = "trajectory",
     result_name = "tiny_trajectory",
-    variables = "Gene1",
-    start = c(1, 1),
-    end = c(2, 2),
+    variables = rownames(srt)[1],
+    start = start,
+    end = end,
+    assay = "Spatial",
     layer = "counts",
+    platform = "VisiumSmall",
     n_random = 5,
     nfeatures = 1,
     verbose = FALSE

--- a/tests/testthat/test-spatial-gradient.R
+++ b/tests/testthat/test-spatial-gradient.R
@@ -98,6 +98,39 @@ test_that("numeric annotation thresholds are converted for SPATA2", {
   expect_error(sgf_format_annotation_threshold(NA_real_), "annotation.threshold")
 })
 
+test_that("SPATA2 trajectory preparation does not forward unsupported verbose", {
+  testthat::local_mocked_bindings(
+    sgf_spata_fun = function(fun, required = TRUE) {
+      force(fun)
+      force(required)
+      function(...) list(...)
+    }
+  )
+
+  args <- sgf_prepare_trajectory(
+    object = list(id = "mock"),
+    trajectory_id = "traj",
+    start = c(1, 2),
+    end = c(3, 4),
+    traj_df = NULL,
+    width = NULL,
+    verbose = TRUE
+  )
+
+  expect_equal(args$id, "traj")
+  expect_true(isTRUE(args$overwrite))
+  expect_false("verbose" %in% names(args))
+})
+
+test_that("cpp backend coordinates prefer metadata coord.cols", {
+  srt <- make_spatial_gradient_seurat()
+  coords <- sgf_cpp_coords(srt, image = NULL, coord.cols = c("x", "y"))
+
+  expect_equal(rownames(coords), colnames(srt))
+  expect_equal(unname(coords$x), unname(srt$x))
+  expect_equal(unname(coords$y), unname(srt$y))
+})
+
 test_that("top variable table merges significance and best model fits deterministically", {
   significance <- data.frame(
     variable = c("Gene3", "Gene1", "Gene2"),

--- a/tests/testthat/test-spatial-gradient.R
+++ b/tests/testthat/test-spatial-gradient.R
@@ -318,6 +318,32 @@ test_that("SpatialGradientPlot combined returns a patchwork object when patchwor
   expect_s3_class(p, "patchwork")
 })
 
+test_that("SpatialGradientPlot reuses stored assay layer for surface plots", {
+  testthat::skip_if_not_installed("patchwork")
+  srt <- make_spatial_gradient_seurat()
+  result <- make_spatial_gradient_result()
+  result$parameters <- data.frame(
+    key = c("assay", "layer"),
+    value = c("RNA", "counts"),
+    stringsAsFactors = FALSE
+  )
+  srt <- sgf_store_result(srt, "mock_counts", result, assay = "RNA", set_variable_features = FALSE)
+
+  p <- expect_warning(
+    SpatialGradientPlot(
+      srt,
+      result_name = "mock_counts",
+      plot_type = "combined",
+      features = "Gene1",
+      coord.cols = c("x", "y"),
+      overlay_image = FALSE,
+      theme_use = NULL
+    ),
+    regexp = NA
+  )
+  expect_s3_class(p, "patchwork")
+})
+
 test_that("RunSpatialGradientFeatures has a clear optional SPATA2 dependency error", {
   testthat::skip_if(requireNamespace("SPATA2", quietly = TRUE))
   srt <- make_spatial_gradient_seurat()

--- a/tests/testthat/test-spatial-gradient.R
+++ b/tests/testthat/test-spatial-gradient.R
@@ -209,6 +209,9 @@ test_that("cpp backend stores annotation gradient result tables", {
   expect_true(nrow(stored$screening) > 0)
   expect_true(nrow(stored$top_variables) > 0)
   expect_equal(stored$parameters$value[match("backend", stored$parameters$key)], "cpp")
+  expect_true(all(c("norm_var", "rel_var", "linear_r2") %in% colnames(stored$significance)))
+  expect_true(all(c("ascending", "descending", "peak", "valley", "linear") %in% stored$model_fits$model))
+  expect_true(any(stored$significance$tot_var != stored$significance$linear_r2, na.rm = TRUE))
 })
 
 test_that("cpp backend stores trajectory gradient result tables", {
@@ -248,6 +251,15 @@ test_that("SpatialGradientPlot handles stored results and missing tables clearly
     SpatialGradientPlot(srt, result_name = "mock", plot_type = "line", theme_use = NULL),
     "ggplot"
   )
+  p_line_lm <- SpatialGradientPlot(
+    srt,
+    result_name = "mock",
+    plot_type = "line",
+    line_fit = "lm",
+    theme_use = NULL
+  )
+  expect_s3_class(p_line_lm, "ggplot")
+  expect_s3_class(p_line_lm$layers[[2]]$geom, "GeomSmooth")
   expect_s3_class(
     SpatialGradientPlot(srt, result_name = "mock", plot_type = "summary", theme_use = NULL),
     "ggplot"


### PR DESCRIPTION
## Summary
- add `RunSpatialGradientFeatures()` as a lightweight SPATA2 STS/SAS wrapper for spatial gradient feature screening
- add `SpatialGradientPlot()` for summary, surface, line, model, and combined SCOP-style visualizations
- store only stable data frames (`screening`, `significance`, `model_fits`, `top_variables`, `parameters`) instead of persisting SPATA2 objects
- add focused tests for optional SPATA2 dependency handling, result normalization/storage, plotting, and skipped SPATA2 integration coverage

## Validation
- `R CMD INSTALL --library=D:\scop-dev\r-tmp\scop-rctd-pr-lib --no-multiarch --with-keep.source .`
- `testthat::test_dir("tests/testthat", env = asNamespace("scop"), reporter = "summary")`
- `R CMD check --no-examples --no-manual --no-build-vignettes --library=D:\scop-dev\r-tmp\scop-rctd-pr-lib scop_0.8.9.tar.gz` with `_R_CHECK_FORCE_SUGGESTS_=false`

## Notes
- SPATA2 is a GitHub-only optional runtime dependency. It is checked with `requireNamespace("SPATA2")` and not listed in `DESCRIPTION`, so CI dependency resolution does not try to install it from CRAN/Bioc.
- Local SPATA2 integration test is skipped unless SPATA2 is installed.
- The remaining local `R CMD check` warning is the pre-existing `Signac::ATACqc` missing/unexported warning, not related to this change.