### PR TITLE
Add executable spatial documentation examples

### DIFF
--- a/R/GiottoObject.R
+++ b/R/GiottoObject.R
@@ -120,33 +120,61 @@ giotto_do_call <- function(name, args) {
 #' @return A `giotto2` object.
 #'
 #' @examples
-#' \dontrun{
-#' # Convert Seurat/SCT data into a standalone Giotto workflow object.
-#' g <- SeuratToScopGiotto(
-#'   spatial_seurat,
-#'   assay = "RNA",
-#'   layer = "counts",
-#'   use_sct = "normalized"
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:300]
+#' )
+#' g <- structure(
+#'   list(
+#'     giotto = list(
+#'       umap = cbind(
+#'         UMAP_1 = as.numeric(scale(spatial$x)),
+#'         UMAP_2 = as.numeric(scale(spatial$y))
+#'       )
+#'     ),
+#'     source = list(
+#'       cells = colnames(spatial),
+#'       features = rownames(spatial),
+#'       coordinates = data.frame(
+#'         cell_ID = colnames(spatial),
+#'         sdimx = spatial$x,
+#'         sdimy = spatial$y
+#'       )
+#'     ),
+#'     results = list(
+#'       cluster = list(
+#'         table = data.frame(
+#'           cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) %% 3 + 1),
+#'           row.names = colnames(spatial)
+#'         )
+#'       ),
+#'       spatial_network = list(
+#'         table = data.frame(
+#'           from = colnames(spatial)[1:8],
+#'           to = colnames(spatial)[2:9]
+#'         )
+#'       )
+#'     ),
+#'     active = "cluster"
+#'   ),
+#'   class = c("giotto2", "list")
 #' )
 #'
-#' # Run the basic Giotto pipeline and plot directly from the Giotto object.
-#' g <- RunGiottoWorkflow(g, steps = "basic")
 #' GiottoPlot(g, plot_type = "cluster")
 #' GiottoPlot(g, plot_type = "network")
-#' GiottoPlot(g, plot_type = "dim")
 #'
-#' # Add selected Giotto analyses without writing to the Seurat object.
-#' g <- GiottoSpatialGenes(g, top_n = 50)
-#' g <- GiottoCellProximity(g, group.by = "celltype", number_of_simulations = 100)
-#' GiottoPlot(g, plot_type = "spatial_genes", top_n = 20)
-#' GiottoPlot(g, plot_type = "cell_proximity")
-#'
-#' # Export a result back to Seurat only when explicitly requested.
-#' spatial_seurat <- AddGiottoToSeurat(
-#'   spatial_seurat,
-#'   g,
-#'   result = "cluster",
-#'   name = "Giotto_cluster"
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' g <- SeuratToScopGiotto(
+#'   spatial,
+#'   assay = "Spatial",
+#'   layer = "counts",
+#'   coord.cols = c("x", "y"),
+#'   verbose = FALSE
 #' )
 #' }
 #' @export
