### PR TITLE
fix: resolve NumericMatrix constructor ambiguity with Rcpp 1.1.1 (#225)

### DIFF
--- a/src/ScTenifoldKnk.cpp
+++ b/src/ScTenifoldKnk.cpp
@@ -735,7 +735,7 @@ NumericMatrix sctenifold_tensor_decomposition(
 
   std::vector<arma::mat> tensors;
   tensors.reserve(n_net);
-  NumericMatrix first_mat(x_list[0]);
+  NumericMatrix first_mat = Rcpp::as<NumericMatrix>(x_list[0]);
   const arma::uword n_genes = first_mat.nrow();
   if (n_genes != static_cast<arma::uword>(first_mat.ncol())) {
     stop("all networks must be square matrices");
@@ -743,7 +743,7 @@ NumericMatrix sctenifold_tensor_decomposition(
 
   double tensor_ss = 0.0;
   for (arma::uword l = 0; l < n_net; ++l) {
-    NumericMatrix xm(x_list[l]);
+    NumericMatrix xm = Rcpp::as<NumericMatrix>(x_list[l]);
     if (static_cast<arma::uword>(xm.nrow()) != n_genes ||
         static_cast<arma::uword>(xm.ncol()) != n_genes) {
       stop("all networks must have the same dimensions");


### PR DESCRIPTION
## Problem

Rcpp 1.1.1 introduced new constructor overloads that make the implicit conversion from  (returns ) to  ambiguous, causing compilation failure:



This was reported in #225.

## Fix

Changed two lines in  (function ):

```cpp
// Before (ambiguous with Rcpp 1.1.1)
NumericMatrix first_mat(x_list[0]);
NumericMatrix xm(x_list[l]);

// After (explicit conversion, compatible with all Rcpp versions)
NumericMatrix first_mat = Rcpp::as<NumericMatrix>(x_list[0]);
NumericMatrix xm = Rcpp::as<NumericMatrix>(x_list[l]);
```

 is the Rcpp-recommended explicit conversion mechanism, backward-compatible with older Rcpp versions.

## Testing

- [ ] R CMD check on Windows/Linux/macOS
- [ ] scTenifoldKnk backend ("cpp") runs without errors

Closes #225