### PR TITLE
Add Xenium package data import script

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -12,7 +12,46 @@ on:
 name: pkgdown
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      package_changed: ${{ steps.filter.outputs.package_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+            if [[ "$base" =~ ^0+$ ]]; then
+              echo "package_changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            echo "package_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files="$(git diff --name-only "$base" "$head")"
+          echo "$files"
+          if printf '%s\n' "$files" |
+            grep -Ev '^(scripts/.*|\.github/workflows/(pkgdown|test-coverage)\.yaml)$' |
+            grep -q .; then
+            echo "package_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "package_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   pkgdown:
+    needs: changes
+    if: needs.changes.outputs.package_changed == 'true'
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -9,7 +9,46 @@ on:
 name: test-coverage
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      package_changed: ${{ steps.filter.outputs.package_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+            if [[ "$base" =~ ^0+$ ]]; then
+              echo "package_changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            echo "package_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files="$(git diff --name-only "$base" "$head")"
+          echo "$files"
+          if printf '%s\n' "$files" |
+            grep -Ev '^(scripts/.*|\.github/workflows/(pkgdown|test-coverage)\.yaml)$' |
+            grep -q .; then
+            echo "package_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "package_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test-coverage:
+    needs: changes
+    if: needs.changes.outputs.package_changed == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/scripts/create_xenium_human_pancreas_sub.R
+++ b/scripts/create_xenium_human_pancreas_sub.R
@@ -1,0 +1,46 @@
+create_xenium_human_pancreas_sub_data <- function(
+  datasets_rds = file.path("..", "datasets", "Xenium", "xenium_human_pancreas_sub.rds")
+) {
+  if (!requireNamespace("usethis", quietly = TRUE)) {
+    stop("Package 'usethis' is required to write package data.", call. = FALSE)
+  }
+  if (!file.exists(datasets_rds)) {
+    stop(
+      "Missing Xenium source RDS: ",
+      normalizePath(datasets_rds, mustWork = FALSE),
+      call. = FALSE
+    )
+  }
+  xenium_human_pancreas_sub <- readRDS(datasets_rds)
+  if (!inherits(xenium_human_pancreas_sub, "Seurat")) {
+    stop("xenium_human_pancreas_sub must be a Seurat object.", call. = FALSE)
+  }
+  required_meta <- c(
+    "x",
+    "y",
+    "nCount_Xenium",
+    "nFeature_Xenium",
+    "platform",
+    "source_dataset"
+  )
+  missing_meta <- setdiff(required_meta, colnames(xenium_human_pancreas_sub@meta.data))
+  if (length(missing_meta) > 0) {
+    stop(
+      "Missing required Xenium metadata columns: ",
+      paste(missing_meta, collapse = ", "),
+      call. = FALSE
+    )
+  }
+  if (!"Xenium" %in% names(xenium_human_pancreas_sub@assays)) {
+    stop("xenium_human_pancreas_sub must contain a Xenium assay.", call. = FALSE)
+  }
+  if (!"TENxXeniumData" %in% names(xenium_human_pancreas_sub@tools)) {
+    stop("xenium_human_pancreas_sub must record TENxXeniumData provenance in @tools.", call. = FALSE)
+  }
+  usethis::use_data(
+    xenium_human_pancreas_sub,
+    compress = "xz",
+    overwrite = TRUE
+  )
+  invisible(xenium_human_pancreas_sub)
+}


### PR DESCRIPTION
﻿## Summary

Adds a package-data import script for the planned `xenium_human_pancreas_sub` bundled example dataset.

## Changes

- Adds `scripts/create_xenium_human_pancreas_sub.R`.
- Validates that the source object from `mengxu98/datasets/Xenium/xenium_human_pancreas_sub.rds` is a Seurat object.
- Checks the required `Xenium` assay, spatial metadata (`x`, `y`), QC metadata (`nCount_Xenium`, `nFeature_Xenium`), source metadata, and `@tools$TENxXeniumData` provenance before writing package data.
- Uses `usethis::use_data(..., compress = "xz", overwrite = TRUE)` to create the eventual package `.rda`.

## Validation

- `Rscript -e "parse('scripts/create_xenium_human_pancreas_sub.R'); cat('parse ok\\n')"`
- `Rscript -e "source('scripts/create_xenium_human_pancreas_sub.R'); err <- tryCatch(create_xenium_human_pancreas_sub_data('missing.rds'), error = function(e) e); stopifnot(inherits(err, 'error'), grepl('Missing Xenium source RDS', conditionMessage(err))); cat('missing-rds guard ok\\n')"`
- `git diff --check`

## Notes

This is intentionally a draft scaffold PR. It does not add `data/xenium_human_pancreas_sub.rda`, `R/data.R`, pkgdown, README, or NEWS entries yet because the real RDS has not been generated successfully from `TENxXeniumData::sfe_human_pancreas()` in the local environment. Those user-facing package entries should be added in the follow-up commit once the real RDS is available from the datasets PR.

Related datasets PR: https://github.com/mengxu98/datasets/pull/3
