### PR TITLE
Avoid slow inferCNV subcluster defaults

### DIFF
--- a/R/RunCNV.R
+++ b/R/RunCNV.R
@@ -378,7 +378,7 @@ cnv_run_copykat <- function(
     setwd(output_dir)
     on.exit(setwd(oldwd), add = TRUE)
   }
-  result <- do.call(copykat_fun, args[names(args) %in% names(formals(copykat_fun))])
+  result <- cnv_call_backend_fun(copykat_fun, args)
   cnv_extract_copykat(result)
 }
 
@@ -417,7 +417,7 @@ cnv_run_fastcnv <- function(
     ),
     list(...)
   )
-  result <- do.call(fastcnv_fun, args[names(args) %in% names(formals(fastcnv_fun))])
+  result <- cnv_call_backend_fun(fastcnv_fun, args)
   cnv_extract_fastcnv(
     result,
     cells = colnames(srt),
@@ -458,7 +458,7 @@ cnv_run_scevan <- function(
     setwd(output_dir)
     on.exit(setwd(oldwd), add = TRUE)
   }
-  result <- do.call(scevan_fun, args[names(args) %in% names(formals(scevan_fun))])
+  result <- cnv_call_backend_fun(scevan_fun, args)
   cnv_extract_scevan(
     result = result,
     cells = colnames(counts),
@@ -530,13 +530,21 @@ cnv_run_infercnv <- function(
       infercnv_obj = infer_obj,
       cutoff = 0.1,
       out_dir = out_dir,
-      cluster_by_groups = TRUE,
-      denoise = TRUE,
-      HMM = FALSE
+      cluster_by_groups = FALSE,
+      denoise = FALSE,
+      HMM = FALSE,
+      analysis_mode = "samples",
+      tumor_subcluster_partition_method = "qnorm",
+      plot_steps = FALSE,
+      no_plot = TRUE,
+      save_rds = FALSE,
+      save_final_rds = FALSE,
+      inspect_subclusters = FALSE,
+      num_threads = cnv_default_threads()
     ),
     list(...)
   )
-  result <- do.call(run_fun, args[names(args) %in% names(formals(run_fun))])
+  result <- cnv_call_backend_fun(run_fun, args)
   cnv_extract_generic_result(result, method = "infercnv", cells = colnames(counts))
 }
 
@@ -568,7 +576,7 @@ cnv_run_numbat <- function(
     ),
     list(...)
   )
-  result <- do.call(run_fun, args[names(args) %in% names(formals(run_fun))])
+  result <- cnv_call_backend_fun(run_fun, args)
   cnv_extract_numbat(result = result, cells = colnames(counts), output_dir = out_dir)
 }
 
@@ -608,7 +616,7 @@ cnv_run_casper <- function(
     ),
     list(...)
   )
