### PR TITLE
Add remotes for harmony dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -135,7 +135,9 @@ Suggests:
     yardstick
 Remotes:
     Moonerss/CIBERSORT,
-    Hy4m/linkET
+    Hy4m/linkET,
+    immunogenomics/harmony,
+    immunogenomics/symphony
 LinkingTo:
     cli,
     Rcpp,


### PR DESCRIPTION
﻿## Summary
- Add GitHub remotes for `harmony` and `symphony` in `DESCRIPTION`.
- This lets `r-lib/actions/setup-r-dependencies` / `pak` resolve these Suggests dependencies during CI.

## Context
The macOS R-CMD-check job failed during dependency resolution before package checks ran:

```text
Can't install dependency harmony
Can't install dependency symphony
harmony: Can't find package called harmony, symphony.
symphony: Can't find package called harmony, symphony.
```

`RunHarmony2()` checks for `harmony`, and `RunSymphonyMap()` checks for `immunogenomics/symphony`, but the remotes were not listed for CI dependency installation.

## Validation
- `read.dcf("DESCRIPTION")` includes both new remotes
- `pak::pkg_deps(".", dependencies = "all")` resolves `harmony` and `symphony` as GitHub dependencies

Follow-up to the CI failure on merge commit db15cf37f9ed55feac0afc5213f9380a79ba8371.