@@ -394,6 +422,53 @@ giotto_validate_runtime_object <- function(x, verbose = TRUE) {
 #'
 #' @return A Seurat object by default for Seurat input, otherwise a `giotto2`
 #' workflow object.
+#'
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:300]
+#' )
+#' g <- structure(
+#'   list(
+#'     source = list(
+#'       cells = colnames(spatial),
+#'       features = rownames(spatial),
+#'       coordinates = data.frame(
+#'         cell_ID = colnames(spatial),
+#'         sdimx = spatial$x,
+#'         sdimy = spatial$y
+#'       )
+#'     ),
+#'     results = list(
+#'       cluster = list(
+#'         table = data.frame(
+#'           cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) %% 3 + 1),
+#'           row.names = colnames(spatial)
+#'         )
+#'       )
+#'     ),
+#'     active = "cluster"
+#'   ),
+#'   class = c("giotto2", "list")
+#' )
+#' GiottoPlot(g, plot_type = "cluster")
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' g <- RunGiottoWorkflow(
+#'   spatial,
+#'   steps = "basic",
+#'   assay = "Spatial",
+#'   layer = "counts",
+#'   coord.cols = c("x", "y"),
+#'   return_seurat = FALSE,
+#'   verbose = FALSE
+#' )
+#' }
 #' @export
 RunGiottoWorkflow <- function(
   x,
@@ -613,6 +688,31 @@ RunGiottoWorkflow <- function(
 #' @param seed Random seed for reproducible Giotto calls.
 #'
 #' @return A `giotto2` workflow object.
+#'
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(visium_human_pancreas_sub, cells = colnames(visium_human_pancreas_sub)[1:60])
+#' g <- structure(
+#'   list(
+#'     source = list(
+#'       cells = colnames(spatial),
+#'       features = rownames(spatial)[1:100],
+#'       coordinates = data.frame(cell_ID = colnames(spatial), sdimx = spatial$x, sdimy = spatial$y)
+#'     ),
+#'     results = list(),
+#'     active = NULL
+#'   ),
+#'   class = c("giotto2", "list")
+#' )
+#' GiottoPlot(g, plot_type = "spatial")
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' g <- SeuratToScopGiotto(spatial, assay = "Spatial", coord.cols = c("x", "y"), verbose = FALSE)
+#' g <- GiottoPreprocess(g, verbose = FALSE)
+#' }
 #' @export
 GiottoPreprocess <- function(
   x,
@@ -744,6 +844,46 @@ GiottoPreprocess <- function(
 #' @param seed Random seed for reproducible Giotto calls.
 #'
 #' @return A `giotto2` workflow object.
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:200]
+#' )
+#' embedding <- cbind(
+#'   UMAP_1 = as.numeric(scale(spatial$x)),
+#'   UMAP_2 = as.numeric(scale(spatial$y))
+#' )
+#' rownames(embedding) <- colnames(spatial)
+#' g <- structure(
+#'   list(
+#'     giotto = list(umap = embedding),
+#'     source = list(cells = colnames(spatial), features = rownames(spatial)),
+#'     results = list(
+#'       cluster = list(
+#'         table = data.frame(
+#'           cell = colnames(spatial),
+#'           cluster = spatial$coda_label,
+#'           row.names = colnames(spatial)
+#'         )
+#'       )
+#'     ),
+#'     parameters = list(umap_name = "umap")
+#'   ),
+#'   class = c("giotto2", "list")
+#' )
+#' GiottoPlot(g, plot_type = "dim")
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+#'   g <- GiottoPreprocess(g)
+#'   g <- GiottoReduce(g, reduction = "pca", dims = 1:10)
+#'   g <- GiottoReduce(g, reduction = "umap", dims = 1:10)
+#' }
 #' @export
 GiottoReduce <- function(
   x,
@@ -838,6 +978,46 @@ GiottoReduce <- function(
 #' @param seed Random seed for reproducible Giotto calls.
 #'
 #' @return A `giotto2` workflow object.
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:200]
+#' )
+#' coords <- data.frame(
+#'   cell_ID = colnames(spatial),
+#'   sdimx = spatial$x,
+#'   sdimy = spatial$y,
+#'   row.names = colnames(spatial)
+#' )
+#' g <- structure(
+#'   list(
+#'     source = list(cells = colnames(spatial), coordinates = coords),
+#'     results = list(
+#'       cluster = list(
+#'         table = data.frame(
+#'           cell = colnames(spatial),
+#'           cluster = spatial$coda_label,
+#'           row.names = colnames(spatial)
+#'         )
+#'       )
+#'     ),
+#'     parameters = list(k = 8, resolution = 0.4)
+#'   ),
+#'   class = c("giotto2", "list")
+#' )
+#' GiottoPlot(g, plot_type = "cluster")
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+#'   g <- GiottoPreprocess(g)
+#'   g <- GiottoReduce(g, reduction = "pca", dims = 1:10)
+#'   g <- GiottoCluster(g, dims = 1:10, k = 8, resolution = 0.4)
+#' }
 #' @export
 GiottoCluster <- function(
   x,
@@ -939,6 +1119,39 @@ GiottoCluster <- function(
 #' @param verbose Whether to print progress messages.
 #'
 #' @return A `giotto2` workflow object.
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:200]
+#' )
+#' coords <- data.frame(
+#'   cell_ID = colnames(spatial),
+#'   sdimx = spatial$x,
+#'   sdimy = spatial$y,
+#'   row.names = colnames(spatial)
+#' )
+#' edges <- data.frame(
+#'   from = colnames(spatial)[1:79],
+#'   to = colnames(spatial)[2:80]
+#' )
+#' g <- structure(
+#'   list(
+#'     source = list(cells = colnames(spatial), coordinates = coords),
+#'     results = list(spatial_network = list(name = "Delaunay_network", table = edges))
+#'   ),
+#'   class = c("giotto2", "list")
+#' )
+#' GiottoPlot(g, plot_type = "network")
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+#'   g <- GiottoSpatialNetwork(g, network_method = "Delaunay")
+#' }
 #' @export
 GiottoSpatialNetwork <- function(
   x,
@@ -1016,6 +1229,47 @@ giotto_get_spatial_network_table <- function(gobject, network_name, spat_unit = 
 #' @param seed Random seed for reproducible Giotto calls.
 #'
 #' @return A `giotto2` workflow object.
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:200]
+#' )
+#' coords <- data.frame(
+#'   cell_ID = colnames(spatial),
+#'   sdimx = spatial$x,
+#'   sdimy = spatial$y,
+#'   row.names = colnames(spatial)
+#' )
+#' spatial_gene_table <- data.frame(
+#'   feat_ID = rownames(spatial)[1:8],
+#'   spatGeneRank = seq_len(8),
+#'   adj.p.value = seq(0.001, 0.04, length.out = 8)
+#' )
+#' g <- structure(
+#'   list(
+#'     source = list(cells = colnames(spatial), coordinates = coords),
+#'     results = list(
+#'       spatial_genes = list(
+#'         table = spatial_gene_table,
+#'         top_features = spatial_gene_table$feat_ID
+#'       )
+#'     )
+#'   ),
+#'   class = c("giotto2", "list")
+#' )
+#' GiottoPlot(g, plot_type = "spatial_genes", top_n = 6)
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+#'   g <- GiottoPreprocess(g)
+#'   g <- GiottoSpatialNetwork(g)
+#'   g <- GiottoSpatialGenes(g, features = rownames(spatial)[1:50], top_n = 10)
+#' }
 #' @export
 GiottoSpatialGenes <- function(
   x,
@@ -1095,6 +1349,43 @@ GiottoSpatialGenes <- function(
 #' @param seed Random seed for reproducible Giotto calls.
 #'
 #' @return A `giotto2` workflow object.
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:200]
+#' )
+#' features <- rownames(spatial)[1:6]
+#' module_table <- expand.grid(
+#'   feat_ID = features,
+#'   variable = paste0("module_", 1:3),
+#'   stringsAsFactors = FALSE
+#' )
+#' module_table$spat_cor <- seq(-0.7, 0.8, length.out = nrow(module_table))
+#' g <- structure(
+#'   list(
+#'     source = list(cells = colnames(spatial), features = features),
+#'     results = list(
+#'       spatial_modules = list(
+#'         module_tables = list(result.cor_DT = module_table),
+#'         features = features
+#'       )
+#'     )
+#'   ),
+#'   class = c("giotto2", "list")
+#' )
+#' GiottoPlot(g, plot_type = "spatial_modules", top_n = 6)
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+#'   g <- GiottoPreprocess(g)
+#'   g <- GiottoSpatialNetwork(g)
+#'   g <- GiottoSpatialModules(g, features = rownames(spatial)[1:50], k = 3)
+#' }
 #' @export
 GiottoSpatialModules <- function(
   x,
@@ -1184,6 +1475,36 @@ GiottoSpatialModules <- function(
 #' @param seed Random seed for reproducible Giotto calls.
 #'
 #' @return A `giotto2` workflow object.
+#' @examples
+#' proximity <- data.frame(
+#'   group_1 = c("Ductal", "Ductal", "Endocrine", "Stromal"),
+#'   group_2 = c("Endocrine", "Stromal", "Stromal", "Ductal"),
+#'   enrichment = c(1.6, 0.8, 1.3, 0.7),
+#'   p.adj = c(0.01, 0.08, 0.03, 0.12)
+#' )
+#' g <- structure(
+#'   list(
+#'     results = list(cell_proximity = list(table = proximity)),
+#'     parameters = list(network_method = "Delaunay", number_of_simulations = 100)
+#'   ),
+#'   class = c("giotto2", "list")
+#' )
+#' GiottoPlot(g, plot_type = "cell_proximity")
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#'   data(visium_human_pancreas_sub)
+#'   spatial <- subset(
+#'     visium_human_pancreas_sub,
+#'     cells = colnames(visium_human_pancreas_sub)[1:80],
+#'     features = rownames(visium_human_pancreas_sub)[1:200]
+#'   )
+#'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+#'   g <- GiottoSpatialNetwork(g)
+#'   g <- GiottoCellProximity(g, group.by = "coda_label", number_of_simulations = 100)
+#' }
 #' @export
 GiottoCellProximity <- function(
   x,
@@ -1256,6 +1577,47 @@ GiottoCellProximity <- function(
 #' @param seed Random seed for reproducible Giotto calls.
 #'
 #' @return A `giotto2` workflow object.
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:200]
+#' )
+#' coords <- data.frame(
+#'   cell_ID = colnames(spatial),
+#'   sdimx = spatial$x,
+#'   sdimy = spatial$y,
+#'   row.names = colnames(spatial)
+#' )
+#' hmrf_meta <- data.frame(
+#'   cell_ID = colnames(spatial),
+#'   scop_HMRF_k4_b10 = paste0("domain_", as.integer(factor(spatial$coda_label)) %% 4 + 1),
+#'   row.names = colnames(spatial)
+#' )
+#' g <- structure(
+#'   list(
+#'     source = list(cells = colnames(spatial), coordinates = coords),
+#'     results = list(
+#'       hmrf = list(
+#'         table = hmrf_meta["scop_HMRF_k4_b10"],
+#'         metadata = hmrf_meta
+#'       )
+#'     )
+#'   ),
+#'   class = c("giotto2", "list")
+#' )
+#' GiottoPlot(g, plot_type = "hmrf")
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+#'   g <- GiottoPreprocess(g)
+#'   g <- GiottoSpatialNetwork(g)
+#'   g <- GiottoHMRF(g, spatial_genes = rownames(spatial)[1:30], k = 4)
+#' }
 #' @export
 GiottoHMRF <- function(
   x,
@@ -1361,6 +1723,42 @@ giotto_ensure_spatial_network <- function(x, network_method = "Delaunay", networ
 #' `srt@tools[[tool_name]]`.
 #'
 #' @return A Seurat object.
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:200]
+#' )
+#' g <- structure(
+#'   list(
+#'     source = list(cells = colnames(spatial)),
+#'     results = list(
+#'       cluster = list(
+#'         table = data.frame(
+#'           cell = colnames(spatial),
+#'           cluster = spatial$coda_label,
+#'           row.names = colnames(spatial)
+#'         )
+#'       )
+#'     )
+#'   ),
+#'   class = c("giotto2", "list")
+#' )
+#' spatial <- AddGiottoToSeurat(
+#'   spatial,
+#'   g,
+#'   result = "cluster",
+#'   name = "Giotto_cluster",
+#'   store_result = FALSE
+#' )
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "Giotto_cluster",
+#'   plot_type = "point",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
 #' @export
 AddGiottoToSeurat <- function(
   srt,

--- a/R/GiottoPlot.R
+++ b/R/GiottoPlot.R
@@ -12,6 +12,32 @@
 #' @return A `ggplot` object.
 #'
 #' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:300]
+#' )
+#' cluster_result <- list(
+#'   clusters = data.frame(
+#'     cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) %% 3 + 1),
+#'     row.names = colnames(spatial)
+#'   ),
+#'   parameters = list(
+#'     cluster_colname = "Giotto_cluster",
+#'     coord.cols = c("x", "y"),
+#'     k = 8,
+#'     resolution = 0.4
+#'   )
+#' )
+#' class(cluster_result) <- c("giotto2_cluster", "giotto2_result", "list")
+#' GiottoPlot(
+#'   cluster_result,
+#'   srt = spatial,
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#'
 #' proximity <- list(
 #'   enrichment = data.frame(
 #'     group_1 = c("Tumor", "Tumor", "Stroma", "Immune"),
@@ -21,7 +47,7 @@
 #'   ),
 #'   parameters = list(network_method = "Delaunay", number_of_simulations = 100)
 #' )
-#' class(proximity) <- c("giotto2_cell_proximity", "scop_giotto_result")
+#' class(proximity) <- c("giotto2_cell_proximity", "giotto2_result", "list")
 #' GiottoPlot(proximity)
 #'
 #' spatial_genes <- list(
@@ -32,8 +58,25 @@
 #'   top_features = c("COL1A1", "KRT19", "MS4A1"),
 #'   parameters = list(assay = "Spatial", layer = "data")
 #' )
-#' class(spatial_genes) <- c("giotto2_spatial_genes", "scop_giotto_result")
+#' class(spatial_genes) <- c("giotto2_spatial_genes", "giotto2_result", "list")
 #' GiottoPlot(spatial_genes, plot_type = "ranking", top_n = 4)
+#'
+#' modules <- list(
+#'   module_tables = list(
+#'     result.cor_DT = expand.grid(
+#'       feat_ID = c("COL1A1", "KRT19", "MS4A1"),
+#'       variable = c("COL1A1", "KRT19", "MS4A1")
+#'     )
+#'   ),
+#'   features = c("COL1A1", "KRT19", "MS4A1")
+#' )
+#' modules$module_tables$result.cor_DT$spat_cor <- c(
+#'   1, 0.35, -0.20,
+#'   0.35, 1, 0.15,
+#'   -0.20, 0.15, 1
+#' )
+#' class(modules) <- c("giotto2_spatial_modules", "giotto2_result", "list")
+#' GiottoPlot(modules, top_n = 3)
 #'
 #' @export
 GiottoPlot <- function(x, ...) {

--- a/R/RunBANKSY.R
+++ b/R/RunBANKSY.R
@@ -42,17 +42,38 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- RunBANKSY(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' spatial$BANKSY_cluster <- factor(
+#'   paste0("BANKSY", (seq_len(ncol(spatial)) - 1) %% 3 + 1)
+#' )
+#'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "BANKSY_cluster",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#'
+#' if (
+#'   requireNamespace("Banksy", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' spatial <- RunBANKSY(
+#'   spatial,
 #'   assay = "Spatial",
 #'   layer = "counts",
+#'   coord.cols = c("x", "y"),
+#'   features = rownames(spatial)[1:300],
 #'   lambda = 0.2,
-#'   k_geom = 15,
-#'   resolution = 0.6
+#'   k_geom = 8,
+#'   resolution = 0.6,
+#'   verbose = FALSE
 #' )
-#' SpatialSpotPlot(spatial, group.by = "BANKSY_cluster")
 #' }
 RunBANKSY <- function(
   srt,

--- a/R/RunBayesSpace.R
+++ b/R/RunBayesSpace.R
@@ -29,8 +29,28 @@
 #' @export
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- RunBayesSpace(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' spatial$BayesSpace_cluster <- factor(
+#'   paste0("domain_", (seq_len(ncol(spatial)) - 1) %% 3 + 1)
+#' )
+#'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "BayesSpace_cluster",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#'
+#' if (
+#'   requireNamespace("BayesSpace", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' spatial <- RunBayesSpace(
+#'   spatial,
 #'   q = 3,
 #'   n.PCs = 5,
 #'   n.HVGs = 200,
@@ -43,7 +63,7 @@
 #'   )
 #' )
 #' table(spatial$BayesSpace_cluster)
-#' SpatialSpotPlot(spatial, group.by = "BayesSpace_cluster")
+#' }
 RunBayesSpace <- function(
   srt,
   q,

--- a/R/RunCARD.R
+++ b/R/RunCARD.R
@@ -24,19 +24,59 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' data(panc8_sub)
-#'
-#' spatial <- RunCARD(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   reference = panc8_sub,
-#'   reference_label = "celltype",
-#'   assay = "Spatial",
-#'   reference_assay = "RNA"
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
-#' SpatialSpotPlot(spatial, group.by = "CARD_dominant_type")
-#' SpatialSpotPlot(spatial, group.by = "CARD_dominant_type", plot_type = "pie")
+#' card_weights <- data.frame(
+#'   CARD_prop_Ductal = seq(0.70, 0.20, length.out = ncol(spatial)),
+#'   CARD_prop_Endocrine = seq(0.20, 0.70, length.out = ncol(spatial)),
+#'   CARD_prop_Stromal = 0.10,
+#'   row.names = colnames(spatial)
+#' )
+#' card_weights <- card_weights / rowSums(card_weights)
+#' spatial <- Seurat::AddMetaData(spatial, card_weights)
+#' spatial$CARD_dominant_type <- sub(
+#'   "^CARD_prop_",
+#'   "",
+#'   colnames(card_weights)[max.col(card_weights)]
+#' )
+#' spatial$CARD_max_prop <- apply(card_weights, 1, max)
+#'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "CARD_dominant_type",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' if (requireNamespace("scatterpie", quietly = TRUE)) {
+#'   SpatialSpotPlot(
+#'     spatial,
+#'     group.by = "CARD_dominant_type",
+#'     plot_type = "pie",
+#'     overlay_image = FALSE,
+#'     coord.cols = c("x", "y")
+#'   )
+#' }
+#'
+#' if (
+#'   (requireNamespace("CARD", quietly = TRUE) ||
+#'     requireNamespace("CARDspa", quietly = TRUE)) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' data(pancreas_sub)
+#' features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
+#' spatial <- RunCARD(
+#'   spatial,
+#'   reference = pancreas_sub,
+#'   reference_label = "CellType",
+#'   assay = "Spatial",
+#'   reference_assay = "RNA",
+#'   features = features_use,
+#'   verbose = FALSE
+#' )
 #' }
 RunCARD <- function(
   srt,

--- a/R/RunCSIDE.R
+++ b/R/RunCSIDE.R
@@ -40,36 +40,59 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
-#' library(scop)
-#'
 #' data(visium_human_pancreas_sub)
-#' data(panc8_sub)
-#'
-#' spatial <- RunRCTD(
-#'   srt = visium_human_pancreas_sub,
-#'   reference = panc8_sub,
-#'   reference_label = "celltype",
-#'   assay = "Spatial",
-#'   reference_assay = "RNA",
-#'   rctd_mode = "full",
-#'   max_cores = 1
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' spatial$region <- ifelse(spatial$x > stats::median(spatial$x), "right", "left")
+#' spatial$CSIDE_n_sig <- ifelse(spatial$region == "right", 12, 4)
+#' spatial$CSIDE_mode <- "regions"
+#' cside_result <- data.frame(
+#'   feature = rownames(spatial)[1:4],
+#'   celltype = rep(c("Ductal", "Endocrine"), each = 2),
+#'   parameter = "right_vs_left",
+#'   logFC = c(1.2, 0.8, -0.9, -1.1),
+#'   statistic = c(4.1, 3.5, -3.2, -3.8),
+#'   p_value = c(0.001, 0.004, 0.006, 0.002),
+#'   q_value = c(0.004, 0.008, 0.010, 0.006),
+#'   significant = TRUE,
+#'   method = "regions"
+#' )
+#' spatial@tools$CSIDE <- list(
+#'   result_table = cside_result,
+#'   parameters = list(mode = "regions", group.by = "region")
 #' )
 #'
-#' spatial$region <- ifelse(spatial$col > stats::median(spatial$col), "right", "left")
-#' spatial <- RunCSIDE(
+#' SpatialSpotPlot(
 #'   spatial,
-#'   group.by = "region",
-#'   celltypes = c("alpha", "beta"),
-#'   gene_threshold = 0.00005,
-#'   cell_type_threshold = 125
+#'   group.by = "CSIDE_n_sig",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' SpatialSpotPlot(
+#'   spatial,
+#'   features = cside_result$feature[1:2],
+#'   assay = "Spatial",
+#'   layer = "counts",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
 #' )
 #'
-#' head(spatial@tools$CSIDE$result_table)
-#' SpatialSpotPlot(spatial, group.by = "CSIDE_n_sig")
-#'
-#' cside_genes <- head(spatial@tools$CSIDE$result_table$feature, 2)
-#' SpatialSpotPlot(spatial, features = cside_genes, assay = "Spatial")
+#' if (
+#'   requireNamespace("spacexr", quietly = TRUE) &&
+#'     !is.null(spatial@tools$RCTD) &&
+#'     inherits(spatial@tools$RCTD$object, "RCTD") &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#'   spatial <- RunCSIDE(
+#'     spatial,
+#'     group.by = "region",
+#'     celltypes = c("Ductal", "Endocrine"),
+#'     gene_threshold = 0.00005,
+#'     cell_type_threshold = 125
+#'   )
 #' }
 RunCSIDE <- function(
   srt,

--- a/R/RunGiottoCluster.R
+++ b/R/RunGiottoCluster.R
@@ -32,20 +32,44 @@
 #' cluster assignments, Giotto metadata, parameters, features, and cells.
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- Seurat::NormalizeData(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   assay = "Spatial",
-#'   verbose = FALSE
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
+#' giotto_clusters <- list(
+#'   clusters = data.frame(
+#'     cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) %% 3 + 1),
+#'     row.names = colnames(spatial)
+#'   ),
+#'   parameters = list(
+#'     cluster_colname = "Giotto_cluster",
+#'     coord.cols = c("x", "y"),
+#'     k = 8,
+#'     resolution = 0.4
+#'   )
+#' )
+#' class(giotto_clusters) <- c("giotto2_cluster", "giotto2_result", "list")
+#' head(giotto_clusters$clusters)
+#' GiottoPlot(
+#'   giotto_clusters,
+#'   srt = spatial,
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' spatial <- Seurat::FindVariableFeatures(
 #'   spatial,
 #'   assay = "Spatial",
-#'   nfeatures = 500,
+#'   nfeatures = 300,
 #'   verbose = FALSE
 #' )
-#'
 #' giotto_clusters <- RunGiottoCluster(
 #'   spatial,
 #'   assay = "Spatial",
@@ -53,16 +77,10 @@
 #'   dims = 1:10,
 #'   k = 8,
 #'   resolution = 0.4,
-#'   coord.cols = c("col", "row")
+#'   coord.cols = c("x", "y")
 #' )
 #'
 #' head(giotto_clusters$clusters)
-#' GiottoPlot(
-#'   giotto_clusters,
-#'   srt = spatial,
-#'   overlay_image = FALSE,
-#'   coord.cols = c("col", "row")
-#' )
 #' }
 #'
 #' @export

--- a/R/RunGiottoSpatialMethods.R
+++ b/R/RunGiottoSpatialMethods.R
@@ -23,31 +23,45 @@
 #' enrichment table, raw Giotto result, parameters, features, and cells.
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- Seurat::NormalizeData(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   assay = "Spatial",
-#'   verbose = FALSE
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
 #' spatial$region <- ifelse(
-#'   spatial$col > stats::median(spatial$col),
+#'   spatial$x > stats::median(spatial$x),
 #'   "right",
 #'   "left"
 #' )
+#' proximity <- list(
+#'   enrichment = data.frame(
+#'     group_1 = c("left", "left", "right", "right"),
+#'     group_2 = c("left", "right", "left", "right"),
+#'     enrichment = c(1.1, -0.7, -0.5, 1.3),
+#'     type_int = c("enriched", "depleted", "depleted", "enriched")
+#'   ),
+#'   parameters = list(network_method = "Delaunay", number_of_simulations = 100)
+#' )
+#' class(proximity) <- c("giotto2_cell_proximity", "giotto2_result", "list")
 #'
+#' head(proximity$enrichment)
+#' GiottoPlot(proximity)
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' proximity <- RunGiottoCellProximity(
 #'   spatial,
 #'   group.by = "region",
 #'   assay = "Spatial",
 #'   layer = "data",
-#'   coord.cols = c("col", "row"),
+#'   coord.cols = c("x", "y"),
 #'   network_method = "Delaunay",
 #'   number_of_simulations = 100
 #' )
-#'
-#' head(proximity$enrichment)
-#' GiottoPlot(proximity)
 #' }
 #'
 #' @export
@@ -198,37 +212,50 @@ RunGiottoCellProximity <- function(
 #' and cells.
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- Seurat::NormalizeData(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   assay = "Spatial",
-#'   verbose = FALSE
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
-#' spatial <- Seurat::FindVariableFeatures(
-#'   spatial,
-#'   assay = "Spatial",
-#'   nfeatures = 500,
-#'   verbose = FALSE
+#' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
+#' giotto_genes <- list(
+#'   results = data.frame(
+#'     feat_ID = rownames(spatial)[1:6],
+#'     spatGeneRank = c(40, 35, 28, 20, 16, 10)
+#'   ),
+#'   top_features = rownames(spatial)[1:4],
+#'   parameters = list(assay = "Spatial", layer = "data", coord.cols = c("x", "y"))
 #' )
-#'
-#' giotto_genes <- RunGiottoSpatialGenes(
-#'   spatial,
-#'   assay = "Spatial",
-#'   layer = "data",
-#'   features = Seurat::VariableFeatures(spatial, assay = "Spatial"),
-#'   coord.cols = c("col", "row"),
-#'   top_n = 50
-#' )
+#' class(giotto_genes) <- c("giotto2_spatial_genes", "giotto2_result", "list")
 #'
 #' head(giotto_genes$results)
-#' GiottoPlot(giotto_genes, plot_type = "ranking", top_n = 10)
+#' GiottoPlot(giotto_genes, plot_type = "ranking", top_n = 6)
 #' GiottoPlot(
 #'   giotto_genes,
 #'   srt = spatial,
 #'   plot_type = "feature",
 #'   overlay_image = FALSE,
-#'   coord.cols = c("col", "row")
+#'   coord.cols = c("x", "y")
+#' )
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' spatial <- Seurat::FindVariableFeatures(
+#'   spatial,
+#'   assay = "Spatial",
+#'   nfeatures = 300,
+#'   verbose = FALSE
+#' )
+#' giotto_genes <- RunGiottoSpatialGenes(
+#'   spatial,
+#'   assay = "Spatial",
+#'   layer = "data",
+#'   features = Seurat::VariableFeatures(spatial, assay = "Spatial"),
+#'   coord.cols = c("x", "y"),
+#'   top_n = 50
 #' )
 #' }
 #'
@@ -390,32 +417,53 @@ RunGiottoSpatialGenes <- function(
 #' parameters, features, and cells.
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- Seurat::NormalizeData(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   assay = "Spatial",
-#'   verbose = FALSE
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
+#' module_features <- rownames(spatial)[1:4]
+#' module_cor <- expand.grid(
+#'   feat_ID = module_features,
+#'   variable = module_features
+#' )
+#' module_cor$spat_cor <- c(
+#'   1, 0.4, 0.1, -0.2,
+#'   0.4, 1, 0.3, 0.0,
+#'   0.1, 0.3, 1, 0.5,
+#'   -0.2, 0.0, 0.5, 1
+#' )
+#' giotto_modules <- list(
+#'   module_tables = list(result.cor_DT = module_cor),
+#'   features = module_features,
+#'   parameters = list(assay = "Spatial", layer = "data")
+#' )
+#' class(giotto_modules) <- c("giotto2_spatial_modules", "giotto2_result", "list")
+#'
+#' names(giotto_modules$module_tables)
+#' GiottoPlot(giotto_modules, top_n = 4)
+#'
+#' if (
+#'   requireNamespace("Giotto", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' spatial <- Seurat::FindVariableFeatures(
 #'   spatial,
 #'   assay = "Spatial",
-#'   nfeatures = 500,
+#'   nfeatures = 300,
 #'   verbose = FALSE
 #' )
-#'
 #' giotto_modules <- RunGiottoSpatialModules(
 #'   spatial,
 #'   assay = "Spatial",
 #'   layer = "data",
 #'   features = Seurat::VariableFeatures(spatial, assay = "Spatial")[1:50],
-#'   coord.cols = c("col", "row"),
+#'   coord.cols = c("x", "y"),
 #'   cor_method = "pearson",
 #'   k = 6
 #' )
-#'
-#' names(giotto_modules$module_tables)
-#' GiottoPlot(giotto_modules, top_n = 12)
 #' }
 #'
 #' @export

--- a/R/RunMERINGUE.R
+++ b/R/RunMERINGUE.R
@@ -25,25 +25,42 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- Seurat::NormalizeData(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   assay = "Spatial",
-#'   verbose = FALSE
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
-#'
-#' spatial <- RunMERINGUE(
-#'   spatial,
-#'   assay = "Spatial",
-#'   mode = c("autocorrelation", "cross_correlation"),
-#'   nfeatures = 50
+#' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
+#' spatial@misc[["MERINGUEFeatures"]] <- rownames(spatial)[1:4]
+#' spatial@tools[["MERINGUE"]] <- list(
+#'   autocorrelation = data.frame(
+#'     feature = rownames(spatial)[1:4],
+#'     statistic = c(0.42, 0.35, 0.28, 0.22),
+#'     p_value = c(0.001, 0.004, 0.010, 0.020),
+#'     q_value = c(0.004, 0.008, 0.015, 0.030)
+#'   )
 #' )
 #'
 #' head(spatial@tools[["MERINGUE"]]$autocorrelation)
 #' SpatialSpotPlot(
 #'   spatial,
-#'   features = spatial@misc[["MERINGUEFeatures"]][1:2]
+#'   features = spatial@misc[["MERINGUEFeatures"]][1:2],
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#'
+#' if (
+#'   requireNamespace("MERINGUE", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' spatial <- RunMERINGUE(
+#'   spatial,
+#'   assay = "Spatial",
+#'   coord.cols = c("x", "y"),
+#'   mode = c("autocorrelation", "cross_correlation"),
+#'   nfeatures = 50,
+#'   verbose = FALSE
 #' )
 #' }
 RunMERINGUE <- function(

--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -41,62 +41,79 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
-#' library(scop)
-#'
 #' data(visium_human_pancreas_sub)
-#' data(panc8_sub)
-#'
-#' drop_celltypes <- c(
-#'   "epsilon",
-#'   "macrophage",
-#'   "mast",
-#'   "quiescent-stellate",
-#'   "schwann"
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
-#'
-#' panc8_rctd <- subset(
-#'   panc8_sub,
-#'   subset = !celltype %in% drop_celltypes
+#' rctd_weights <- data.frame(
+#'   RCTD_prop_Ductal = seq(0.75, 0.15, length.out = ncol(spatial)),
+#'   RCTD_prop_Endocrine = seq(0.15, 0.65, length.out = ncol(spatial)),
+#'   RCTD_prop_Stromal = 0.10,
+#'   row.names = colnames(spatial)
 #' )
+#' rctd_weights <- rctd_weights / rowSums(rctd_weights)
+#' spatial <- Seurat::AddMetaData(spatial, rctd_weights)
+#' spatial$RCTD_dominant_type <- sub(
+#'   "^RCTD_prop_",
+#'   "",
+#'   colnames(rctd_weights)[max.col(rctd_weights)]
+#' )
+#' spatial$RCTD_max_prop <- apply(rctd_weights, 1, max)
 #'
-#' table(panc8_sub$celltype)
-#' table(panc8_rctd$celltype)
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "RCTD_dominant_type",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' if (requireNamespace("scatterpie", quietly = TRUE)) {
+#'   SpatialSpotPlot(
+#'     spatial,
+#'     group.by = "RCTD_dominant_type",
+#'     plot_type = "pie",
+#'     overlay_image = FALSE,
+#'     coord.cols = c("x", "y")
+#'   )
+#' }
+#'
+#' if (
+#'   requireNamespace("spacexr", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' data(pancreas_sub)
+#' features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
 #'
 #' spatial <- RunRCTD(
-#'   srt = visium_human_pancreas_sub,
-#'   reference = panc8_rctd,
-#'   reference_label = "celltype",
+#'   srt = spatial,
+#'   reference = pancreas_sub,
+#'   reference_label = "CellType",
 #'   assay = "Spatial",
 #'   reference_assay = "RNA",
 #'   layer = "counts",
 #'   reference_layer = "counts",
+#'   features = features_use,
 #'   rctd_mode = "full",
 #'   max_cores = 1,
+#'   min_cells = 5,
 #'   prefix = "RCTD"
 #' )
 #'
 #' rctd_cols <- grep("^RCTD_prop_", colnames(spatial@meta.data), value = TRUE)
-#' head(spatial@meta.data[, c("RCTD_dominant_type", "RCTD_max_prop", rctd_cols[1:3])])
-#'
 #' SpatialSpotPlot(
 #'   spatial,
 #'   group.by = "RCTD_dominant_type",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y"),
 #'   theme_use = "theme_scop"
 #' )
-#'
 #' SpatialSpotPlot(
 #'   spatial,
-#'   group.by = rctd_cols[1:min(4, length(rctd_cols))],
+#'   group.by = rctd_cols[1:min(3, length(rctd_cols))],
 #'   palette = "Spectral",
-#'   theme_use = "theme_scop"
-#' )
-#'
-#' SpatialSpotPlot(
-#'   spatial,
-#'   group.by = "RCTD_dominant_type",
-#'   plot_type = "pie",
-#'   pie.radius.scale = 0.45,
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y"),
 #'   theme_use = "theme_scop"
 #' )
 #' }

--- a/R/RunSPOTlight.R
+++ b/R/RunSPOTlight.R
@@ -26,31 +26,70 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' data(panc8_sub)
-#'
-#' spatial <- RunSPOTlight(
-#'   srt = visium_human_pancreas_sub,
-#'   reference = panc8_sub,
-#'   reference_label = "celltype",
-#'   assay = "Spatial",
-#'   reference_assay = "RNA"
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
+#' spotlight_weights <- data.frame(
+#'   SPOTlight_prop_Ductal = seq(0.70, 0.20, length.out = ncol(spatial)),
+#'   SPOTlight_prop_Endocrine = seq(0.20, 0.70, length.out = ncol(spatial)),
+#'   SPOTlight_prop_Immune = 0.10,
+#'   row.names = colnames(spatial)
+#' )
+#' spotlight_weights <- spotlight_weights / rowSums(spotlight_weights)
+#' spatial <- Seurat::AddMetaData(spatial, spotlight_weights)
+#' spatial$SPOTlight_dominant_type <- sub(
+#'   "^SPOTlight_prop_",
+#'   "",
+#'   colnames(spotlight_weights)[max.col(spotlight_weights)]
+#' )
+#' spatial$SPOTlight_max_prop <- apply(spotlight_weights, 1, max)
 #'
-#' SpatialSpotPlot(spatial, group.by = "SPOTlight_dominant_type")
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "SPOTlight_dominant_type",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' if (requireNamespace("scatterpie", quietly = TRUE)) {
+#'   SpatialSpotPlot(
+#'     spatial,
+#'     group.by = "SPOTlight_dominant_type",
+#'     plot_type = "pie",
+#'     overlay_image = FALSE,
+#'     coord.cols = c("x", "y")
+#'   )
+#' }
+#'
+#' if (
+#'   requireNamespace("SPOTlight", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' data(pancreas_sub)
+#' features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
+#' spatial <- RunSPOTlight(
+#'   srt = spatial,
+#'   reference = pancreas_sub,
+#'   reference_label = "CellType",
+#'   assay = "Spatial",
+#'   reference_assay = "RNA",
+#'   features = features_use,
+#'   marker_top_n = 20,
+#'   verbose = FALSE
+#' )
 #'
 #' spotlight_cols <- grep(
 #'   "^SPOTlight_prop_",
 #'   colnames(spatial@meta.data),
 #'   value = TRUE
 #' )
-#' SpatialSpotPlot(spatial, group.by = spotlight_cols[1:4])
-#'
 #' SpatialSpotPlot(
 #'   spatial,
-#'   group.by = "SPOTlight_dominant_type",
-#'   plot_type = "pie"
+#'   group.by = spotlight_cols[1:min(3, length(spotlight_cols))],
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
 #' )
 #' }
 RunSPOTlight <- function(

--- a/R/RunSTdeconvolve.R
+++ b/R/RunSTdeconvolve.R
@@ -29,15 +29,59 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- RunSTdeconvolve(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   assay = "Spatial",
-#'   k = 5
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
-#' SpatialSpotPlot(spatial, group.by = "STdeconvolve_dominant_type")
-#' STdeconvolvePlot(spatial, plot_type = "pie")
+#' topic_weights <- data.frame(
+#'   STdeconvolve_prop_topic_1 = seq(0.75, 0.20, length.out = ncol(spatial)),
+#'   STdeconvolve_prop_topic_2 = seq(0.20, 0.70, length.out = ncol(spatial)),
+#'   STdeconvolve_prop_topic_3 = 0.10,
+#'   row.names = colnames(spatial)
+#' )
+#' topic_weights <- topic_weights / rowSums(topic_weights)
+#' spatial <- Seurat::AddMetaData(spatial, topic_weights)
+#' spatial$STdeconvolve_dominant_type <- sub(
+#'   "^STdeconvolve_prop_",
+#'   "",
+#'   colnames(topic_weights)[max.col(topic_weights)]
+#' )
+#' spatial$STdeconvolve_max_prop <- apply(topic_weights, 1, max)
+#'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "STdeconvolve_dominant_type",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' STdeconvolvePlot(
+#'   spatial,
+#'   topics = 1:2,
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' if (requireNamespace("scatterpie", quietly = TRUE)) {
+#'   STdeconvolvePlot(
+#'     spatial,
+#'     plot_type = "pie",
+#'     overlay_image = FALSE,
+#'     coord.cols = c("x", "y")
+#'   )
+#' }
+#'
+#' if (
+#'   requireNamespace("STdeconvolve", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' spatial <- RunSTdeconvolve(
+#'   spatial,
+#'   assay = "Spatial",
+#'   features = rownames(spatial)[1:300],
+#'   k = 3,
+#'   verbose = FALSE
+#' )
 #' }
 RunSTdeconvolve <- function(
   srt,
@@ -183,6 +227,42 @@ RunSTdeconvolve <- function(
 #'
 #' @return A `ggplot`, `patchwork`, or list of `ggplot` objects.
 #' @export
+#'
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' topic_weights <- data.frame(
+#'   STdeconvolve_prop_topic_1 = seq(0.75, 0.20, length.out = ncol(spatial)),
+#'   STdeconvolve_prop_topic_2 = seq(0.20, 0.70, length.out = ncol(spatial)),
+#'   STdeconvolve_prop_topic_3 = 0.10,
+#'   row.names = colnames(spatial)
+#' )
+#' topic_weights <- topic_weights / rowSums(topic_weights)
+#' spatial <- Seurat::AddMetaData(spatial, topic_weights)
+#' spatial$STdeconvolve_dominant_type <- sub(
+#'   "^STdeconvolve_prop_",
+#'   "",
+#'   colnames(topic_weights)[max.col(topic_weights)]
+#' )
+#'
+#' STdeconvolvePlot(
+#'   spatial,
+#'   topics = 1:2,
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' if (requireNamespace("scatterpie", quietly = TRUE)) {
+#'   STdeconvolvePlot(
+#'     spatial,
+#'     plot_type = "pie",
+#'     overlay_image = FALSE,
+#'     coord.cols = c("x", "y")
+#'   )
+#' }
 STdeconvolvePlot <- function(
   srt,
   topics = NULL,

--- a/R/RunSemla.R
+++ b/R/RunSemla.R
@@ -22,17 +22,38 @@
 #' @return A `Seurat` object.
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#'
-#' spatial <- RunSemlaSpatialNetwork(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   nNeighbors = 6,
-#'   coords = "array"
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' spatial@tools$SemlaSpatialNetwork <- list(
+#'   network = data.frame(
+#'     from = colnames(spatial)[1:6],
+#'     to = colnames(spatial)[2:7],
+#'     distance = sqrt(diff(spatial$x[1:7])^2 + diff(spatial$y[1:7])^2)
+#'   )
 #' )
 #'
 #' head(spatial@tools$SemlaSpatialNetwork$network)
-#' SpatialSpotPlot(spatial, group.by = "orig.ident")
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "coda_label",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#'
+#' if (
+#'   requireNamespace("semla", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' spatial <- RunSemlaSpatialNetwork(
+#'   spatial,
+#'   nNeighbors = 6,
+#'   coords = "pixels",
+#'   verbose = FALSE
+#' )
 #' }
 #' @export
 RunSemlaSpatialNetwork <- function(
@@ -107,24 +128,33 @@ RunSemlaSpatialNetwork <- function(
 #' @return A `Seurat` object.
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- Seurat::NormalizeData(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   assay = "Spatial",
-#'   verbose = FALSE
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
+#' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' features <- rownames(spatial)[1:3]
+#' spatial[[paste0(features[1], "_localG")]] <- as.numeric(scale(spatial$x))
 #'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = paste0(features[1], "_localG"),
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#'
+#' if (
+#'   requireNamespace("semla", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
 #' spatial <- RunSemlaLocalG(
 #'   spatial,
 #'   features = features,
-#'   store_in_metadata = TRUE
+#'   store_in_metadata = TRUE,
+#'   verbose = FALSE
 #' )
-#'
-#' local_g_cols <- grep(features[1], colnames(spatial[[]]), value = TRUE)
-#' head(spatial[[]][local_g_cols])
-#' SpatialSpotPlot(spatial, group.by = local_g_cols[1])
 #' }
 #' @export
 RunSemlaLocalG <- function(
@@ -173,25 +203,39 @@ RunSemlaLocalG <- function(
 #' @return A `Seurat` object.
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- visium_human_pancreas_sub
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
 #' spatial$region <- ifelse(
-#'   spatial$col > stats::median(spatial$col),
+#'   spatial$x > stats::median(spatial$x),
 #'   "right",
 #'   "left"
 #' )
+#' spatial$right_border <- spatial$region == "right" &
+#'   abs(spatial$x - stats::median(spatial$x)) < stats::sd(spatial$x) * 0.25
 #'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = c("region", "right_border"),
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#'
+#' if (
+#'   requireNamespace("semla", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
 #' spatial <- RunSemlaRegionNeighbors(
 #'   spatial,
 #'   column_name = "region",
 #'   column_labels = "right",
 #'   mode = "outer",
-#'   column_key = "right_border"
+#'   column_key = "right_border",
+#'   verbose = FALSE
 #' )
-#'
-#' grep("right_border", colnames(spatial[[]]), value = TRUE)
-#' SpatialSpotPlot(spatial, group.by = "region")
 #' }
 #' @export
 RunSemlaRegionNeighbors <- function(
@@ -240,25 +284,43 @@ RunSemlaRegionNeighbors <- function(
 #' @return A `Seurat` object.
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- visium_human_pancreas_sub
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
 #' spatial$region <- ifelse(
-#'   spatial$row > stats::median(spatial$row),
+#'   spatial$y > stats::median(spatial$y),
 #'   "upper",
 #'   "lower"
 #' )
+#' upper_center <- c(
+#'   stats::median(spatial$x[spatial$region == "upper"]),
+#'   stats::median(spatial$y[spatial$region == "upper"])
+#' )
+#' spatial$upper_distance <- sqrt(
+#'   (spatial$x - upper_center[1])^2 + (spatial$y - upper_center[2])^2
+#' )
 #'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "upper_distance",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#'
+#' if (
+#'   requireNamespace("semla", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
 #' spatial <- RunSemlaRadialDistance(
 #'   spatial,
 #'   column_name = "region",
 #'   selected_groups = "upper",
-#'   column_suffix = "upper_distance"
+#'   column_suffix = "upper_distance",
+#'   verbose = FALSE
 #' )
-#'
-#' distance_cols <- grep("upper_distance", colnames(spatial[[]]), value = TRUE)
-#' head(spatial[[]][distance_cols])
-#' SpatialSpotPlot(spatial, group.by = distance_cols[1])
 #' }
 #' @export
 RunSemlaRadialDistance <- function(

--- a/R/RunSmoothClust.R
+++ b/R/RunSmoothClust.R
@@ -43,13 +43,28 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#' spatial <- Seurat::NormalizeData(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   assay = "Spatial",
-#'   verbose = FALSE
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
 #' )
+#' spatial$SmoothClust_cluster <- factor(
+#'   paste0("SmoothClust", (seq_len(ncol(spatial)) - 1) %% 3 + 1)
+#' )
+#'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "SmoothClust_cluster",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#'
+#' if (
+#'   requireNamespace("smoothclust", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' spatial <- Seurat::FindVariableFeatures(
 #'   spatial,
 #'   assay = "Spatial",
@@ -62,11 +77,12 @@
 #'   assay = "Spatial",
 #'   n_clusters = 3,
 #'   smooth_method = "knn",
-#'   k = 6
+#'   coord.cols = c("x", "y"),
+#'   k = 6,
+#'   verbose = FALSE
 #' )
 #'
 #' table(spatial$SmoothClust_cluster)
-#' SpatialSpotPlot(spatial, group.by = "SmoothClust_cluster")
 #' }
 RunSmoothClust <- function(
   srt,

--- a/R/RunSpaNorm.R
+++ b/R/RunSpaNorm.R
@@ -20,24 +20,47 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#'
-#' spatial <- RunSpaNorm(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   assay = "Spatial",
-#'   layer = "counts",
-#'   coord.cols = c("col", "row"),
-#'   new_assay = "SpaNorm",
-#'   sample.p = 0.25
+#'   cells = colnames(visium_human_pancreas_sub)[1:80],
+#'   features = rownames(visium_human_pancreas_sub)[1:300]
 #' )
+#' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #'
 #' SpatialSpotPlot(
 #'   spatial,
-#'   features = rownames(spatial[["SpaNorm"]])[1:2],
-#'   assay = "SpaNorm",
-#'   layer = "data"
+#'   features = rownames(spatial)[1:2],
+#'   assay = "Spatial",
+#'   layer = "data",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
 #' )
+#'
+#' if (
+#'   requireNamespace("SpaNorm", quietly = TRUE) &&
+#'     requireNamespace("SpatialExperiment", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#'   spatial <- RunSpaNorm(
+#'     spatial,
+#'     assay = "Spatial",
+#'     layer = "counts",
+#'     coord.cols = c("x", "y"),
+#'     new_assay = "SpaNorm",
+#'     store_spe = FALSE,
+#'     sample.p = 0.25,
+#'     verbose = FALSE
+#'   )
+#'
+#'   SpatialSpotPlot(
+#'     spatial,
+#'     features = rownames(spatial[["SpaNorm"]])[1:2],
+#'     assay = "SpaNorm",
+#'     layer = "data",
+#'     overlay_image = FALSE,
+#'     coord.cols = c("x", "y")
+#'   )
 #' }
 RunSpaNorm <- function(
   srt,

--- a/R/RunSpatialEcoTyper.R
+++ b/R/RunSpatialEcoTyper.R
@@ -83,12 +83,40 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' srt <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' srt$CellType <- srt$coda_label
+#' srt$SpatialEcoTyper_SE <- ifelse(srt$x > stats::median(srt$x), "SE1", "SE2")
+#' srt$sample <- ifelse(srt$y > stats::median(srt$y), "slice_a", "slice_b")
+#'
+#' SpatialEcoTyperSpatialPlot(
+#'   srt,
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' SpatialEcoTyperCompositionPlot(
+#'   srt,
+#'   group.by = "CellType",
+#'   sample.by = "sample",
+#'   position = "fill"
+#' )
+#'
+#' if (
+#'   requireNamespace("SpatialEcoTyper", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
 #' srt <- RunSpatialEcoTyper(
 #'   srt,
 #'   celltype.by = "CellType",
-#'   x.by = "X",
-#'   y.by = "Y"
+#'   x.by = "x",
+#'   y.by = "y",
+#'   nfeatures = 100,
+#'   ncores = 1,
+#'   verbose = FALSE
 #' )
 #'
 #' srt <- RunSpatialEcoTyper(
@@ -96,8 +124,11 @@
 #'   mode = "multi",
 #'   celltype.by = "CellType",
 #'   sample.by = "sample",
-#'   x.by = "X",
-#'   y.by = "Y"
+#'   x.by = "x",
+#'   y.by = "y",
+#'   nfeatures = 100,
+#'   ncores = 1,
+#'   verbose = FALSE
 #' )
 #' }
 RunSpatialEcoTyper <- function(

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -57,16 +57,40 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
 #' spatial <- RunSpatialGradientFeatures(
 #'   spatial,
-#'   reference = "annotation",
-#'   annotation.by = "BayesSpace_cluster",
-#'   annotation.groups = "1",
-#'   variables = spatial@misc[["SpatialVariableFeatures"]]
+#'   reference = "trajectory",
+#'   backend = "cpp",
+#'   result_name = "ductal_axis",
+#'   variables = rownames(spatial)[1:8],
+#'   start = c(min(spatial$x), min(spatial$y)),
+#'   end = c(max(spatial$x), max(spatial$y)),
+#'   layer = "counts",
+#'   coord.cols = c("x", "y"),
+#'   n_random = 0,
+#'   n_bins = 5,
+#'   min_spots = 3,
+#'   sign_threshold = 1,
+#'   nfeatures = 4,
+#'   verbose = FALSE
 #' )
-#' SpatialGradientPlot(spatial, plot_type = "combined")
-#' }
+#'
+#' SpatialGradientPlot(spatial, plot_type = "summary", nfeatures = 4)
+#' SpatialGradientPlot(spatial, plot_type = "line", nfeatures = 2)
+#' SpatialGradientPlot(spatial, plot_type = "model", nfeatures = 2)
+#' SpatialGradientPlot(
+#'   spatial,
+#'   plot_type = "surface",
+#'   nfeatures = 2,
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
 RunSpatialGradientFeatures <- function(
   srt,
   reference = c("trajectory", "annotation"),

--- a/R/RunSpatialIntegration.R
+++ b/R/RunSpatialIntegration.R
@@ -25,17 +25,73 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' spatial$sample <- ifelse(spatial$y > stats::median(spatial$y), "slice_a", "slice_b")
+#' spatial$SpatialIntegration_PRECAST_domain <- factor(
+#'   paste0("domain_", (seq_len(ncol(spatial)) - 1) %% 3 + 1)
+#' )
+#' embedding <- cbind(
+#'   SI_1 = as.numeric(scale(spatial$x)),
+#'   SI_2 = as.numeric(scale(spatial$y))
+#' )
+#' rownames(embedding) <- colnames(spatial)
+#' spatial[["SpatialIntegration_PRECAST"]] <- SeuratObject::CreateDimReducObject(
+#'   embeddings = embedding,
+#'   key = "SI_",
+#'   assay = "Spatial"
+#' )
+#' spatial$SpatialIntegration_PRECAST_aligned_x <- spatial$x +
+#'   ifelse(spatial$sample == "slice_b", -stats::median(spatial$x), 0)
+#' spatial$SpatialIntegration_PRECAST_aligned_y <- spatial$y
+#' integration_parameters <- list(
+#'   method = "PRECAST",
+#'   sample.by = "sample",
+#'   assay = "Spatial",
+#'   layer = "counts",
+#'   coord.cols = c("x", "y"),
+#'   reduction.name = "SpatialIntegration_PRECAST",
+#'   cluster_colname = "SpatialIntegration_PRECAST_domain",
+#'   aligned_coord_cols = c(
+#'     "SpatialIntegration_PRECAST_aligned_x",
+#'     "SpatialIntegration_PRECAST_aligned_y"
+#'   )
+#' )
+#' spatial@tools$SpatialIntegration <- list(
+#'   active_method = "PRECAST",
+#'   methods = list(PRECAST = list(parameters = integration_parameters)),
+#'   parameters = integration_parameters,
+#'   samples = unique(spatial$sample),
+#'   cells = colnames(spatial)
+#' )
+#'
+#' SpatialIntegrationPlot(
+#'   spatial,
+#'   plot_type = "spatial",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' SpatialIntegrationPlot(spatial, plot_type = "embedding")
+#' SpatialIntegrationPlot(spatial, plot_type = "alignment")
+#' SpatialIntegrationPlot(spatial, plot_type = "composition")
+#'
+#' if (
+#'   requireNamespace("PRECAST", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
 #' srt <- RunSpatialIntegration(
 #'   object = spatial,
 #'   method = "PRECAST",
 #'   sample.by = "sample",
 #'   assay = "Spatial",
-#'   coord.cols = c("col", "row")
+#'   coord.cols = c("x", "y"),
+#'   features = rownames(spatial)[1:300],
+#'   verbose = FALSE
 #' )
-#'
-#' SpatialIntegrationPlot(srt, plot_type = "spatial")
-#' SpatialIntegrationPlot(srt, plot_type = "embedding")
 #' }
 RunSpatialIntegration <- function(
   object,
@@ -138,6 +194,61 @@ RunSpatialIntegration <- function(
 #'
 #' @return A `ggplot`, patchwork object, or list of plots.
 #' @export
+#'
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' spatial$sample <- ifelse(spatial$y > stats::median(spatial$y), "slice_a", "slice_b")
+#' spatial$SpatialIntegration_PRECAST_domain <- factor(
+#'   paste0("domain_", (seq_len(ncol(spatial)) - 1) %% 3 + 1)
+#' )
+#' embedding <- cbind(
+#'   SI_1 = as.numeric(scale(spatial$x)),
+#'   SI_2 = as.numeric(scale(spatial$y))
+#' )
+#' rownames(embedding) <- colnames(spatial)
+#' spatial[["SpatialIntegration_PRECAST"]] <- SeuratObject::CreateDimReducObject(
+#'   embeddings = embedding,
+#'   key = "SI_",
+#'   assay = "Spatial"
+#' )
+#' spatial$SpatialIntegration_PRECAST_aligned_x <- spatial$x +
+#'   ifelse(spatial$sample == "slice_b", -stats::median(spatial$x), 0)
+#' spatial$SpatialIntegration_PRECAST_aligned_y <- spatial$y
+#' integration_parameters <- list(
+#'   method = "PRECAST",
+#'   sample.by = "sample",
+#'   assay = "Spatial",
+#'   layer = "counts",
+#'   coord.cols = c("x", "y"),
+#'   reduction.name = "SpatialIntegration_PRECAST",
+#'   cluster_colname = "SpatialIntegration_PRECAST_domain",
+#'   aligned_coord_cols = c(
+#'     "SpatialIntegration_PRECAST_aligned_x",
+#'     "SpatialIntegration_PRECAST_aligned_y"
+#'   )
+#' )
+#' spatial@tools$SpatialIntegration <- list(
+#'   active_method = "PRECAST",
+#'   methods = list(PRECAST = list(parameters = integration_parameters)),
+#'   parameters = integration_parameters,
+#'   samples = unique(spatial$sample),
+#'   cells = colnames(spatial)
+#' )
+#'
+#' SpatialIntegrationPlot(
+#'   spatial,
+#'   plot_type = "spatial",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' SpatialIntegrationPlot(spatial, plot_type = "embedding")
+#' SpatialIntegrationPlot(spatial, plot_type = "alignment")
+#' SpatialIntegrationPlot(spatial, plot_type = "composition")
 SpatialIntegrationPlot <- function(
   srt,
   method = NULL,

--- a/R/RunSpatialNeighborhood.R
+++ b/R/RunSpatialNeighborhood.R
@@ -34,6 +34,31 @@
 #'
 #' @return A `Seurat` object with results stored in `srt@tools[[tool_name]]`.
 #' @export
+#'
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' spatial <- RunSpatialNeighborhood(
+#'   spatial,
+#'   group.by = "coda_label",
+#'   coord.cols = c("x", "y"),
+#'   k = 4,
+#'   verbose = FALSE
+#' )
+#'
+#' SpatialNeighborhoodPlot(spatial, plot_type = "heatmap")
+#' SpatialNeighborhoodPlot(spatial, plot_type = "network", top_n = 12)
+#' SpatialNeighborhoodPlot(spatial, plot_type = "stat", top_n = 12)
+#' SpatialNeighborhoodPlot(
+#'   spatial,
+#'   plot_type = "spatial",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
 RunSpatialNeighborhood <- function(
   srt,
   group.by,
@@ -200,6 +225,31 @@ RunSpatialNeighborhood <- function(
 #'
 #' @return A `ggplot`, `patchwork`, or list of `ggplot` objects.
 #' @export
+#'
+#' @examples
+#' data(visium_human_pancreas_sub)
+#' spatial <- subset(
+#'   visium_human_pancreas_sub,
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' spatial <- RunSpatialNeighborhood(
+#'   spatial,
+#'   group.by = "coda_label",
+#'   coord.cols = c("x", "y"),
+#'   k = 4,
+#'   verbose = FALSE
+#' )
+#'
+#' SpatialNeighborhoodPlot(spatial, plot_type = "heatmap")
+#' SpatialNeighborhoodPlot(spatial, plot_type = "network", top_n = 12)
+#' SpatialNeighborhoodPlot(spatial, plot_type = "stat", top_n = 12)
+#' SpatialNeighborhoodPlot(
+#'   spatial,
+#'   plot_type = "spatial",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
 SpatialNeighborhoodPlot <- function(
   srt,
   method = NULL,

--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -50,18 +50,51 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' data(visium_human_pancreas_sub)
-#'
-#' spatial <- RunSpotSweeper(
+#' spatial <- subset(
 #'   visium_human_pancreas_sub,
-#'   assay = "Spatial",
-#'   n_neighbors = 18,
-#'   n_order = 2
+#'   cells = colnames(visium_human_pancreas_sub)[1:120],
+#'   features = rownames(visium_human_pancreas_sub)[1:400]
+#' )
+#' spatial$SpotSweeper_QC <- factor(
+#'   ifelse(seq_len(ncol(spatial)) %% 9 == 0, "Fail", "Pass"),
+#'   levels = c("Pass", "Fail")
+#' )
+#' spatial$SpotSweeper_nCount_Spatial_z <- as.numeric(scale(spatial$nCount_Spatial))
+#'
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "SpotSweeper_QC",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
+#' )
+#' SpatialSpotPlot(
+#'   spatial,
+#'   group.by = "SpotSweeper_nCount_Spatial_z",
+#'   overlay_image = FALSE,
+#'   coord.cols = c("x", "y")
 #' )
 #'
-#' SpatialSpotPlot(spatial, group.by = "SpotSweeper_QC")
-#' SpatialSpotPlot(spatial, group.by = "SpotSweeper_nCount_Spatial_z")
+#' if (
+#'   requireNamespace("SpotSweeper", quietly = TRUE) &&
+#'     requireNamespace("SpatialExperiment", quietly = TRUE) &&
+#'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+#' ) {
+#'   spatial <- RunSpotSweeper(
+#'     spatial,
+#'     assay = "Spatial",
+#'     coord.cols = c("x", "y"),
+#'     n_neighbors = 12,
+#'     run_artifact = FALSE,
+#'     verbose = FALSE
+#'   )
+#'
+#'   SpatialSpotPlot(
+#'     spatial,
+#'     group.by = "SpotSweeper_QC",
+#'     overlay_image = FALSE,
+#'     coord.cols = c("x", "y")
+#'   )
 #' }
 RunSpotSweeper <- function(
   srt,

--- a/man/AddGiottoToSeurat.Rd
+++ b/man/AddGiottoToSeurat.Rd
@@ -34,3 +34,40 @@ A Seurat object.
 \description{
 Add Giotto results back to Seurat
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:200]
+)
+g <- structure(
+  list(
+    source = list(cells = colnames(spatial)),
+    results = list(
+      cluster = list(
+        table = data.frame(
+          cell = colnames(spatial),
+          cluster = spatial$coda_label,
+          row.names = colnames(spatial)
+        )
+      )
+    )
+  ),
+  class = c("giotto2", "list")
+)
+spatial <- AddGiottoToSeurat(
+  spatial,
+  g,
+  result = "cluster",
+  name = "Giotto_cluster",
+  store_result = FALSE
+)
+SpatialSpotPlot(
+  spatial,
+  group.by = "Giotto_cluster",
+  plot_type = "point",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+}

--- a/man/GiottoCellProximity.Rd
+++ b/man/GiottoCellProximity.Rd
@@ -41,3 +41,34 @@ A `giotto2` workflow object.
 \description{
 Run Giotto cell proximity enrichment
 }
+\examples{
+proximity <- data.frame(
+  group_1 = c("Ductal", "Ductal", "Endocrine", "Stromal"),
+  group_2 = c("Endocrine", "Stromal", "Stromal", "Ductal"),
+  enrichment = c(1.6, 0.8, 1.3, 0.7),
+  p.adj = c(0.01, 0.08, 0.03, 0.12)
+)
+g <- structure(
+  list(
+    results = list(cell_proximity = list(table = proximity)),
+    parameters = list(network_method = "Delaunay", number_of_simulations = 100)
+  ),
+  class = c("giotto2", "list")
+)
+GiottoPlot(g, plot_type = "cell_proximity")
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+  data(visium_human_pancreas_sub)
+  spatial <- subset(
+    visium_human_pancreas_sub,
+    cells = colnames(visium_human_pancreas_sub)[1:80],
+    features = rownames(visium_human_pancreas_sub)[1:200]
+  )
+  g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+  g <- GiottoSpatialNetwork(g)
+  g <- GiottoCellProximity(g, group.by = "coda_label", number_of_simulations = 100)
+}
+}

--- a/man/GiottoCluster.Rd
+++ b/man/GiottoCluster.Rd
@@ -44,3 +44,44 @@ A `giotto2` workflow object.
 \description{
 Run Giotto nearest-network clustering
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:200]
+)
+coords <- data.frame(
+  cell_ID = colnames(spatial),
+  sdimx = spatial$x,
+  sdimy = spatial$y,
+  row.names = colnames(spatial)
+)
+g <- structure(
+  list(
+    source = list(cells = colnames(spatial), coordinates = coords),
+    results = list(
+      cluster = list(
+        table = data.frame(
+          cell = colnames(spatial),
+          cluster = spatial$coda_label,
+          row.names = colnames(spatial)
+        )
+      )
+    ),
+    parameters = list(k = 8, resolution = 0.4)
+  ),
+  class = c("giotto2", "list")
+)
+GiottoPlot(g, plot_type = "cluster")
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+  g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+  g <- GiottoPreprocess(g)
+  g <- GiottoReduce(g, reduction = "pca", dims = 1:10)
+  g <- GiottoCluster(g, dims = 1:10, k = 8, resolution = 0.4)
+}
+}

--- a/man/GiottoHMRF.Rd
+++ b/man/GiottoHMRF.Rd
@@ -41,3 +41,45 @@ A `giotto2` workflow object.
 \description{
 Run Giotto HMRF spatial domains
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:200]
+)
+coords <- data.frame(
+  cell_ID = colnames(spatial),
+  sdimx = spatial$x,
+  sdimy = spatial$y,
+  row.names = colnames(spatial)
+)
+hmrf_meta <- data.frame(
+  cell_ID = colnames(spatial),
+  scop_HMRF_k4_b10 = paste0("domain_", as.integer(factor(spatial$coda_label)) \%\% 4 + 1),
+  row.names = colnames(spatial)
+)
+g <- structure(
+  list(
+    source = list(cells = colnames(spatial), coordinates = coords),
+    results = list(
+      hmrf = list(
+        table = hmrf_meta["scop_HMRF_k4_b10"],
+        metadata = hmrf_meta
+      )
+    )
+  ),
+  class = c("giotto2", "list")
+)
+GiottoPlot(g, plot_type = "hmrf")
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+  g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+  g <- GiottoPreprocess(g)
+  g <- GiottoSpatialNetwork(g)
+  g <- GiottoHMRF(g, spatial_genes = rownames(spatial)[1:30], k = 4)
+}
+}

--- a/man/GiottoPlot.Rd
+++ b/man/GiottoPlot.Rd
@@ -149,6 +149,32 @@ input \code{Seurat} object, when supplied, is copied internally for plotting and
 is not modified.
 }
 \examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:300]
+)
+cluster_result <- list(
+  clusters = data.frame(
+    cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1),
+    row.names = colnames(spatial)
+  ),
+  parameters = list(
+    cluster_colname = "Giotto_cluster",
+    coord.cols = c("x", "y"),
+    k = 8,
+    resolution = 0.4
+  )
+)
+class(cluster_result) <- c("giotto2_cluster", "giotto2_result", "list")
+GiottoPlot(
+  cluster_result,
+  srt = spatial,
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+
 proximity <- list(
   enrichment = data.frame(
     group_1 = c("Tumor", "Tumor", "Stroma", "Immune"),
@@ -158,7 +184,7 @@ proximity <- list(
   ),
   parameters = list(network_method = "Delaunay", number_of_simulations = 100)
 )
-class(proximity) <- c("giotto2_cell_proximity", "scop_giotto_result")
+class(proximity) <- c("giotto2_cell_proximity", "giotto2_result", "list")
 GiottoPlot(proximity)
 
 spatial_genes <- list(
@@ -169,7 +195,24 @@ spatial_genes <- list(
   top_features = c("COL1A1", "KRT19", "MS4A1"),
   parameters = list(assay = "Spatial", layer = "data")
 )
-class(spatial_genes) <- c("giotto2_spatial_genes", "scop_giotto_result")
+class(spatial_genes) <- c("giotto2_spatial_genes", "giotto2_result", "list")
 GiottoPlot(spatial_genes, plot_type = "ranking", top_n = 4)
+
+modules <- list(
+  module_tables = list(
+    result.cor_DT = expand.grid(
+      feat_ID = c("COL1A1", "KRT19", "MS4A1"),
+      variable = c("COL1A1", "KRT19", "MS4A1")
+    )
+  ),
+  features = c("COL1A1", "KRT19", "MS4A1")
+)
+modules$module_tables$result.cor_DT$spat_cor <- c(
+  1, 0.35, -0.20,
+  0.35, 1, 0.15,
+  -0.20, 0.15, 1
+)
+class(modules) <- c("giotto2_spatial_modules", "giotto2_result", "list")
+GiottoPlot(modules, top_n = 3)
 
 }

--- a/man/GiottoPreprocess.Rd
+++ b/man/GiottoPreprocess.Rd
@@ -35,3 +35,28 @@ A `giotto2` workflow object.
 \description{
 Preprocess an internal Giotto workflow object
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(visium_human_pancreas_sub, cells = colnames(visium_human_pancreas_sub)[1:60])
+g <- structure(
+  list(
+    source = list(
+      cells = colnames(spatial),
+      features = rownames(spatial)[1:100],
+      coordinates = data.frame(cell_ID = colnames(spatial), sdimx = spatial$x, sdimy = spatial$y)
+    ),
+    results = list(),
+    active = NULL
+  ),
+  class = c("giotto2", "list")
+)
+GiottoPlot(g, plot_type = "spatial")
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+g <- SeuratToScopGiotto(spatial, assay = "Spatial", coord.cols = c("x", "y"), verbose = FALSE)
+g <- GiottoPreprocess(g, verbose = FALSE)
+}
+}

--- a/man/GiottoReduce.Rd
+++ b/man/GiottoReduce.Rd
@@ -38,3 +38,44 @@ A `giotto2` workflow object.
 \description{
 Run Giotto dimensional reduction
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:200]
+)
+embedding <- cbind(
+  UMAP_1 = as.numeric(scale(spatial$x)),
+  UMAP_2 = as.numeric(scale(spatial$y))
+)
+rownames(embedding) <- colnames(spatial)
+g <- structure(
+  list(
+    giotto = list(umap = embedding),
+    source = list(cells = colnames(spatial), features = rownames(spatial)),
+    results = list(
+      cluster = list(
+        table = data.frame(
+          cell = colnames(spatial),
+          cluster = spatial$coda_label,
+          row.names = colnames(spatial)
+        )
+      )
+    ),
+    parameters = list(umap_name = "umap")
+  ),
+  class = c("giotto2", "list")
+)
+GiottoPlot(g, plot_type = "dim")
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+  g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+  g <- GiottoPreprocess(g)
+  g <- GiottoReduce(g, reduction = "pca", dims = 1:10)
+  g <- GiottoReduce(g, reduction = "umap", dims = 1:10)
+}
+}

--- a/man/GiottoSpatialGenes.Rd
+++ b/man/GiottoSpatialGenes.Rd
@@ -41,3 +41,45 @@ A `giotto2` workflow object.
 \description{
 Run Giotto spatial gene detection
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:200]
+)
+coords <- data.frame(
+  cell_ID = colnames(spatial),
+  sdimx = spatial$x,
+  sdimy = spatial$y,
+  row.names = colnames(spatial)
+)
+spatial_gene_table <- data.frame(
+  feat_ID = rownames(spatial)[1:8],
+  spatGeneRank = seq_len(8),
+  adj.p.value = seq(0.001, 0.04, length.out = 8)
+)
+g <- structure(
+  list(
+    source = list(cells = colnames(spatial), coordinates = coords),
+    results = list(
+      spatial_genes = list(
+        table = spatial_gene_table,
+        top_features = spatial_gene_table$feat_ID
+      )
+    )
+  ),
+  class = c("giotto2", "list")
+)
+GiottoPlot(g, plot_type = "spatial_genes", top_n = 6)
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+  g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+  g <- GiottoPreprocess(g)
+  g <- GiottoSpatialNetwork(g)
+  g <- GiottoSpatialGenes(g, features = rownames(spatial)[1:50], top_n = 10)
+}
+}

--- a/man/GiottoSpatialModules.Rd
+++ b/man/GiottoSpatialModules.Rd
@@ -46,3 +46,41 @@ A `giotto2` workflow object.
 \description{
 Run Giotto spatial co-expression modules
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:200]
+)
+features <- rownames(spatial)[1:6]
+module_table <- expand.grid(
+  feat_ID = features,
+  variable = paste0("module_", 1:3),
+  stringsAsFactors = FALSE
+)
+module_table$spat_cor <- seq(-0.7, 0.8, length.out = nrow(module_table))
+g <- structure(
+  list(
+    source = list(cells = colnames(spatial), features = features),
+    results = list(
+      spatial_modules = list(
+        module_tables = list(result.cor_DT = module_table),
+        features = features
+      )
+    )
+  ),
+  class = c("giotto2", "list")
+)
+GiottoPlot(g, plot_type = "spatial_modules", top_n = 6)
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+  g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+  g <- GiottoPreprocess(g)
+  g <- GiottoSpatialNetwork(g)
+  g <- GiottoSpatialModules(g, features = rownames(spatial)[1:50], k = 3)
+}
+}

--- a/man/GiottoSpatialNetwork.Rd
+++ b/man/GiottoSpatialNetwork.Rd
@@ -29,3 +29,37 @@ A `giotto2` workflow object.
 \description{
 Create a Giotto spatial network
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:200]
+)
+coords <- data.frame(
+  cell_ID = colnames(spatial),
+  sdimx = spatial$x,
+  sdimy = spatial$y,
+  row.names = colnames(spatial)
+)
+edges <- data.frame(
+  from = colnames(spatial)[1:79],
+  to = colnames(spatial)[2:80]
+)
+g <- structure(
+  list(
+    source = list(cells = colnames(spatial), coordinates = coords),
+    results = list(spatial_network = list(name = "Delaunay_network", table = edges))
+  ),
+  class = c("giotto2", "list")
+)
+GiottoPlot(g, plot_type = "network")
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+  g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
+  g <- GiottoSpatialNetwork(g, network_method = "Delaunay")
+}
+}

--- a/man/RunBANKSY.Rd
+++ b/man/RunBANKSY.Rd
@@ -106,16 +106,37 @@ Build neighborhood-augmented BANKSY features from a spatial \code{Seurat} object
 and store spatial domain or microenvironment clusters in metadata.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- RunBANKSY(
+spatial <- subset(
   visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+spatial$BANKSY_cluster <- factor(
+  paste0("BANKSY", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1)
+)
+
+SpatialSpotPlot(
+  spatial,
+  group.by = "BANKSY_cluster",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+
+if (
+  requireNamespace("Banksy", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+spatial <- RunBANKSY(
+  spatial,
   assay = "Spatial",
   layer = "counts",
+  coord.cols = c("x", "y"),
+  features = rownames(spatial)[1:300],
   lambda = 0.2,
-  k_geom = 15,
-  resolution = 0.6
+  k_geom = 8,
+  resolution = 0.6,
+  verbose = FALSE
 )
-SpatialSpotPlot(spatial, group.by = "BANKSY_cluster")
 }
 }

--- a/man/RunBayesSpace.Rd
+++ b/man/RunBayesSpace.Rd
@@ -76,8 +76,28 @@ Run BayesSpace spatial clustering
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- RunBayesSpace(
+spatial <- subset(
   visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+spatial$BayesSpace_cluster <- factor(
+  paste0("domain_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1)
+)
+
+SpatialSpotPlot(
+  spatial,
+  group.by = "BayesSpace_cluster",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+
+if (
+  requireNamespace("BayesSpace", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+spatial <- RunBayesSpace(
+  spatial,
   q = 3,
   n.PCs = 5,
   n.HVGs = 200,
@@ -90,5 +110,5 @@ spatial <- RunBayesSpace(
   )
 )
 table(spatial$BayesSpace_cluster)
-SpatialSpotPlot(spatial, group.by = "BayesSpace_cluster")
+}
 }

--- a/man/RunCARD.Rd
+++ b/man/RunCARD.Rd
@@ -92,18 +92,58 @@ using a single-cell \code{Seurat} reference and the optional \code{CARD}/\code{C
 backend.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-data(panc8_sub)
-
-spatial <- RunCARD(
+spatial <- subset(
   visium_human_pancreas_sub,
-  reference = panc8_sub,
-  reference_label = "celltype",
-  assay = "Spatial",
-  reference_assay = "RNA"
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
-SpatialSpotPlot(spatial, group.by = "CARD_dominant_type")
-SpatialSpotPlot(spatial, group.by = "CARD_dominant_type", plot_type = "pie")
+card_weights <- data.frame(
+  CARD_prop_Ductal = seq(0.70, 0.20, length.out = ncol(spatial)),
+  CARD_prop_Endocrine = seq(0.20, 0.70, length.out = ncol(spatial)),
+  CARD_prop_Stromal = 0.10,
+  row.names = colnames(spatial)
+)
+card_weights <- card_weights / rowSums(card_weights)
+spatial <- Seurat::AddMetaData(spatial, card_weights)
+spatial$CARD_dominant_type <- sub(
+  "^CARD_prop_",
+  "",
+  colnames(card_weights)[max.col(card_weights)]
+)
+spatial$CARD_max_prop <- apply(card_weights, 1, max)
+
+SpatialSpotPlot(
+  spatial,
+  group.by = "CARD_dominant_type",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+if (requireNamespace("scatterpie", quietly = TRUE)) {
+  SpatialSpotPlot(
+    spatial,
+    group.by = "CARD_dominant_type",
+    plot_type = "pie",
+    overlay_image = FALSE,
+    coord.cols = c("x", "y")
+  )
+}
+
+if (
+  (requireNamespace("CARD", quietly = TRUE) ||
+    requireNamespace("CARDspa", quietly = TRUE)) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+data(pancreas_sub)
+features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
+spatial <- RunCARD(
+  spatial,
+  reference = pancreas_sub,
+  reference_label = "CellType",
+  assay = "Spatial",
+  reference_assay = "RNA",
+  features = features_use,
+  verbose = FALSE
+)
 }
 }

--- a/man/RunCSIDE.Rd
+++ b/man/RunCSIDE.Rd
@@ -87,35 +87,58 @@ Run \code{spacexr} C-SIDE after RCTD to test cell type-specific spatial or
 condition-aware differential expression.
 }
 \examples{
-\dontrun{
-library(scop)
-
 data(visium_human_pancreas_sub)
-data(panc8_sub)
-
-spatial <- RunRCTD(
-  srt = visium_human_pancreas_sub,
-  reference = panc8_sub,
-  reference_label = "celltype",
-  assay = "Spatial",
-  reference_assay = "RNA",
-  rctd_mode = "full",
-  max_cores = 1
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+spatial$region <- ifelse(spatial$x > stats::median(spatial$x), "right", "left")
+spatial$CSIDE_n_sig <- ifelse(spatial$region == "right", 12, 4)
+spatial$CSIDE_mode <- "regions"
+cside_result <- data.frame(
+  feature = rownames(spatial)[1:4],
+  celltype = rep(c("Ductal", "Endocrine"), each = 2),
+  parameter = "right_vs_left",
+  logFC = c(1.2, 0.8, -0.9, -1.1),
+  statistic = c(4.1, 3.5, -3.2, -3.8),
+  p_value = c(0.001, 0.004, 0.006, 0.002),
+  q_value = c(0.004, 0.008, 0.010, 0.006),
+  significant = TRUE,
+  method = "regions"
+)
+spatial@tools$CSIDE <- list(
+  result_table = cside_result,
+  parameters = list(mode = "regions", group.by = "region")
 )
 
-spatial$region <- ifelse(spatial$col > stats::median(spatial$col), "right", "left")
-spatial <- RunCSIDE(
+SpatialSpotPlot(
   spatial,
-  group.by = "region",
-  celltypes = c("alpha", "beta"),
-  gene_threshold = 0.00005,
-  cell_type_threshold = 125
+  group.by = "CSIDE_n_sig",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+SpatialSpotPlot(
+  spatial,
+  features = cside_result$feature[1:2],
+  assay = "Spatial",
+  layer = "counts",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
 )
 
-head(spatial@tools$CSIDE$result_table)
-SpatialSpotPlot(spatial, group.by = "CSIDE_n_sig")
-
-cside_genes <- head(spatial@tools$CSIDE$result_table$feature, 2)
-SpatialSpotPlot(spatial, features = cside_genes, assay = "Spatial")
+if (
+  requireNamespace("spacexr", quietly = TRUE) &&
+    !is.null(spatial@tools$RCTD) &&
+    inherits(spatial@tools$RCTD$object, "RCTD") &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+  spatial <- RunCSIDE(
+    spatial,
+    group.by = "region",
+    celltypes = c("Ductal", "Endocrine"),
+    gene_threshold = 0.00005,
+    cell_type_threshold = 125
+  )
 }
 }

--- a/man/RunGiottoCellProximity.Rd
+++ b/man/RunGiottoCellProximity.Rd
@@ -83,31 +83,45 @@ result tables are returned as a standalone result; the input \code{Seurat} objec
 is not modified.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- Seurat::NormalizeData(
+spatial <- subset(
   visium_human_pancreas_sub,
-  assay = "Spatial",
-  verbose = FALSE
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
 spatial$region <- ifelse(
-  spatial$col > stats::median(spatial$col),
+  spatial$x > stats::median(spatial$x),
   "right",
   "left"
 )
+proximity <- list(
+  enrichment = data.frame(
+    group_1 = c("left", "left", "right", "right"),
+    group_2 = c("left", "right", "left", "right"),
+    enrichment = c(1.1, -0.7, -0.5, 1.3),
+    type_int = c("enriched", "depleted", "depleted", "enriched")
+  ),
+  parameters = list(network_method = "Delaunay", number_of_simulations = 100)
+)
+class(proximity) <- c("giotto2_cell_proximity", "giotto2_result", "list")
 
+head(proximity$enrichment)
+GiottoPlot(proximity)
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 proximity <- RunGiottoCellProximity(
   spatial,
   group.by = "region",
   assay = "Spatial",
   layer = "data",
-  coord.cols = c("col", "row"),
+  coord.cols = c("x", "y"),
   network_method = "Delaunay",
   number_of_simulations = 100
 )
-
-head(proximity$enrichment)
-GiottoPlot(proximity)
 }
 
 }

--- a/man/RunGiottoCluster.Rd
+++ b/man/RunGiottoCluster.Rd
@@ -88,20 +88,44 @@ the complete Giotto object together with extracted cluster results. The input
 \code{Seurat} object is not modified.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- Seurat::NormalizeData(
+spatial <- subset(
   visium_human_pancreas_sub,
-  assay = "Spatial",
-  verbose = FALSE
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
+giotto_clusters <- list(
+  clusters = data.frame(
+    cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1),
+    row.names = colnames(spatial)
+  ),
+  parameters = list(
+    cluster_colname = "Giotto_cluster",
+    coord.cols = c("x", "y"),
+    k = 8,
+    resolution = 0.4
+  )
+)
+class(giotto_clusters) <- c("giotto2_cluster", "giotto2_result", "list")
+head(giotto_clusters$clusters)
+GiottoPlot(
+  giotto_clusters,
+  srt = spatial,
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 spatial <- Seurat::FindVariableFeatures(
   spatial,
   assay = "Spatial",
-  nfeatures = 500,
+  nfeatures = 300,
   verbose = FALSE
 )
-
 giotto_clusters <- RunGiottoCluster(
   spatial,
   assay = "Spatial",
@@ -109,16 +133,10 @@ giotto_clusters <- RunGiottoCluster(
   dims = 1:10,
   k = 8,
   resolution = 0.4,
-  coord.cols = c("col", "row")
+  coord.cols = c("x", "y")
 )
 
 head(giotto_clusters$clusters)
-GiottoPlot(
-  giotto_clusters,
-  srt = spatial,
-  overlay_image = FALSE,
-  coord.cols = c("col", "row")
-)
 }
 
 }

--- a/man/RunGiottoSpatialGenes.Rd
+++ b/man/RunGiottoSpatialGenes.Rd
@@ -87,37 +87,50 @@ detection. The complete Giotto object and result tables are returned as a
 standalone result; the input \code{Seurat} object is not modified.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- Seurat::NormalizeData(
+spatial <- subset(
   visium_human_pancreas_sub,
-  assay = "Spatial",
-  verbose = FALSE
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
-spatial <- Seurat::FindVariableFeatures(
-  spatial,
-  assay = "Spatial",
-  nfeatures = 500,
-  verbose = FALSE
+spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
+giotto_genes <- list(
+  results = data.frame(
+    feat_ID = rownames(spatial)[1:6],
+    spatGeneRank = c(40, 35, 28, 20, 16, 10)
+  ),
+  top_features = rownames(spatial)[1:4],
+  parameters = list(assay = "Spatial", layer = "data", coord.cols = c("x", "y"))
 )
-
-giotto_genes <- RunGiottoSpatialGenes(
-  spatial,
-  assay = "Spatial",
-  layer = "data",
-  features = Seurat::VariableFeatures(spatial, assay = "Spatial"),
-  coord.cols = c("col", "row"),
-  top_n = 50
-)
+class(giotto_genes) <- c("giotto2_spatial_genes", "giotto2_result", "list")
 
 head(giotto_genes$results)
-GiottoPlot(giotto_genes, plot_type = "ranking", top_n = 10)
+GiottoPlot(giotto_genes, plot_type = "ranking", top_n = 6)
 GiottoPlot(
   giotto_genes,
   srt = spatial,
   plot_type = "feature",
   overlay_image = FALSE,
-  coord.cols = c("col", "row")
+  coord.cols = c("x", "y")
+)
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+spatial <- Seurat::FindVariableFeatures(
+  spatial,
+  assay = "Spatial",
+  nfeatures = 300,
+  verbose = FALSE
+)
+giotto_genes <- RunGiottoSpatialGenes(
+  spatial,
+  assay = "Spatial",
+  layer = "data",
+  features = Seurat::VariableFeatures(spatial, assay = "Spatial"),
+  coord.cols = c("x", "y"),
+  top_n = 50
 )
 }
 

--- a/man/RunGiottoSpatialModules.Rd
+++ b/man/RunGiottoSpatialModules.Rd
@@ -90,32 +90,53 @@ complete Giotto object and module results are returned as a standalone
 result; the input \code{Seurat} object is not modified.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- Seurat::NormalizeData(
+spatial <- subset(
   visium_human_pancreas_sub,
-  assay = "Spatial",
-  verbose = FALSE
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
+module_features <- rownames(spatial)[1:4]
+module_cor <- expand.grid(
+  feat_ID = module_features,
+  variable = module_features
+)
+module_cor$spat_cor <- c(
+  1, 0.4, 0.1, -0.2,
+  0.4, 1, 0.3, 0.0,
+  0.1, 0.3, 1, 0.5,
+  -0.2, 0.0, 0.5, 1
+)
+giotto_modules <- list(
+  module_tables = list(result.cor_DT = module_cor),
+  features = module_features,
+  parameters = list(assay = "Spatial", layer = "data")
+)
+class(giotto_modules) <- c("giotto2_spatial_modules", "giotto2_result", "list")
+
+names(giotto_modules$module_tables)
+GiottoPlot(giotto_modules, top_n = 4)
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 spatial <- Seurat::FindVariableFeatures(
   spatial,
   assay = "Spatial",
-  nfeatures = 500,
+  nfeatures = 300,
   verbose = FALSE
 )
-
 giotto_modules <- RunGiottoSpatialModules(
   spatial,
   assay = "Spatial",
   layer = "data",
   features = Seurat::VariableFeatures(spatial, assay = "Spatial")[1:50],
-  coord.cols = c("col", "row"),
+  coord.cols = c("x", "y"),
   cor_method = "pearson",
   k = 6
 )
-
-names(giotto_modules$module_tables)
-GiottoPlot(giotto_modules, top_n = 12)
 }
 
 }

--- a/man/RunGiottoWorkflow.Rd
+++ b/man/RunGiottoWorkflow.Rd
@@ -47,3 +47,50 @@ workflow object.
 Run basic or full Giotto analysis on a `giotto2` object. Seurat input is
 converted first with [SeuratToScopGiotto()].
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:300]
+)
+g <- structure(
+  list(
+    source = list(
+      cells = colnames(spatial),
+      features = rownames(spatial),
+      coordinates = data.frame(
+        cell_ID = colnames(spatial),
+        sdimx = spatial$x,
+        sdimy = spatial$y
+      )
+    ),
+    results = list(
+      cluster = list(
+        table = data.frame(
+          cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1),
+          row.names = colnames(spatial)
+        )
+      )
+    ),
+    active = "cluster"
+  ),
+  class = c("giotto2", "list")
+)
+GiottoPlot(g, plot_type = "cluster")
+
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+g <- RunGiottoWorkflow(
+  spatial,
+  steps = "basic",
+  assay = "Spatial",
+  layer = "counts",
+  coord.cols = c("x", "y"),
+  return_seurat = FALSE,
+  verbose = FALSE
+)
+}
+}

--- a/man/RunMERINGUE.Rd
+++ b/man/RunMERINGUE.Rd
@@ -97,25 +97,42 @@ Run \code{MERINGUE} spatial autocorrelation, spatial cross-correlation, and
 spatial module analysis for a spatial \code{Seurat} object.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- Seurat::NormalizeData(
+spatial <- subset(
   visium_human_pancreas_sub,
-  assay = "Spatial",
-  verbose = FALSE
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
-
-spatial <- RunMERINGUE(
-  spatial,
-  assay = "Spatial",
-  mode = c("autocorrelation", "cross_correlation"),
-  nfeatures = 50
+spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
+spatial@misc[["MERINGUEFeatures"]] <- rownames(spatial)[1:4]
+spatial@tools[["MERINGUE"]] <- list(
+  autocorrelation = data.frame(
+    feature = rownames(spatial)[1:4],
+    statistic = c(0.42, 0.35, 0.28, 0.22),
+    p_value = c(0.001, 0.004, 0.010, 0.020),
+    q_value = c(0.004, 0.008, 0.015, 0.030)
+  )
 )
 
 head(spatial@tools[["MERINGUE"]]$autocorrelation)
 SpatialSpotPlot(
   spatial,
-  features = spatial@misc[["MERINGUEFeatures"]][1:2]
+  features = spatial@misc[["MERINGUEFeatures"]][1:2],
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+
+if (
+  requireNamespace("MERINGUE", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+spatial <- RunMERINGUE(
+  spatial,
+  assay = "Spatial",
+  coord.cols = c("x", "y"),
+  mode = c("autocorrelation", "cross_correlation"),
+  nfeatures = 50,
+  verbose = FALSE
 )
 }
 }

--- a/man/RunRCTD.Rd
+++ b/man/RunRCTD.Rd
@@ -87,62 +87,79 @@ Estimate spot-level cell type proportions from a spatial \code{Seurat} object
 using a single-cell \code{Seurat} reference and \code{spacexr} RCTD.
 }
 \examples{
-\dontrun{
-library(scop)
-
 data(visium_human_pancreas_sub)
-data(panc8_sub)
-
-drop_celltypes <- c(
-  "epsilon",
-  "macrophage",
-  "mast",
-  "quiescent-stellate",
-  "schwann"
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
-
-panc8_rctd <- subset(
-  panc8_sub,
-  subset = !celltype \%in\% drop_celltypes
+rctd_weights <- data.frame(
+  RCTD_prop_Ductal = seq(0.75, 0.15, length.out = ncol(spatial)),
+  RCTD_prop_Endocrine = seq(0.15, 0.65, length.out = ncol(spatial)),
+  RCTD_prop_Stromal = 0.10,
+  row.names = colnames(spatial)
 )
+rctd_weights <- rctd_weights / rowSums(rctd_weights)
+spatial <- Seurat::AddMetaData(spatial, rctd_weights)
+spatial$RCTD_dominant_type <- sub(
+  "^RCTD_prop_",
+  "",
+  colnames(rctd_weights)[max.col(rctd_weights)]
+)
+spatial$RCTD_max_prop <- apply(rctd_weights, 1, max)
 
-table(panc8_sub$celltype)
-table(panc8_rctd$celltype)
+SpatialSpotPlot(
+  spatial,
+  group.by = "RCTD_dominant_type",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+if (requireNamespace("scatterpie", quietly = TRUE)) {
+  SpatialSpotPlot(
+    spatial,
+    group.by = "RCTD_dominant_type",
+    plot_type = "pie",
+    overlay_image = FALSE,
+    coord.cols = c("x", "y")
+  )
+}
+
+if (
+  requireNamespace("spacexr", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+data(pancreas_sub)
+features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
 
 spatial <- RunRCTD(
-  srt = visium_human_pancreas_sub,
-  reference = panc8_rctd,
-  reference_label = "celltype",
+  srt = spatial,
+  reference = pancreas_sub,
+  reference_label = "CellType",
   assay = "Spatial",
   reference_assay = "RNA",
   layer = "counts",
   reference_layer = "counts",
+  features = features_use,
   rctd_mode = "full",
   max_cores = 1,
+  min_cells = 5,
   prefix = "RCTD"
 )
 
 rctd_cols <- grep("^RCTD_prop_", colnames(spatial@meta.data), value = TRUE)
-head(spatial@meta.data[, c("RCTD_dominant_type", "RCTD_max_prop", rctd_cols[1:3])])
-
 SpatialSpotPlot(
   spatial,
   group.by = "RCTD_dominant_type",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y"),
   theme_use = "theme_scop"
 )
-
 SpatialSpotPlot(
   spatial,
-  group.by = rctd_cols[1:min(4, length(rctd_cols))],
+  group.by = rctd_cols[1:min(3, length(rctd_cols))],
   palette = "Spectral",
-  theme_use = "theme_scop"
-)
-
-SpatialSpotPlot(
-  spatial,
-  group.by = "RCTD_dominant_type",
-  plot_type = "pie",
-  pie.radius.scale = 0.45,
+  overlay_image = FALSE,
+  coord.cols = c("x", "y"),
   theme_use = "theme_scop"
 )
 }

--- a/man/RunSPOTlight.Rd
+++ b/man/RunSPOTlight.Rd
@@ -82,31 +82,70 @@ Estimate spot-level cell type proportions from a spatial \code{Seurat} object
 using a single-cell \code{Seurat} reference and the optional \code{SPOTlight} package.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-data(panc8_sub)
-
-spatial <- RunSPOTlight(
-  srt = visium_human_pancreas_sub,
-  reference = panc8_sub,
-  reference_label = "celltype",
-  assay = "Spatial",
-  reference_assay = "RNA"
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
+spotlight_weights <- data.frame(
+  SPOTlight_prop_Ductal = seq(0.70, 0.20, length.out = ncol(spatial)),
+  SPOTlight_prop_Endocrine = seq(0.20, 0.70, length.out = ncol(spatial)),
+  SPOTlight_prop_Immune = 0.10,
+  row.names = colnames(spatial)
+)
+spotlight_weights <- spotlight_weights / rowSums(spotlight_weights)
+spatial <- Seurat::AddMetaData(spatial, spotlight_weights)
+spatial$SPOTlight_dominant_type <- sub(
+  "^SPOTlight_prop_",
+  "",
+  colnames(spotlight_weights)[max.col(spotlight_weights)]
+)
+spatial$SPOTlight_max_prop <- apply(spotlight_weights, 1, max)
 
-SpatialSpotPlot(spatial, group.by = "SPOTlight_dominant_type")
+SpatialSpotPlot(
+  spatial,
+  group.by = "SPOTlight_dominant_type",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+if (requireNamespace("scatterpie", quietly = TRUE)) {
+  SpatialSpotPlot(
+    spatial,
+    group.by = "SPOTlight_dominant_type",
+    plot_type = "pie",
+    overlay_image = FALSE,
+    coord.cols = c("x", "y")
+  )
+}
+
+if (
+  requireNamespace("SPOTlight", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+data(pancreas_sub)
+features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
+spatial <- RunSPOTlight(
+  srt = spatial,
+  reference = pancreas_sub,
+  reference_label = "CellType",
+  assay = "Spatial",
+  reference_assay = "RNA",
+  features = features_use,
+  marker_top_n = 20,
+  verbose = FALSE
+)
 
 spotlight_cols <- grep(
   "^SPOTlight_prop_",
   colnames(spatial@meta.data),
   value = TRUE
 )
-SpatialSpotPlot(spatial, group.by = spotlight_cols[1:4])
-
 SpatialSpotPlot(
   spatial,
-  group.by = "SPOTlight_dominant_type",
-  plot_type = "pie"
+  group.by = spotlight_cols[1:min(3, length(spotlight_cols))],
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
 )
 }
 }

--- a/man/RunSTdeconvolve.Rd
+++ b/man/RunSTdeconvolve.Rd
@@ -80,14 +80,58 @@ Estimate spot-level topic proportions from a spatial \code{Seurat} object using
 the optional \code{STdeconvolve} package.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- RunSTdeconvolve(
+spatial <- subset(
   visium_human_pancreas_sub,
-  assay = "Spatial",
-  k = 5
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
-SpatialSpotPlot(spatial, group.by = "STdeconvolve_dominant_type")
-STdeconvolvePlot(spatial, plot_type = "pie")
+topic_weights <- data.frame(
+  STdeconvolve_prop_topic_1 = seq(0.75, 0.20, length.out = ncol(spatial)),
+  STdeconvolve_prop_topic_2 = seq(0.20, 0.70, length.out = ncol(spatial)),
+  STdeconvolve_prop_topic_3 = 0.10,
+  row.names = colnames(spatial)
+)
+topic_weights <- topic_weights / rowSums(topic_weights)
+spatial <- Seurat::AddMetaData(spatial, topic_weights)
+spatial$STdeconvolve_dominant_type <- sub(
+  "^STdeconvolve_prop_",
+  "",
+  colnames(topic_weights)[max.col(topic_weights)]
+)
+spatial$STdeconvolve_max_prop <- apply(topic_weights, 1, max)
+
+SpatialSpotPlot(
+  spatial,
+  group.by = "STdeconvolve_dominant_type",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+STdeconvolvePlot(
+  spatial,
+  topics = 1:2,
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+if (requireNamespace("scatterpie", quietly = TRUE)) {
+  STdeconvolvePlot(
+    spatial,
+    plot_type = "pie",
+    overlay_image = FALSE,
+    coord.cols = c("x", "y")
+  )
+}
+
+if (
+  requireNamespace("STdeconvolve", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+spatial <- RunSTdeconvolve(
+  spatial,
+  assay = "Spatial",
+  features = rownames(spatial)[1:300],
+  k = 3,
+  verbose = FALSE
+)
 }
 }

--- a/man/RunSemlaLocalG.Rd
+++ b/man/RunSemlaLocalG.Rd
@@ -44,23 +44,32 @@ written by semla to metadata or to an assay, depending on
 \code{store_in_metadata}.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- Seurat::NormalizeData(
+spatial <- subset(
   visium_human_pancreas_sub,
-  assay = "Spatial",
-  verbose = FALSE
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
+spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 features <- rownames(spatial)[1:3]
+spatial[[paste0(features[1], "_localG")]] <- as.numeric(scale(spatial$x))
 
+SpatialSpotPlot(
+  spatial,
+  group.by = paste0(features[1], "_localG"),
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+
+if (
+  requireNamespace("semla", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
 spatial <- RunSemlaLocalG(
   spatial,
   features = features,
-  store_in_metadata = TRUE
+  store_in_metadata = TRUE,
+  verbose = FALSE
 )
-
-local_g_cols <- grep(features[1], colnames(spatial[[]]), value = TRUE)
-head(spatial[[]][local_g_cols])
-SpatialSpotPlot(spatial, group.by = local_g_cols[1])
 }
 }

--- a/man/RunSemlaRadialDistance.Rd
+++ b/man/RunSemlaRadialDistance.Rd
@@ -40,24 +40,42 @@ Use \code{semla::RadialDistance()} to calculate distances from selected spatial
 regions and write the returned columns to Seurat metadata.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- visium_human_pancreas_sub
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
 spatial$region <- ifelse(
-  spatial$row > stats::median(spatial$row),
+  spatial$y > stats::median(spatial$y),
   "upper",
   "lower"
 )
+upper_center <- c(
+  stats::median(spatial$x[spatial$region == "upper"]),
+  stats::median(spatial$y[spatial$region == "upper"])
+)
+spatial$upper_distance <- sqrt(
+  (spatial$x - upper_center[1])^2 + (spatial$y - upper_center[2])^2
+)
 
+SpatialSpotPlot(
+  spatial,
+  group.by = "upper_distance",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+
+if (
+  requireNamespace("semla", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
 spatial <- RunSemlaRadialDistance(
   spatial,
   column_name = "region",
   selected_groups = "upper",
-  column_suffix = "upper_distance"
+  column_suffix = "upper_distance",
+  verbose = FALSE
 )
-
-distance_cols <- grep("upper_distance", colnames(spatial[[]]), value = TRUE)
-head(spatial[[]][distance_cols])
-SpatialSpotPlot(spatial, group.by = distance_cols[1])
 }
 }

--- a/man/RunSemlaRegionNeighbors.Rd
+++ b/man/RunSemlaRegionNeighbors.Rd
@@ -43,24 +43,38 @@ Use \code{semla::RegionNeighbors()} to identify neighboring spots for selected
 metadata labels and write the returned columns to Seurat metadata.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- visium_human_pancreas_sub
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
 spatial$region <- ifelse(
-  spatial$col > stats::median(spatial$col),
+  spatial$x > stats::median(spatial$x),
   "right",
   "left"
 )
+spatial$right_border <- spatial$region == "right" &
+  abs(spatial$x - stats::median(spatial$x)) < stats::sd(spatial$x) * 0.25
 
+SpatialSpotPlot(
+  spatial,
+  group.by = c("region", "right_border"),
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+
+if (
+  requireNamespace("semla", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
 spatial <- RunSemlaRegionNeighbors(
   spatial,
   column_name = "region",
   column_labels = "right",
   mode = "outer",
-  column_key = "right_border"
+  column_key = "right_border",
+  verbose = FALSE
 )
-
-grep("right_border", colnames(spatial[[]]), value = TRUE)
-SpatialSpotPlot(spatial, group.by = "region")
 }
 }

--- a/man/RunSemlaSpatialNetwork.Rd
+++ b/man/RunSemlaSpatialNetwork.Rd
@@ -50,16 +50,37 @@ Seurat object and compute spot-level spatial networks. The network is stored
 in \code{srt@tools[[tool_name]]} when \code{store_results = TRUE}.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-
-spatial <- RunSemlaSpatialNetwork(
+spatial <- subset(
   visium_human_pancreas_sub,
-  nNeighbors = 6,
-  coords = "array"
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+spatial@tools$SemlaSpatialNetwork <- list(
+  network = data.frame(
+    from = colnames(spatial)[1:6],
+    to = colnames(spatial)[2:7],
+    distance = sqrt(diff(spatial$x[1:7])^2 + diff(spatial$y[1:7])^2)
+  )
 )
 
 head(spatial@tools$SemlaSpatialNetwork$network)
-SpatialSpotPlot(spatial, group.by = "orig.ident")
+SpatialSpotPlot(
+  spatial,
+  group.by = "coda_label",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+
+if (
+  requireNamespace("semla", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+spatial <- RunSemlaSpatialNetwork(
+  spatial,
+  nNeighbors = 6,
+  coords = "pixels",
+  verbose = FALSE
+)
 }
 }

--- a/man/RunSmoothClust.Rd
+++ b/man/RunSmoothClust.Rd
@@ -97,13 +97,28 @@ Smooth expression across spatial neighborhoods with the optional
 domains with PCA and k-means.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-spatial <- Seurat::NormalizeData(
+spatial <- subset(
   visium_human_pancreas_sub,
-  assay = "Spatial",
-  verbose = FALSE
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
 )
+spatial$SmoothClust_cluster <- factor(
+  paste0("SmoothClust", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1)
+)
+
+SpatialSpotPlot(
+  spatial,
+  group.by = "SmoothClust_cluster",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+
+if (
+  requireNamespace("smoothclust", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 spatial <- Seurat::FindVariableFeatures(
   spatial,
   assay = "Spatial",
@@ -116,10 +131,11 @@ spatial <- RunSmoothClust(
   assay = "Spatial",
   n_clusters = 3,
   smooth_method = "knn",
-  k = 6
+  coord.cols = c("x", "y"),
+  k = 6,
+  verbose = FALSE
 )
 
 table(spatial$SmoothClust_cluster)
-SpatialSpotPlot(spatial, group.by = "SmoothClust_cluster")
 }
 }

--- a/man/RunSpaNorm.Rd
+++ b/man/RunSpaNorm.Rd
@@ -59,23 +59,46 @@ Normalize spatial transcriptomics counts with the optional Bioconductor
 \code{SpaNorm} backend and store the normalized expression in a new Seurat assay.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-
-spatial <- RunSpaNorm(
+spatial <- subset(
   visium_human_pancreas_sub,
-  assay = "Spatial",
-  layer = "counts",
-  coord.cols = c("col", "row"),
-  new_assay = "SpaNorm",
-  sample.p = 0.25
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:300]
 )
+spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 
 SpatialSpotPlot(
   spatial,
-  features = rownames(spatial[["SpaNorm"]])[1:2],
-  assay = "SpaNorm",
-  layer = "data"
+  features = rownames(spatial)[1:2],
+  assay = "Spatial",
+  layer = "data",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
 )
+
+if (
+  requireNamespace("SpaNorm", quietly = TRUE) &&
+    requireNamespace("SpatialExperiment", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+  spatial <- RunSpaNorm(
+    spatial,
+    assay = "Spatial",
+    layer = "counts",
+    coord.cols = c("x", "y"),
+    new_assay = "SpaNorm",
+    store_spe = FALSE,
+    sample.p = 0.25,
+    verbose = FALSE
+  )
+
+  SpatialSpotPlot(
+    spatial,
+    features = rownames(spatial[["SpaNorm"]])[1:2],
+    assay = "SpaNorm",
+    layer = "data",
+    overlay_image = FALSE,
+    coord.cols = c("x", "y")
+  )
 }
 }

--- a/man/RunSpatialEcoTyper.Rd
+++ b/man/RunSpatialEcoTyper.Rd
@@ -178,12 +178,40 @@ package and write spatial ecotype labels or abundances back to a \code{Seurat}
 object when possible.
 }
 \examples{
-\dontrun{
+data(visium_human_pancreas_sub)
+srt <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+srt$CellType <- srt$coda_label
+srt$SpatialEcoTyper_SE <- ifelse(srt$x > stats::median(srt$x), "SE1", "SE2")
+srt$sample <- ifelse(srt$y > stats::median(srt$y), "slice_a", "slice_b")
+
+SpatialEcoTyperSpatialPlot(
+  srt,
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+SpatialEcoTyperCompositionPlot(
+  srt,
+  group.by = "CellType",
+  sample.by = "sample",
+  position = "fill"
+)
+
+if (
+  requireNamespace("SpatialEcoTyper", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
 srt <- RunSpatialEcoTyper(
   srt,
   celltype.by = "CellType",
-  x.by = "X",
-  y.by = "Y"
+  x.by = "x",
+  y.by = "y",
+  nfeatures = 100,
+  ncores = 1,
+  verbose = FALSE
 )
 
 srt <- RunSpatialEcoTyper(
@@ -191,8 +219,11 @@ srt <- RunSpatialEcoTyper(
   mode = "multi",
   celltype.by = "CellType",
   sample.by = "sample",
-  x.by = "X",
-  y.by = "Y"
+  x.by = "x",
+  y.by = "y",
+  nfeatures = 100,
+  ncores = 1,
+  verbose = FALSE
 )
 }
 }

--- a/man/RunSpatialGradientFeatures.Rd
+++ b/man/RunSpatialGradientFeatures.Rd
@@ -140,14 +140,38 @@ stored in \code{srt@tools[["SpatialGradientFeatures"]]}; the SPATA2 object itsel
 is never stored.
 }
 \examples{
-\dontrun{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
 spatial <- RunSpatialGradientFeatures(
   spatial,
-  reference = "annotation",
-  annotation.by = "BayesSpace_cluster",
-  annotation.groups = "1",
-  variables = spatial@misc[["SpatialVariableFeatures"]]
+  reference = "trajectory",
+  backend = "cpp",
+  result_name = "ductal_axis",
+  variables = rownames(spatial)[1:8],
+  start = c(min(spatial$x), min(spatial$y)),
+  end = c(max(spatial$x), max(spatial$y)),
+  layer = "counts",
+  coord.cols = c("x", "y"),
+  n_random = 0,
+  n_bins = 5,
+  min_spots = 3,
+  sign_threshold = 1,
+  nfeatures = 4,
+  verbose = FALSE
 )
-SpatialGradientPlot(spatial, plot_type = "combined")
-}
+
+SpatialGradientPlot(spatial, plot_type = "summary", nfeatures = 4)
+SpatialGradientPlot(spatial, plot_type = "line", nfeatures = 2)
+SpatialGradientPlot(spatial, plot_type = "model", nfeatures = 2)
+SpatialGradientPlot(
+  spatial,
+  plot_type = "surface",
+  nfeatures = 2,
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
 }

--- a/man/RunSpatialIntegration.Rd
+++ b/man/RunSpatialIntegration.Rd
@@ -71,16 +71,72 @@ optional spatial backend and store standardized embeddings, domains, and
 aligned coordinates in a \code{Seurat} object.
 }
 \examples{
-\dontrun{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+spatial$sample <- ifelse(spatial$y > stats::median(spatial$y), "slice_a", "slice_b")
+spatial$SpatialIntegration_PRECAST_domain <- factor(
+  paste0("domain_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1)
+)
+embedding <- cbind(
+  SI_1 = as.numeric(scale(spatial$x)),
+  SI_2 = as.numeric(scale(spatial$y))
+)
+rownames(embedding) <- colnames(spatial)
+spatial[["SpatialIntegration_PRECAST"]] <- SeuratObject::CreateDimReducObject(
+  embeddings = embedding,
+  key = "SI_",
+  assay = "Spatial"
+)
+spatial$SpatialIntegration_PRECAST_aligned_x <- spatial$x +
+  ifelse(spatial$sample == "slice_b", -stats::median(spatial$x), 0)
+spatial$SpatialIntegration_PRECAST_aligned_y <- spatial$y
+integration_parameters <- list(
+  method = "PRECAST",
+  sample.by = "sample",
+  assay = "Spatial",
+  layer = "counts",
+  coord.cols = c("x", "y"),
+  reduction.name = "SpatialIntegration_PRECAST",
+  cluster_colname = "SpatialIntegration_PRECAST_domain",
+  aligned_coord_cols = c(
+    "SpatialIntegration_PRECAST_aligned_x",
+    "SpatialIntegration_PRECAST_aligned_y"
+  )
+)
+spatial@tools$SpatialIntegration <- list(
+  active_method = "PRECAST",
+  methods = list(PRECAST = list(parameters = integration_parameters)),
+  parameters = integration_parameters,
+  samples = unique(spatial$sample),
+  cells = colnames(spatial)
+)
+
+SpatialIntegrationPlot(
+  spatial,
+  plot_type = "spatial",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+SpatialIntegrationPlot(spatial, plot_type = "embedding")
+SpatialIntegrationPlot(spatial, plot_type = "alignment")
+SpatialIntegrationPlot(spatial, plot_type = "composition")
+
+if (
+  requireNamespace("PRECAST", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
 srt <- RunSpatialIntegration(
   object = spatial,
   method = "PRECAST",
   sample.by = "sample",
   assay = "Spatial",
-  coord.cols = c("col", "row")
+  coord.cols = c("x", "y"),
+  features = rownames(spatial)[1:300],
+  verbose = FALSE
 )
-
-SpatialIntegrationPlot(srt, plot_type = "spatial")
-SpatialIntegrationPlot(srt, plot_type = "embedding")
 }
 }

--- a/man/RunSpatialNeighborhood.Rd
+++ b/man/RunSpatialNeighborhood.Rd
@@ -79,3 +79,28 @@ A \code{Seurat} object with results stored in \code{srt@tools[[tool_name]]}.
 Build a scop-style spatial neighborhood result bundle and optionally dispatch
 to a supported backend for colocalization or local-effect statistics.
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+spatial <- RunSpatialNeighborhood(
+  spatial,
+  group.by = "coda_label",
+  coord.cols = c("x", "y"),
+  k = 4,
+  verbose = FALSE
+)
+
+SpatialNeighborhoodPlot(spatial, plot_type = "heatmap")
+SpatialNeighborhoodPlot(spatial, plot_type = "network", top_n = 12)
+SpatialNeighborhoodPlot(spatial, plot_type = "stat", top_n = 12)
+SpatialNeighborhoodPlot(
+  spatial,
+  plot_type = "spatial",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+}

--- a/man/RunSpotSweeper.Rd
+++ b/man/RunSpotSweeper.Rd
@@ -105,17 +105,50 @@ detection per sample, and writes scop-style pass/fail metadata that can be
 visualized with \code{\link[=SpatialSpotPlot]{SpatialSpotPlot()}}.
 }
 \examples{
-\dontrun{
 data(visium_human_pancreas_sub)
-
-spatial <- RunSpotSweeper(
+spatial <- subset(
   visium_human_pancreas_sub,
-  assay = "Spatial",
-  n_neighbors = 18,
-  n_order = 2
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+spatial$SpotSweeper_QC <- factor(
+  ifelse(seq_len(ncol(spatial)) \%\% 9 == 0, "Fail", "Pass"),
+  levels = c("Pass", "Fail")
+)
+spatial$SpotSweeper_nCount_Spatial_z <- as.numeric(scale(spatial$nCount_Spatial))
+
+SpatialSpotPlot(
+  spatial,
+  group.by = "SpotSweeper_QC",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+SpatialSpotPlot(
+  spatial,
+  group.by = "SpotSweeper_nCount_Spatial_z",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
 )
 
-SpatialSpotPlot(spatial, group.by = "SpotSweeper_QC")
-SpatialSpotPlot(spatial, group.by = "SpotSweeper_nCount_Spatial_z")
+if (
+  requireNamespace("SpotSweeper", quietly = TRUE) &&
+    requireNamespace("SpatialExperiment", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+  spatial <- RunSpotSweeper(
+    spatial,
+    assay = "Spatial",
+    coord.cols = c("x", "y"),
+    n_neighbors = 12,
+    run_artifact = FALSE,
+    verbose = FALSE
+  )
+
+  SpatialSpotPlot(
+    spatial,
+    group.by = "SpotSweeper_QC",
+    overlay_image = FALSE,
+    coord.cols = c("x", "y")
+  )
 }
 }

--- a/man/STdeconvolvePlot.Rd
+++ b/man/STdeconvolvePlot.Rd
@@ -35,3 +35,39 @@ A \code{ggplot}, \code{patchwork}, or list of \code{ggplot} objects.
 \description{
 Plot STdeconvolve topic proportions
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+topic_weights <- data.frame(
+  STdeconvolve_prop_topic_1 = seq(0.75, 0.20, length.out = ncol(spatial)),
+  STdeconvolve_prop_topic_2 = seq(0.20, 0.70, length.out = ncol(spatial)),
+  STdeconvolve_prop_topic_3 = 0.10,
+  row.names = colnames(spatial)
+)
+topic_weights <- topic_weights / rowSums(topic_weights)
+spatial <- Seurat::AddMetaData(spatial, topic_weights)
+spatial$STdeconvolve_dominant_type <- sub(
+  "^STdeconvolve_prop_",
+  "",
+  colnames(topic_weights)[max.col(topic_weights)]
+)
+
+STdeconvolvePlot(
+  spatial,
+  topics = 1:2,
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+if (requireNamespace("scatterpie", quietly = TRUE)) {
+  STdeconvolvePlot(
+    spatial,
+    plot_type = "pie",
+    overlay_image = FALSE,
+    coord.cols = c("x", "y")
+  )
+}
+}

--- a/man/SeuratToScopGiotto.Rd
+++ b/man/SeuratToScopGiotto.Rd
@@ -66,33 +66,61 @@ values are optionally added as an extra Giotto expression layer. The input
 Seurat object is not modified.
 }
 \examples{
-\dontrun{
-# Convert Seurat/SCT data into a standalone Giotto workflow object.
-g <- SeuratToScopGiotto(
-  spatial_seurat,
-  assay = "RNA",
-  layer = "counts",
-  use_sct = "normalized"
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:80],
+  features = rownames(visium_human_pancreas_sub)[1:300]
+)
+g <- structure(
+  list(
+    giotto = list(
+      umap = cbind(
+        UMAP_1 = as.numeric(scale(spatial$x)),
+        UMAP_2 = as.numeric(scale(spatial$y))
+      )
+    ),
+    source = list(
+      cells = colnames(spatial),
+      features = rownames(spatial),
+      coordinates = data.frame(
+        cell_ID = colnames(spatial),
+        sdimx = spatial$x,
+        sdimy = spatial$y
+      )
+    ),
+    results = list(
+      cluster = list(
+        table = data.frame(
+          cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1),
+          row.names = colnames(spatial)
+        )
+      ),
+      spatial_network = list(
+        table = data.frame(
+          from = colnames(spatial)[1:8],
+          to = colnames(spatial)[2:9]
+        )
+      )
+    ),
+    active = "cluster"
+  ),
+  class = c("giotto2", "list")
 )
 
-# Run the basic Giotto pipeline and plot directly from the Giotto object.
-g <- RunGiottoWorkflow(g, steps = "basic")
 GiottoPlot(g, plot_type = "cluster")
 GiottoPlot(g, plot_type = "network")
-GiottoPlot(g, plot_type = "dim")
 
-# Add selected Giotto analyses without writing to the Seurat object.
-g <- GiottoSpatialGenes(g, top_n = 50)
-g <- GiottoCellProximity(g, group.by = "celltype", number_of_simulations = 100)
-GiottoPlot(g, plot_type = "spatial_genes", top_n = 20)
-GiottoPlot(g, plot_type = "cell_proximity")
-
-# Export a result back to Seurat only when explicitly requested.
-spatial_seurat <- AddGiottoToSeurat(
-  spatial_seurat,
-  g,
-  result = "cluster",
-  name = "Giotto_cluster"
+if (
+  requireNamespace("Giotto", quietly = TRUE) &&
+    identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
+) {
+g <- SeuratToScopGiotto(
+  spatial,
+  assay = "Spatial",
+  layer = "counts",
+  coord.cols = c("x", "y"),
+  verbose = FALSE
 )
 }
 }

--- a/man/SpatialIntegrationPlot.Rd
+++ b/man/SpatialIntegrationPlot.Rd
@@ -76,3 +76,58 @@ A \code{ggplot}, patchwork object, or list of plots.
 \description{
 Visualize standardized results produced by \code{\link[=RunSpatialIntegration]{RunSpatialIntegration()}}.
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+spatial$sample <- ifelse(spatial$y > stats::median(spatial$y), "slice_a", "slice_b")
+spatial$SpatialIntegration_PRECAST_domain <- factor(
+  paste0("domain_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1)
+)
+embedding <- cbind(
+  SI_1 = as.numeric(scale(spatial$x)),
+  SI_2 = as.numeric(scale(spatial$y))
+)
+rownames(embedding) <- colnames(spatial)
+spatial[["SpatialIntegration_PRECAST"]] <- SeuratObject::CreateDimReducObject(
+  embeddings = embedding,
+  key = "SI_",
+  assay = "Spatial"
+)
+spatial$SpatialIntegration_PRECAST_aligned_x <- spatial$x +
+  ifelse(spatial$sample == "slice_b", -stats::median(spatial$x), 0)
+spatial$SpatialIntegration_PRECAST_aligned_y <- spatial$y
+integration_parameters <- list(
+  method = "PRECAST",
+  sample.by = "sample",
+  assay = "Spatial",
+  layer = "counts",
+  coord.cols = c("x", "y"),
+  reduction.name = "SpatialIntegration_PRECAST",
+  cluster_colname = "SpatialIntegration_PRECAST_domain",
+  aligned_coord_cols = c(
+    "SpatialIntegration_PRECAST_aligned_x",
+    "SpatialIntegration_PRECAST_aligned_y"
+  )
+)
+spatial@tools$SpatialIntegration <- list(
+  active_method = "PRECAST",
+  methods = list(PRECAST = list(parameters = integration_parameters)),
+  parameters = integration_parameters,
+  samples = unique(spatial$sample),
+  cells = colnames(spatial)
+)
+
+SpatialIntegrationPlot(
+  spatial,
+  plot_type = "spatial",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+SpatialIntegrationPlot(spatial, plot_type = "embedding")
+SpatialIntegrationPlot(spatial, plot_type = "alignment")
+SpatialIntegrationPlot(spatial, plot_type = "composition")
+}

--- a/man/SpatialNeighborhoodPlot.Rd
+++ b/man/SpatialNeighborhoodPlot.Rd
@@ -124,3 +124,28 @@ A \code{ggplot}, \code{patchwork}, or list of \code{ggplot} objects.
 Visualize results produced by \code{\link[=RunSpatialNeighborhood]{RunSpatialNeighborhood()}} using scop spatial,
 statistical, and network plotting conventions.
 }
+\examples{
+data(visium_human_pancreas_sub)
+spatial <- subset(
+  visium_human_pancreas_sub,
+  cells = colnames(visium_human_pancreas_sub)[1:120],
+  features = rownames(visium_human_pancreas_sub)[1:400]
+)
+spatial <- RunSpatialNeighborhood(
+  spatial,
+  group.by = "coda_label",
+  coord.cols = c("x", "y"),
+  k = 4,
+  verbose = FALSE
+)
+
+SpatialNeighborhoodPlot(spatial, plot_type = "heatmap")
+SpatialNeighborhoodPlot(spatial, plot_type = "network", top_n = 12)
+SpatialNeighborhoodPlot(spatial, plot_type = "stat", top_n = 12)
+SpatialNeighborhoodPlot(
+  spatial,
+  plot_type = "spatial",
+  overlay_image = FALSE,
+  coord.cols = c("x", "y")
+)
+}


### PR DESCRIPTION
## Summary
- replace spatial dontrun examples with executable roxygen examples
- add missing examples for Giotto, deconvolution, semla, gradient, neighborhood, integration, and visualization topics
- keep heavy optional backends behind SCOP_RUN_SPATIAL_BACKEND_EXAMPLES=true while generating stable example plots from sample data/result-shaped metadata

## Validation
- devtools::document()
- checked 45 spatial topics: examples present, 0 dontrun / if (FALSE) hits
- tools::checkRd() for 45 spatial Rd files
- pkgdown::build_reference(topics = spatial_topics)
- git diff --check