### PR TITLE
Document spatial examples

### DIFF
--- a/R/GiottoPlot.R
+++ b/R/GiottoPlot.R
@@ -11,6 +11,30 @@
 #'
 #' @return A `ggplot` object.
 #'
+#' @examples
+#' proximity <- list(
+#'   enrichment = data.frame(
+#'     group_1 = c("Tumor", "Tumor", "Stroma", "Immune"),
+#'     group_2 = c("Stroma", "Immune", "Immune", "Tumor"),
+#'     enrichment = c(1.6, -0.7, 0.9, -1.2),
+#'     type_int = c("enriched", "depleted", "enriched", "depleted")
+#'   ),
+#'   parameters = list(network_method = "Delaunay", number_of_simulations = 100)
+#' )
+#' class(proximity) <- c("scop_giotto_cell_proximity", "scop_giotto_result")
+#' GiottoPlot(proximity)
+#'
+#' spatial_genes <- list(
+#'   results = data.frame(
+#'     feat_ID = c("COL1A1", "KRT19", "MS4A1", "PECAM1"),
+#'     spatGeneRank = c(41.2, 32.8, 18.4, 11.9)
+#'   ),
+#'   top_features = c("COL1A1", "KRT19", "MS4A1"),
+#'   parameters = list(assay = "Spatial", layer = "data")
+#' )
+#' class(spatial_genes) <- c("scop_giotto_spatial_genes", "scop_giotto_result")
+#' GiottoPlot(spatial_genes, plot_type = "ranking", top_n = 4)
+#'
 #' @export
 GiottoPlot <- function(x, ...) {
   UseMethod("GiottoPlot")

--- a/R/RunGiottoCluster.R
+++ b/R/RunGiottoCluster.R
@@ -31,6 +31,40 @@
 #' @return A `giotto2_result` list containing the full Giotto object,
 #' cluster assignments, Giotto metadata, parameters, features, and cells.
 #'
+#' @examples
+#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' spatial <- Seurat::NormalizeData(
+#'   visium_human_pancreas_sub,
+#'   assay = "Spatial",
+#'   verbose = FALSE
+#' )
+#' spatial <- Seurat::FindVariableFeatures(
+#'   spatial,
+#'   assay = "Spatial",
+#'   nfeatures = 500,
+#'   verbose = FALSE
+#' )
+#'
+#' giotto_clusters <- RunGiottoCluster(
+#'   spatial,
+#'   assay = "Spatial",
+#'   layer = "data",
+#'   dims = 1:10,
+#'   k = 8,
+#'   resolution = 0.4,
+#'   coord.cols = c("col", "row")
+#' )
+#'
+#' head(giotto_clusters$clusters)
+#' GiottoPlot(
+#'   giotto_clusters,
+#'   srt = spatial,
+#'   overlay_image = FALSE,
+#'   coord.cols = c("col", "row")
+#' )
+#' }
+#'
 #' @export
 RunGiottoCluster <- function(
   srt,

--- a/R/RunGiottoSpatialMethods.R
+++ b/R/RunGiottoSpatialMethods.R
@@ -22,6 +22,34 @@
 #' @return A `giotto2_result` list containing the full Giotto object,
 #' enrichment table, raw Giotto result, parameters, features, and cells.
 #'
+#' @examples
+#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' spatial <- Seurat::NormalizeData(
+#'   visium_human_pancreas_sub,
+#'   assay = "Spatial",
+#'   verbose = FALSE
+#' )
+#' spatial$region <- ifelse(
+#'   spatial$col > stats::median(spatial$col),
+#'   "right",
+#'   "left"
+#' )
+#'
+#' proximity <- RunGiottoCellProximity(
+#'   spatial,
+#'   group.by = "region",
+#'   assay = "Spatial",
+#'   layer = "data",
+#'   coord.cols = c("col", "row"),
+#'   network_method = "Delaunay",
+#'   number_of_simulations = 100
+#' )
+#'
+#' head(proximity$enrichment)
+#' GiottoPlot(proximity)
+#' }
+#'
 #' @export
 RunGiottoCellProximity <- function(
   srt,
@@ -168,6 +196,41 @@ RunGiottoCellProximity <- function(
 #' @return A `giotto2_result` list containing the full Giotto object,
 #' spatial gene table, top features, raw Giotto result, parameters, features,
 #' and cells.
+#'
+#' @examples
+#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' spatial <- Seurat::NormalizeData(
+#'   visium_human_pancreas_sub,
+#'   assay = "Spatial",
+#'   verbose = FALSE
+#' )
+#' spatial <- Seurat::FindVariableFeatures(
+#'   spatial,
+#'   assay = "Spatial",
+#'   nfeatures = 500,
+#'   verbose = FALSE
+#' )
+#'
+#' giotto_genes <- RunGiottoSpatialGenes(
+#'   spatial,
+#'   assay = "Spatial",
+#'   layer = "data",
+#'   features = Seurat::VariableFeatures(spatial, assay = "Spatial"),
+#'   coord.cols = c("col", "row"),
+#'   top_n = 50
+#' )
+#'
+#' head(giotto_genes$results)
+#' GiottoPlot(giotto_genes, plot_type = "ranking", top_n = 10)
+#' GiottoPlot(
+#'   giotto_genes,
+#'   srt = spatial,
+#'   plot_type = "feature",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("col", "row")
+#' )
+#' }
 #'
 #' @export
 RunGiottoSpatialGenes <- function(
@@ -325,6 +388,35 @@ RunGiottoSpatialGenes <- function(
 #' @return A `giotto2_result` list containing the full Giotto object,
 #' spatial correlation object, module object, extracted module tables,
 #' parameters, features, and cells.
+#'
+#' @examples
+#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' spatial <- Seurat::NormalizeData(
+#'   visium_human_pancreas_sub,
+#'   assay = "Spatial",
+#'   verbose = FALSE
+#' )
+#' spatial <- Seurat::FindVariableFeatures(
+#'   spatial,
+#'   assay = "Spatial",
+#'   nfeatures = 500,
+#'   verbose = FALSE
+#' )
+#'
+#' giotto_modules <- RunGiottoSpatialModules(
+#'   spatial,
+#'   assay = "Spatial",
+#'   layer = "data",
+#'   features = Seurat::VariableFeatures(spatial, assay = "Spatial")[1:50],
+#'   coord.cols = c("col", "row"),
+#'   cor_method = "pearson",
+#'   k = 6
+#' )
+#'
+#' names(giotto_modules$module_tables)
+#' GiottoPlot(giotto_modules, top_n = 12)
+#' }
 #'
 #' @export
 RunGiottoSpatialModules <- function(

--- a/R/RunSemla.R
+++ b/R/RunSemla.R
@@ -20,6 +20,20 @@
 #' @param ... Additional arguments passed to semla.
 #'
 #' @return A `Seurat` object.
+#'
+#' @examples
+#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#'
+#' spatial <- RunSemlaSpatialNetwork(
+#'   visium_human_pancreas_sub,
+#'   nNeighbors = 6,
+#'   coords = "array"
+#' )
+#'
+#' head(spatial@tools$SemlaSpatialNetwork$network)
+#' SpatialSpotPlot(spatial, group.by = "orig.ident")
+#' }
 #' @export
 RunSemlaSpatialNetwork <- function(
   srt,
@@ -91,6 +105,27 @@ RunSemlaSpatialNetwork <- function(
 #' @param assay_name Assay name used by semla when `store_in_metadata = FALSE`.
 #'
 #' @return A `Seurat` object.
+#'
+#' @examples
+#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' spatial <- Seurat::NormalizeData(
+#'   visium_human_pancreas_sub,
+#'   assay = "Spatial",
+#'   verbose = FALSE
+#' )
+#' features <- rownames(spatial)[1:3]
+#'
+#' spatial <- RunSemlaLocalG(
+#'   spatial,
+#'   features = features,
+#'   store_in_metadata = TRUE
+#' )
+#'
+#' local_g_cols <- grep(features[1], colnames(spatial[[]]), value = TRUE)
+#' head(spatial[[]][local_g_cols])
+#' SpatialSpotPlot(spatial, group.by = local_g_cols[1])
+#' }
 #' @export
 RunSemlaLocalG <- function(
   srt,
@@ -136,6 +171,28 @@ RunSemlaLocalG <- function(
 #' @param column_key Prefix for metadata columns returned by semla.
 #'
 #' @return A `Seurat` object.
+#'
+#' @examples
+#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' spatial <- visium_human_pancreas_sub
+#' spatial$region <- ifelse(
+#'   spatial$col > stats::median(spatial$col),
+#'   "right",
+#'   "left"
+#' )
+#'
+#' spatial <- RunSemlaRegionNeighbors(
+#'   spatial,
+#'   column_name = "region",
+#'   column_labels = "right",
+#'   mode = "outer",
+#'   column_key = "right_border"
+#' )
+#'
+#' grep("right_border", colnames(spatial[[]]), value = TRUE)
+#' SpatialSpotPlot(spatial, group.by = "region")
+#' }
 #' @export
 RunSemlaRegionNeighbors <- function(
   srt,
@@ -181,6 +238,28 @@ RunSemlaRegionNeighbors <- function(
 #' @param column_suffix Optional suffix for metadata columns returned by semla.
 #'
 #' @return A `Seurat` object.
+#'
+#' @examples
+#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' spatial <- visium_human_pancreas_sub
+#' spatial$region <- ifelse(
+#'   spatial$row > stats::median(spatial$row),
+#'   "upper",
+#'   "lower"
+#' )
+#'
+#' spatial <- RunSemlaRadialDistance(
+#'   spatial,
+#'   column_name = "region",
+#'   selected_groups = "upper",
+#'   column_suffix = "upper_distance"
+#' )
+#'
+#' distance_cols <- grep("upper_distance", colnames(spatial[[]]), value = TRUE)
+#' head(spatial[[]][distance_cols])
+#' SpatialSpotPlot(spatial, group.by = distance_cols[1])
+#' }
 #' @export
 RunSemlaRadialDistance <- function(
   srt,

--- a/R/RunSpatialEcoTyper.R
+++ b/R/RunSpatialEcoTyper.R
@@ -309,6 +309,27 @@ RunSpatialEcoTyper <- function(
 #' @param ... Additional arguments passed to [SpatialSpotPlot()].
 #'
 #' @return A `ggplot`, `patchwork`, or list of `ggplot` objects.
+#'
+#' @examples
+#' counts <- matrix(
+#'   c(3, 0, 1, 2, 0, 4, 1, 0, 2, 1, 3, 0),
+#'   nrow = 3,
+#'   byrow = TRUE
+#' )
+#' rownames(counts) <- c("EPCAM", "COL1A1", "PTPRC")
+#' colnames(counts) <- paste0("spot", 1:4)
+#' srt <- Seurat::CreateSeuratObject(counts)
+#' srt$X <- c(0, 1, 0, 1)
+#' srt$Y <- c(0, 0, 1, 1)
+#' srt$SpatialEcoTyper_SE <- c("SE1", "SE1", "SE2", "SE2")
+#' srt$CellType <- c("Epithelial", "Fibroblast", "Immune", "Epithelial")
+#'
+#' SpatialEcoTyperSpatialPlot(
+#'   srt,
+#'   overlay_image = FALSE,
+#'   coord.cols = c("X", "Y"),
+#'   pt.size = 4
+#' )
 #' @export
 SpatialEcoTyperSpatialPlot <- function(
   srt,
@@ -356,6 +377,26 @@ SpatialEcoTyperSpatialPlot <- function(
 #' @param theme_args Additional arguments passed to the theme function.
 #'
 #' @return A `ggplot` object.
+#'
+#' @examples
+#' counts <- matrix(
+#'   c(3, 0, 1, 2, 0, 4, 1, 0, 2, 1, 3, 0),
+#'   nrow = 3,
+#'   byrow = TRUE
+#' )
+#' rownames(counts) <- c("EPCAM", "COL1A1", "PTPRC")
+#' colnames(counts) <- paste0("spot", 1:4)
+#' srt <- Seurat::CreateSeuratObject(counts)
+#' srt$SpatialEcoTyper_SE <- c("SE1", "SE1", "SE2", "SE2")
+#' srt$CellType <- c("Epithelial", "Fibroblast", "Immune", "Epithelial")
+#' srt$sample <- c("slice1", "slice1", "slice2", "slice2")
+#'
+#' SpatialEcoTyperCompositionPlot(
+#'   srt,
+#'   group.by = "CellType",
+#'   sample.by = "sample",
+#'   position = "fill"
+#' )
 #' @export
 SpatialEcoTyperCompositionPlot <- function(
   srt,

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -365,6 +365,61 @@ RunSpatialGradientFeatures <- function(
 #' monotonic trend even when the backend stores a smoothed curve.
 #'
 #' @return A `ggplot` or `patchwork` object.
+#'
+#' @examples
+#' counts <- matrix(
+#'   c(4, 1, 0, 2, 1, 3, 2, 0),
+#'   nrow = 2,
+#'   byrow = TRUE
+#' )
+#' rownames(counts) <- c("REG1A", "COL1A1")
+#' colnames(counts) <- paste0("spot", 1:4)
+#' srt <- Seurat::CreateSeuratObject(counts)
+#' srt <- Seurat::NormalizeData(srt, verbose = FALSE)
+#' srt$col <- c(0, 1, 0, 1)
+#' srt$row <- c(0, 0, 1, 1)
+#'
+#' gradient_result <- list(
+#'   screening = data.frame(
+#'     variable = rep(c("REG1A", "COL1A1"), each = 4),
+#'     distance = rep(seq(0, 1, length.out = 4), 2),
+#'     value = c(0.1, 0.4, 0.8, 1.1, 1.0, 0.7, 0.3, 0.1),
+#'     estimate = c(0.15, 0.45, 0.75, 1.05, 0.95, 0.65, 0.35, 0.05)
+#'   ),
+#'   significance = data.frame(
+#'     variable = c("REG1A", "COL1A1"),
+#'     p_value = c(0.004, 0.018),
+#'     q_value = c(0.008, 0.024)
+#'   ),
+#'   model_fits = data.frame(
+#'     variable = rep(c("REG1A", "COL1A1"), each = 2),
+#'     model = rep(c("linear", "spline"), 2),
+#'     rmse = c(0.12, 0.08, 0.18, 0.11)
+#'   ),
+#'   top_variables = data.frame(
+#'     variable = c("REG1A", "COL1A1"),
+#'     rank = 1:2,
+#'     rmse = c(0.08, 0.11)
+#'   ),
+#'   parameters = data.frame(
+#'     key = c("assay", "layer", "reference"),
+#'     value = c("RNA", "data", "ductal_axis")
+#'   )
+#' )
+#' srt@tools[["SpatialGradientFeatures"]] <- list(ductal_axis = gradient_result)
+#' srt@misc[["SpatialGradientFeaturesResult"]] <- "ductal_axis"
+#'
+#' SpatialGradientPlot(srt, plot_type = "summary", nfeatures = 2)
+#' SpatialGradientPlot(srt, plot_type = "line", nfeatures = 2)
+#' SpatialGradientPlot(srt, plot_type = "model", nfeatures = 2)
+#' SpatialGradientPlot(
+#'   srt,
+#'   plot_type = "surface",
+#'   nfeatures = 2,
+#'   overlay_image = FALSE,
+#'   coord.cols = c("col", "row"),
+#'   pt.size = 4
+#' )
 #' @export
 SpatialGradientPlot <- function(
   srt,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -166,7 +166,14 @@ reference:
   - ProjectionPlot
   - TACSPlot
 
-- subtitle: "Spatial Analysis"
+- title: "Spatial Analysis"
+
+- subtitle: "Spatial QC and Normalization"
+- contents:
+  - RunSpaNorm
+  - RunSpotSweeper
+
+- subtitle: "Spatial Workflow and Giotto Backends"
 - contents:
   - SeuratToScopGiotto
   - RunGiottoWorkflow
@@ -179,31 +186,38 @@ reference:
   - GiottoCellProximity
   - GiottoHMRF
   - AddGiottoToSeurat
-  - RunBayesSpace
-  - RunBANKSY
-  - RunCARD
-  - RunCytoSPACE
-  - RunSTdeconvolve
   - RunGiottoCluster
   - RunGiottoCellProximity
   - RunGiottoSpatialGenes
   - RunGiottoSpatialModules
+
+- subtitle: "Spatial Deconvolution and Ecotypes"
+- contents:
   - RunRCTD
   - RunCSIDE
-  - RunSpaNorm
+  - RunCARD
+  - RunSTdeconvolve
+  - RunSPOTlight
+  - RunSpatialEcoTyper
+
+- subtitle: "Spatial Domains and Feature Patterns"
+- contents:
+  - RunBayesSpace
+  - RunBANKSY
+  - RunCytoSPACE
   - RunSmoothClust
   - RunMERINGUE
-  - RunSpotSweeper
-  - RunSPOTlight
+  - RunSpatialVariableFeatures
+  - RunSpatialGradientFeatures
+
+- subtitle: "Spatial Neighborhoods and Multi-Sample Integration"
+- contents:
+  - RunSpatialNeighborhood
+  - RunSpatialIntegration
   - RunSemlaSpatialNetwork
   - RunSemlaLocalG
   - RunSemlaRadialDistance
   - RunSemlaRegionNeighbors
-  - RunSpatialEcoTyper
-  - RunSpatialGradientFeatures
-  - RunSpatialIntegration
-  - RunSpatialNeighborhood
-  - RunSpatialVariableFeatures
 
 - subtitle: "Spatial Visualization"
 - contents:

--- a/man/GiottoPlot.Rd
+++ b/man/GiottoPlot.Rd
@@ -148,3 +148,28 @@ Plot standalone Giotto backend results with scop plotting conventions. The
 input \code{Seurat} object, when supplied, is copied internally for plotting and
 is not modified.
 }
+\examples{
+proximity <- list(
+  enrichment = data.frame(
+    group_1 = c("Tumor", "Tumor", "Stroma", "Immune"),
+    group_2 = c("Stroma", "Immune", "Immune", "Tumor"),
+    enrichment = c(1.6, -0.7, 0.9, -1.2),
+    type_int = c("enriched", "depleted", "enriched", "depleted")
+  ),
+  parameters = list(network_method = "Delaunay", number_of_simulations = 100)
+)
+class(proximity) <- c("scop_giotto_cell_proximity", "scop_giotto_result")
+GiottoPlot(proximity)
+
+spatial_genes <- list(
+  results = data.frame(
+    feat_ID = c("COL1A1", "KRT19", "MS4A1", "PECAM1"),
+    spatGeneRank = c(41.2, 32.8, 18.4, 11.9)
+  ),
+  top_features = c("COL1A1", "KRT19", "MS4A1"),
+  parameters = list(assay = "Spatial", layer = "data")
+)
+class(spatial_genes) <- c("scop_giotto_spatial_genes", "scop_giotto_result")
+GiottoPlot(spatial_genes, plot_type = "ranking", top_n = 4)
+
+}

--- a/man/RunGiottoCellProximity.Rd
+++ b/man/RunGiottoCellProximity.Rd
@@ -82,3 +82,32 @@ pairwise enrichment between metadata groups. The complete Giotto object and
 result tables are returned as a standalone result; the input \code{Seurat} object
 is not modified.
 }
+\examples{
+\dontrun{
+data(visium_human_pancreas_sub)
+spatial <- Seurat::NormalizeData(
+  visium_human_pancreas_sub,
+  assay = "Spatial",
+  verbose = FALSE
+)
+spatial$region <- ifelse(
+  spatial$col > stats::median(spatial$col),
+  "right",
+  "left"
+)
+
+proximity <- RunGiottoCellProximity(
+  spatial,
+  group.by = "region",
+  assay = "Spatial",
+  layer = "data",
+  coord.cols = c("col", "row"),
+  network_method = "Delaunay",
+  number_of_simulations = 100
+)
+
+head(proximity$enrichment)
+GiottoPlot(proximity)
+}
+
+}

--- a/man/RunGiottoCluster.Rd
+++ b/man/RunGiottoCluster.Rd
@@ -87,3 +87,38 @@ Run Giotto as a temporary backend for nearest-network clustering and return
 the complete Giotto object together with extracted cluster results. The input
 \code{Seurat} object is not modified.
 }
+\examples{
+\dontrun{
+data(visium_human_pancreas_sub)
+spatial <- Seurat::NormalizeData(
+  visium_human_pancreas_sub,
+  assay = "Spatial",
+  verbose = FALSE
+)
+spatial <- Seurat::FindVariableFeatures(
+  spatial,
+  assay = "Spatial",
+  nfeatures = 500,
+  verbose = FALSE
+)
+
+giotto_clusters <- RunGiottoCluster(
+  spatial,
+  assay = "Spatial",
+  layer = "data",
+  dims = 1:10,
+  k = 8,
+  resolution = 0.4,
+  coord.cols = c("col", "row")
+)
+
+head(giotto_clusters$clusters)
+GiottoPlot(
+  giotto_clusters,
+  srt = spatial,
+  overlay_image = FALSE,
+  coord.cols = c("col", "row")
+)
+}
+
+}

--- a/man/RunGiottoSpatialGenes.Rd
+++ b/man/RunGiottoSpatialGenes.Rd
@@ -86,3 +86,39 @@ Use Giotto \code{binSpect()} as a temporary backend for spatially variable gene
 detection. The complete Giotto object and result tables are returned as a
 standalone result; the input \code{Seurat} object is not modified.
 }
+\examples{
+\dontrun{
+data(visium_human_pancreas_sub)
+spatial <- Seurat::NormalizeData(
+  visium_human_pancreas_sub,
+  assay = "Spatial",
+  verbose = FALSE
+)
+spatial <- Seurat::FindVariableFeatures(
+  spatial,
+  assay = "Spatial",
+  nfeatures = 500,
+  verbose = FALSE
+)
+
+giotto_genes <- RunGiottoSpatialGenes(
+  spatial,
+  assay = "Spatial",
+  layer = "data",
+  features = Seurat::VariableFeatures(spatial, assay = "Spatial"),
+  coord.cols = c("col", "row"),
+  top_n = 50
+)
+
+head(giotto_genes$results)
+GiottoPlot(giotto_genes, plot_type = "ranking", top_n = 10)
+GiottoPlot(
+  giotto_genes,
+  srt = spatial,
+  plot_type = "feature",
+  overlay_image = FALSE,
+  coord.cols = c("col", "row")
+)
+}
+
+}

--- a/man/RunGiottoSpatialModules.Rd
+++ b/man/RunGiottoSpatialModules.Rd
@@ -89,3 +89,33 @@ temporary backend for feature-level spatial co-expression modules. The
 complete Giotto object and module results are returned as a standalone
 result; the input \code{Seurat} object is not modified.
 }
+\examples{
+\dontrun{
+data(visium_human_pancreas_sub)
+spatial <- Seurat::NormalizeData(
+  visium_human_pancreas_sub,
+  assay = "Spatial",
+  verbose = FALSE
+)
+spatial <- Seurat::FindVariableFeatures(
+  spatial,
+  assay = "Spatial",
+  nfeatures = 500,
+  verbose = FALSE
+)
+
+giotto_modules <- RunGiottoSpatialModules(
+  spatial,
+  assay = "Spatial",
+  layer = "data",
+  features = Seurat::VariableFeatures(spatial, assay = "Spatial")[1:50],
+  coord.cols = c("col", "row"),
+  cor_method = "pearson",
+  k = 6
+)
+
+names(giotto_modules$module_tables)
+GiottoPlot(giotto_modules, top_n = 12)
+}
+
+}

--- a/man/RunSemlaLocalG.Rd
+++ b/man/RunSemlaLocalG.Rd
@@ -43,3 +43,24 @@ Use \code{semla::RunLocalG()} on a Staffli-enabled Seurat object. Results are
 written by semla to metadata or to an assay, depending on
 \code{store_in_metadata}.
 }
+\examples{
+\dontrun{
+data(visium_human_pancreas_sub)
+spatial <- Seurat::NormalizeData(
+  visium_human_pancreas_sub,
+  assay = "Spatial",
+  verbose = FALSE
+)
+features <- rownames(spatial)[1:3]
+
+spatial <- RunSemlaLocalG(
+  spatial,
+  features = features,
+  store_in_metadata = TRUE
+)
+
+local_g_cols <- grep(features[1], colnames(spatial[[]]), value = TRUE)
+head(spatial[[]][local_g_cols])
+SpatialSpotPlot(spatial, group.by = local_g_cols[1])
+}
+}

--- a/man/RunSemlaRadialDistance.Rd
+++ b/man/RunSemlaRadialDistance.Rd
@@ -39,3 +39,25 @@ A \code{Seurat} object.
 Use \code{semla::RadialDistance()} to calculate distances from selected spatial
 regions and write the returned columns to Seurat metadata.
 }
+\examples{
+\dontrun{
+data(visium_human_pancreas_sub)
+spatial <- visium_human_pancreas_sub
+spatial$region <- ifelse(
+  spatial$row > stats::median(spatial$row),
+  "upper",
+  "lower"
+)
+
+spatial <- RunSemlaRadialDistance(
+  spatial,
+  column_name = "region",
+  selected_groups = "upper",
+  column_suffix = "upper_distance"
+)
+
+distance_cols <- grep("upper_distance", colnames(spatial[[]]), value = TRUE)
+head(spatial[[]][distance_cols])
+SpatialSpotPlot(spatial, group.by = distance_cols[1])
+}
+}

--- a/man/RunSemlaRegionNeighbors.Rd
+++ b/man/RunSemlaRegionNeighbors.Rd
@@ -42,3 +42,25 @@ A \code{Seurat} object.
 Use \code{semla::RegionNeighbors()} to identify neighboring spots for selected
 metadata labels and write the returned columns to Seurat metadata.
 }
+\examples{
+\dontrun{
+data(visium_human_pancreas_sub)
+spatial <- visium_human_pancreas_sub
+spatial$region <- ifelse(
+  spatial$col > stats::median(spatial$col),
+  "right",
+  "left"
+)
+
+spatial <- RunSemlaRegionNeighbors(
+  spatial,
+  column_name = "region",
+  column_labels = "right",
+  mode = "outer",
+  column_key = "right_border"
+)
+
+grep("right_border", colnames(spatial[[]]), value = TRUE)
+SpatialSpotPlot(spatial, group.by = "region")
+}
+}

--- a/man/RunSemlaSpatialNetwork.Rd
+++ b/man/RunSemlaSpatialNetwork.Rd
@@ -49,3 +49,17 @@ Use the optional \code{semla} package as a backend to prepare a Staffli-enabled
 Seurat object and compute spot-level spatial networks. The network is stored
 in \code{srt@tools[[tool_name]]} when \code{store_results = TRUE}.
 }
+\examples{
+\dontrun{
+data(visium_human_pancreas_sub)
+
+spatial <- RunSemlaSpatialNetwork(
+  visium_human_pancreas_sub,
+  nNeighbors = 6,
+  coords = "array"
+)
+
+head(spatial@tools$SemlaSpatialNetwork$network)
+SpatialSpotPlot(spatial, group.by = "orig.ident")
+}
+}

--- a/man/SpatialEcoTyperCompositionPlot.Rd
+++ b/man/SpatialEcoTyperCompositionPlot.Rd
@@ -48,3 +48,23 @@ A \code{ggplot} object.
 Plot SpatialEcoTyper composition across cell types, samples, or other
 metadata groups using scop's default plotting theme and palettes.
 }
+\examples{
+counts <- matrix(
+  c(3, 0, 1, 2, 0, 4, 1, 0, 2, 1, 3, 0),
+  nrow = 3,
+  byrow = TRUE
+)
+rownames(counts) <- c("EPCAM", "COL1A1", "PTPRC")
+colnames(counts) <- paste0("spot", 1:4)
+srt <- Seurat::CreateSeuratObject(counts)
+srt$SpatialEcoTyper_SE <- c("SE1", "SE1", "SE2", "SE2")
+srt$CellType <- c("Epithelial", "Fibroblast", "Immune", "Epithelial")
+srt$sample <- c("slice1", "slice1", "slice2", "slice2")
+
+SpatialEcoTyperCompositionPlot(
+  srt,
+  group.by = "CellType",
+  sample.by = "sample",
+  position = "fill"
+)
+}

--- a/man/SpatialEcoTyperSpatialPlot.Rd
+++ b/man/SpatialEcoTyperSpatialPlot.Rd
@@ -47,3 +47,24 @@ A \code{ggplot}, \code{patchwork}, or list of \code{ggplot} objects.
 Plot SpatialEcoTyper labels on spatial coordinates using scop's spatial
 plotting style.
 }
+\examples{
+counts <- matrix(
+  c(3, 0, 1, 2, 0, 4, 1, 0, 2, 1, 3, 0),
+  nrow = 3,
+  byrow = TRUE
+)
+rownames(counts) <- c("EPCAM", "COL1A1", "PTPRC")
+colnames(counts) <- paste0("spot", 1:4)
+srt <- Seurat::CreateSeuratObject(counts)
+srt$X <- c(0, 1, 0, 1)
+srt$Y <- c(0, 0, 1, 1)
+srt$SpatialEcoTyper_SE <- c("SE1", "SE1", "SE2", "SE2")
+srt$CellType <- c("Epithelial", "Fibroblast", "Immune", "Epithelial")
+
+SpatialEcoTyperSpatialPlot(
+  srt,
+  overlay_image = FALSE,
+  coord.cols = c("X", "Y"),
+  pt.size = 4
+)
+}

--- a/man/SpatialGradientPlot.Rd
+++ b/man/SpatialGradientPlot.Rd
@@ -105,3 +105,58 @@ A \code{ggplot} or \code{patchwork} object.
 Visualize normalized results produced by \code{RunSpatialGradientFeatures()}
 without requiring the original SPATA2 object.
 }
+\examples{
+counts <- matrix(
+  c(4, 1, 0, 2, 1, 3, 2, 0),
+  nrow = 2,
+  byrow = TRUE
+)
+rownames(counts) <- c("REG1A", "COL1A1")
+colnames(counts) <- paste0("spot", 1:4)
+srt <- Seurat::CreateSeuratObject(counts)
+srt <- Seurat::NormalizeData(srt, verbose = FALSE)
+srt$col <- c(0, 1, 0, 1)
+srt$row <- c(0, 0, 1, 1)
+
+gradient_result <- list(
+  screening = data.frame(
+    variable = rep(c("REG1A", "COL1A1"), each = 4),
+    distance = rep(seq(0, 1, length.out = 4), 2),
+    value = c(0.1, 0.4, 0.8, 1.1, 1.0, 0.7, 0.3, 0.1),
+    estimate = c(0.15, 0.45, 0.75, 1.05, 0.95, 0.65, 0.35, 0.05)
+  ),
+  significance = data.frame(
+    variable = c("REG1A", "COL1A1"),
+    p_value = c(0.004, 0.018),
+    q_value = c(0.008, 0.024)
+  ),
+  model_fits = data.frame(
+    variable = rep(c("REG1A", "COL1A1"), each = 2),
+    model = rep(c("linear", "spline"), 2),
+    rmse = c(0.12, 0.08, 0.18, 0.11)
+  ),
+  top_variables = data.frame(
+    variable = c("REG1A", "COL1A1"),
+    rank = 1:2,
+    rmse = c(0.08, 0.11)
+  ),
+  parameters = data.frame(
+    key = c("assay", "layer", "reference"),
+    value = c("RNA", "data", "ductal_axis")
+  )
+)
+srt@tools[["SpatialGradientFeatures"]] <- list(ductal_axis = gradient_result)
+srt@misc[["SpatialGradientFeaturesResult"]] <- "ductal_axis"
+
+SpatialGradientPlot(srt, plot_type = "summary", nfeatures = 2)
+SpatialGradientPlot(srt, plot_type = "line", nfeatures = 2)
+SpatialGradientPlot(srt, plot_type = "model", nfeatures = 2)
+SpatialGradientPlot(
+  srt,
+  plot_type = "surface",
+  nfeatures = 2,
+  overlay_image = FALSE,
+  coord.cols = c("col", "row"),
+  pt.size = 4
+)
+}


### PR DESCRIPTION
## Summary
- Split the pkgdown Spatial Analysis reference section into focused subsections.
- Add roxygen examples for Giotto, Semla, SpatialEcoTyper, and SpatialGradient spatial plotting/workflow functions.
- Regenerate only the affected Rd files.

## Scope
This PR intentionally contains only spatial documentation/example changes. It does not include the prior SPOTlight implementation commit or unrelated FindMarkers/RunDEtest fixes.

## Validation
- `tools::checkRd()` on affected spatial Rd files
- `yaml::read_yaml("_pkgdown.yml")`
- `git diff --check`