-  object <- do.call(create_fun, casper_args[names(casper_args) %in% names(formals(create_fun))])
+  object <- cnv_call_backend_fun(create_fun, casper_args)
   run_args <- utils::modifyList(
     list(
       object = object,
@@ -618,10 +626,10 @@ cnv_run_casper <- function(
     ),
     list(...)
   )
-  final_objects <- do.call(run_fun, run_args[names(run_args) %in% names(formals(run_fun))])
+  final_objects <- cnv_call_backend_fun(run_fun, run_args)
   event_args <- list(final.objects = final_objects)
   final_mat <- tryCatch(
-    do.call(event_fun, event_args[names(event_args) %in% names(formals(event_fun))]),
+    cnv_call_backend_fun(event_fun, event_args),
     error = function(e) NULL
   )
   cnv_extract_casper(
@@ -1838,6 +1846,23 @@ cnv_get_first_namespace_fun <- function(package, names) {
     "{.pkg {package}} does not expose one of {.val {names}}",
     message_type = "error"
   )
+}
+
+cnv_call_backend_fun <- function(fun, args) {
+  formal_names <- names(formals(fun))
+  if (is.null(formal_names)) {
+    return(do.call(fun, args))
+  }
+  allowed <- setdiff(formal_names, "...")
+  do.call(fun, args[names(args) %in% allowed])
+}
+
+cnv_default_threads <- function(max_threads = 4L) {
+  cores <- suppressWarnings(parallel::detectCores(logical = TRUE))
+  if (length(cores) == 0L || !is.finite(cores) || cores < 1L) {
+    return(1L)
+  }
+  max(1L, min(as.integer(max_threads), as.integer(cores)))
 }
 
 cnv_find_seurat_assay_matrix <- function(result, cells) {

--- a/tests/testthat/test-cnv.R
+++ b/tests/testthat/test-cnv.R
@@ -391,6 +391,113 @@ test_that("fastCNV runner skips expensive upstream preparation by default", {
   expect_equal(extracted$cell_info$prediction, c("aneuploid", "diploid", "aneuploid"))
 })
 
+test_that("infercnv runner avoids subclusters by default and filters passthrough arguments", {
+  srt <- make_cnv_seurat()
+  counts <- cnv_get_counts(srt, assay = "RNA", layer = "counts")
+  gene_order <- data.frame(
+    gene = rownames(srt),
+    chr = "chr1",
+    start = seq_len(nrow(srt)) * 100,
+    end = seq_len(nrow(srt)) * 100 + 99
+  )
+  out_dir <- tempfile("infercnv_")
+
+  testthat::local_mocked_bindings(
+    check_r = function(package, ...) {
+      expect_identical(package, "infercnv")
+      TRUE
+    },
+    get_namespace_fun = function(package, name) {
+      expect_identical(package, "infercnv")
+      if (identical(name, "CreateInfercnvObject")) {
+        return(function(
+          raw_counts_matrix,
+          annotations_file,
+          delim,
+          gene_order_file,
+          ref_group_names
+        ) {
+          expect_true(is.matrix(raw_counts_matrix))
+          expect_equal(delim, "\t")
+          expect_equal(ref_group_names, "reference")
+          annotations <- utils::read.delim(annotations_file, header = FALSE)
+          expect_equal(annotations[[2]], c("observation", "reference", "observation"))
+          genes <- utils::read.delim(gene_order_file, header = FALSE)
+          expect_equal(nrow(genes), nrow(gene_order))
+          list(cells = colnames(raw_counts_matrix))
+        })
+      }
+      if (identical(name, "run")) {
+        return(function(
+          infercnv_obj,
+          cutoff,
+          out_dir,
+          cluster_by_groups,
+          denoise,
+          HMM,
+          analysis_mode,
+          tumor_subcluster_partition_method,
+          plot_steps,
+          no_plot,
+          save_rds,
+          save_final_rds,
+          inspect_subclusters,
+          num_threads
+        ) {
+          expect_equal(cutoff, 0.1)
+          expect_true(dir.exists(out_dir))
+          expect_false(cluster_by_groups)
+          expect_false(denoise)
+          expect_false(HMM)
+          expect_identical(analysis_mode, "samples")
+          expect_identical(tumor_subcluster_partition_method, "qnorm")
+          expect_false(plot_steps)
+          expect_true(no_plot)
+          expect_false(save_rds)
+          expect_false(save_final_rds)
+          expect_false(inspect_subclusters)
+          expect_true(is.numeric(num_threads))
+          expect_true(num_threads >= 1)
+          matrix(
+            c(0.2, 0.1, 0, 0, 0.4, 0.3),
+            nrow = 2,
+            dimnames = list(c("seg1", "seg2"), infercnv_obj$cells)
+          )
+        })
+      }
+      stop(name)
+    }
+  )
+
+  extracted <- cnv_run_infercnv(
+    counts = counts,
+    reference.by = "celltype",
+    reference = "Normal",
+    reference_cells = "Cell2",
+    gene_order = gene_order,
+    output_dir = out_dir,
+    verbose = FALSE,
+    layer = "data",
+    assay = "RNA"
+  )
+
+  expect_equal(dim(extracted$cnv_matrix), c(2, 3))
+  expect_identical(colnames(extracted$cnv_matrix), colnames(srt))
+})
+
+test_that("backend argument filtering drops unsupported named arguments", {
+  out <- cnv_call_backend_fun(
+    function(a, b, ...) {
+      list(a = a, b = b, passthrough = list(...))
+    },
+    list(a = 1, b = 2, layer = "counts", assay = "RNA")
+  )
+
+  expect_equal(out$a, 1)
+  expect_equal(out$b, 2)
+  expect_equal(out$passthrough, list())
+})
+
 test_that("SCEVAN extraction reads CNA RData output and cell assignments", {
   srt <- make_cnv_seurat()
   out_dir <- tempfile("scevan_")


### PR DESCRIPTION
## Summary
- make infercnv default to a non-subcluster execution path (`analysis_mode = "samples"`, no denoise/HMM/plot/RDS writes) to avoid the slow Leiden tumor-subcluster step on large integrated objects
- disable infercnv resume/reference clustering/preliminary plot/probability plot/matrix/phylo writes by default so reruns do not reuse stale objects or spend time on outputs SCOP does not consume
- route copykat, fastCNV, SCEVAN, infercnv, numbat, and CaSpER backend calls through a shared argument filter so top-level passthrough arguments such as `layer` cannot leak into package backends
- add regression coverage for infercnv defaults, passthrough filtering, and all-backend prediction fallback standardization

## Why
The observed infercnv stall happens after it enters tumor subcluster/Leiden variance calculations. infercnv 1.28.0 adds more plotting, Seurat, HMM, and Leiden controls, but its heavy HMM/subcluster/Seurat metadata path should be opt-in for SCOP. The default `RunCNV()` path should finish predictably and let users explicitly opt into the full infercnv workflow through `...` when needed.

## Validation
- `Rscript -e "pkgload::load_all('.', quiet=TRUE); testthat::test_file('tests/testthat/test-cnv.R')"` -> `FAIL 0 | WARN 0 | SKIP 0 | PASS 107`
- fastCNV RDS smoke from the previous revision: standardized matrix `217 x 300`, predictions `aneuploid 239`, `diploid 61`
- `git diff --check`