### PR TITLE
Update pandas from 2.0.3 to 2.2.0 for scVI compatibility

### DIFF
--- a/R/PrepareEnv.R
+++ b/R/PrepareEnv.R
@@ -1324,7 +1324,7 @@ core_python_requirements <- function() {
       "llvmlite" = "llvmlite==0.42.0",
       "numpy" = "numpy==1.26.4",
       "packaging" = "packaging>=24.0",
-      "pandas" = "pandas==2.0.3",
+      "pandas" = "pandas==2.2.0",
       "scikit-learn" = "scikit-learn==1.7.0",
       "scipy" = "scipy==1.15.3",
       if (is_apple_silicon()) {


### PR DESCRIPTION
## Summary

- Update `pandas` version pin from `2.0.3` to `2.2.0` in `PrepareEnv.R`
- `anndata 0.12.x` (dependency of `scvi-tools`) requires `pandas>=2.1.0`, but scop pinned `pandas==2.0.3`
- This causes `AttributeError: module 'pandas.arrays' has no attribute 'NumpyExtensionArray'` when running scVI integration

Closes #207

## Dependency analysis

`anndata` version vs `pandas` requirement:
- `anndata 0.11.x`: requires `pandas>=1.4` (compatible with 2.0.3)
- `anndata 0.12.x`: requires `pandas>=2.1.0` (NOT compatible with 2.0.3)

`scanpy==1.11.3` requires `anndata>=0.8`. pip resolves to the latest `anndata 0.12.x`, which triggers the pandas version conflict.

## Local test results

Environment: Python 3.11.9, Windows 11

**1. Core packages compatibility (all installed successfully)**

| Package | Version | numpy requirement | Compatible with numpy 1.26.4 |
|---|---|---|---|
| numpy | 1.26.4 | - | - |
| pandas | 2.2.0 | `>=1.23.2,<2` (Py3.11) | OK |
| scipy | 1.15.3 | `>=1.23.5,<2.5` | OK |
| scikit-learn | 1.7.0 | `>=1.22.0` | OK |
| matplotlib | 3.10.8 | `>=1.23` | OK |
| numba | 0.59.1 | `>=1.22,<1.27` | OK |
| llvmlite | 0.42.0 | - | OK |

**2. Import and functionality tests**

```
numpy: 1.26.4
pandas: 2.2.0
scipy: 1.15.3
scikit-learn: 1.7.0
matplotlib: 3.10.8
numba: 0.59.1
llvmlite: 0.42.0
anndata: 0.12.16
scanpy: 1.11.3
NumpyExtensionArray exists: True
```

- `pd.arrays.NumpyExtensionArray` creation: OK
- `anndata.AnnData` creation with numpy/pandas: OK
- `scanpy.datasets.pbmc3k()` loading: OK (2700, 32738)
- All imports and basic operations successful

**3. Confirmation that pandas 2.0.3 fails**

```
pandas: 2.0.3
NumpyExtensionArray exists: False
```

## Test plan

- [ ] Run `PrepareEnv()` and verify pandas 2.2.0 is installed
- [ ] Run `integration_scop()` with `integration_method = "scVI"` and verify no `NumpyExtensionArray` error