### PR TITLE
Add x-axis text angle option to FeatureStatPlot

### DIFF
--- a/R/ExpressionStatPlot.R
+++ b/R/ExpressionStatPlot.R
@@ -75,7 +75,8 @@ ExpressionStatPlot <- function(
   grid_major_linetype = 2,
   grid_major_linewidth = 0.3,
   force = FALSE,
-  seed = 11
+  seed = 11,
+  x_text_angle = 45
 ) {
   set.seed(seed)
 
@@ -1148,7 +1149,7 @@ ExpressionStatPlot <- function(
             do.call(theme_use, theme_args) +
             theme(
               aspect.ratio = aspect.ratio,
-              axis.text.x = element_text(angle = 45, hjust = 1, vjust = 1),
+              axis.text.x = element_text(angle = x_text_angle, hjust = 1, vjust = 1),
               strip.text.y = element_text(angle = 0),
               panel.grid.major = element_blank(),
               panel.grid.major.x = grid_major_element,
@@ -1162,7 +1163,7 @@ ExpressionStatPlot <- function(
           do.call(theme_use, theme_args) +
           theme(
             aspect.ratio = aspect.ratio,
-            axis.text.x = element_text(angle = 45, hjust = 1, vjust = 1),
+            axis.text.x = element_text(angle = x_text_angle, hjust = 1, vjust = 1),
             strip.text.y = element_text(angle = 0),
             panel.grid.major = element_blank(),
             panel.grid.major.y = grid_major_element,

--- a/R/FeatureStatPlot.R
+++ b/R/FeatureStatPlot.R
@@ -120,6 +120,8 @@
 #' Default is `3.5`.
 #' @param aspect.ratio Aspect ratio of the panel.
 #' Default is `NULL`.
+#' @param x_text_angle Rotation angle for x-axis labels.
+#' Default is `45`.
 #' @param ylab A string specifying the label of the y-axis.
 #' Default is `"Expression level"`.
 #' @param grid_major Whether to show major panel grid lines.
@@ -490,6 +492,7 @@ FeatureStatPlot <- function(
   force = FALSE,
   seed = 11,
   ...,
+  x_text_angle = 45,
   verbose = TRUE
 ) {
   if (is.null(group.by)) {
@@ -635,7 +638,8 @@ FeatureStatPlot <- function(
           grid_major_linetype = grid_major_linetype,
           grid_major_linewidth = grid_major_linewidth,
           force = force,
-          seed = seed
+          seed = seed,
+          x_text_angle = x_text_angle
         )
         plist <- append(plist, p)
       }
@@ -719,7 +723,8 @@ FeatureStatPlot <- function(
       grid_major_linetype = grid_major_linetype,
       grid_major_linewidth = grid_major_linewidth,
       force = force,
-      seed = seed
+      seed = seed,
+      x_text_angle = x_text_angle
     )
   }
 

--- a/man/FeatureStatPlot.Rd
+++ b/man/FeatureStatPlot.Rd
@@ -88,6 +88,7 @@ FeatureStatPlot(
   force = FALSE,
   seed = 11,
   ...,
+  x_text_angle = 45,
   verbose = TRUE
 )
 }
@@ -291,6 +292,9 @@ Default is \code{3.5}.}
 
 \item{aspect.ratio}{Aspect ratio of the panel.
 Default is \code{NULL}.}
+
+\item{x_text_angle}{Rotation angle for x-axis labels.
+Default is \code{45}.}
 
 \item{title}{The text for the title.
 Default is \code{NULL}.}


### PR DESCRIPTION
﻿## Summary
- Add `x_text_angle` to `FeatureStatPlot()` with the existing default of 45 degrees.
- Forward the value to `ExpressionStatPlot()` and use it instead of the hard-coded 45-degree x-axis label rotation.
- Update the generated Rd usage and argument docs.

## Notes
- This directly addresses the `FeatureStatPlot(stack = TRUE, flip = FALSE)` use case from #230.
- The shared lower-level `thisplot::StatPlot()` path is covered separately in mengxu98/thisplot#18 for `CellStatPlot()` and other `StatPlot()` wrappers.

## Validation
- `Rscript -e "parse('R/FeatureStatPlot.R'); parse('R/ExpressionStatPlot.R')"`
- `FeatureStatPlot(..., x_text_angle = 30)` returns `axis.text.x$angle == 30`
- Generated local comparison images for `x_text_angle = 45` and `x_text_angle = 90`

Fixes #230.
