### PR TITLE
Clean up spatial examples

### DIFF
--- a/R/GiottoObject.R
+++ b/R/GiottoObject.R
@@ -121,11 +121,7 @@ giotto_do_call <- function(name, args) {
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:300]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' g <- structure(
 #'   list(
 #'     giotto = list(
@@ -425,11 +421,7 @@ giotto_validate_runtime_object <- function(x, verbose = TRUE) {
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:300]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' g <- structure(
 #'   list(
 #'     source = list(
@@ -691,7 +683,7 @@ RunGiottoWorkflow <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(visium_human_pancreas_sub, cells = colnames(visium_human_pancreas_sub)[1:60])
+#' spatial <- visium_human_pancreas_sub
 #' g <- structure(
 #'   list(
 #'     source = list(
@@ -846,11 +838,7 @@ GiottoPreprocess <- function(
 #' @return A `giotto2` workflow object.
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:200]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' embedding <- cbind(
 #'   UMAP_1 = as.numeric(scale(spatial$x)),
 #'   UMAP_2 = as.numeric(scale(spatial$y))
@@ -980,11 +968,7 @@ GiottoReduce <- function(
 #' @return A `giotto2` workflow object.
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:200]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' coords <- data.frame(
 #'   cell_ID = colnames(spatial),
 #'   sdimx = spatial$x,
@@ -1121,11 +1105,7 @@ GiottoCluster <- function(
 #' @return A `giotto2` workflow object.
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:200]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' coords <- data.frame(
 #'   cell_ID = colnames(spatial),
 #'   sdimx = spatial$x,
@@ -1231,11 +1211,7 @@ giotto_get_spatial_network_table <- function(gobject, network_name, spat_unit = 
 #' @return A `giotto2` workflow object.
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:200]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' coords <- data.frame(
 #'   cell_ID = colnames(spatial),
 #'   sdimx = spatial$x,
@@ -1351,11 +1327,7 @@ GiottoSpatialGenes <- function(
 #' @return A `giotto2` workflow object.
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:200]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' features <- rownames(spatial)[1:6]
 #' module_table <- expand.grid(
 #'   feat_ID = features,
@@ -1496,11 +1468,7 @@ GiottoSpatialModules <- function(
 #'     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
 #' ) {
 #'   data(visium_human_pancreas_sub)
-#'   spatial <- subset(
-#'     visium_human_pancreas_sub,
-#'     cells = colnames(visium_human_pancreas_sub)[1:80],
-#'     features = rownames(visium_human_pancreas_sub)[1:200]
-#'   )
+#'   spatial <- visium_human_pancreas_sub
 #'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
 #'   g <- GiottoSpatialNetwork(g)
 #'   g <- GiottoCellProximity(g, group.by = "coda_label", number_of_simulations = 100)
@@ -1579,11 +1547,7 @@ GiottoCellProximity <- function(
 #' @return A `giotto2` workflow object.
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:200]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' coords <- data.frame(
 #'   cell_ID = colnames(spatial),
 #'   sdimx = spatial$x,
@@ -1725,11 +1689,7 @@ giotto_ensure_spatial_network <- function(x, network_method = "Delaunay", networ
 #' @return A Seurat object.
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:200]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' g <- structure(
 #'   list(
 #'     source = list(cells = colnames(spatial)),

--- a/R/GiottoPlot.R
+++ b/R/GiottoPlot.R
@@ -13,11 +13,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:300]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' cluster_result <- list(
 #'   clusters = data.frame(
 #'     cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) %% 3 + 1),

--- a/R/RunBANKSY.R
+++ b/R/RunBANKSY.R
@@ -43,11 +43,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial$BANKSY_cluster <- factor(
 #'   paste0("BANKSY", (seq_len(ncol(spatial)) - 1) %% 3 + 1)
 #' )

--- a/R/RunBayesSpace.R
+++ b/R/RunBayesSpace.R
@@ -29,11 +29,7 @@
 #' @export
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial$BayesSpace_cluster <- factor(
 #'   paste0("domain_", (seq_len(ncol(spatial)) - 1) %% 3 + 1)
 #' )

--- a/R/RunCARD.R
+++ b/R/RunCARD.R
@@ -25,11 +25,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' card_weights <- data.frame(
 #'   CARD_prop_Ductal = seq(0.70, 0.20, length.out = ncol(spatial)),
 #'   CARD_prop_Endocrine = seq(0.20, 0.70, length.out = ncol(spatial)),

--- a/R/RunCNV.R
+++ b/R/RunCNV.R
@@ -73,24 +73,8 @@
 #'   gene_order = gene_order
 #' )
 #'
-#' # Numbat and CaSpER require allele-aware inputs from matched DNA/allele
-#' # preprocessing workflows.
-#' srt <- RunCNV(
-#'   srt,
-#'   method = "numbat",
-#'   allele_counts = df_allele,
-#'   reference_counts = lambdas_ref,
-#'   genome = "hg38"
-#' )
-#' srt <- RunCNV(
-#'   srt,
-#'   method = "casper",
-#'   reference.by = "celltype",
-#'   reference = "Normal",
-#'   gene_order = gene_order,
-#'   loh = baf_signal,
-#'   cytoband = cytoband_hg38
-#' )
+#' # Numbat and CaSpER can also be run when allele-aware preprocessing
+#' # outputs are available.
 #'
 #' CNVPlot(srt, plot_type = "heatmap", group.by = "CNV_prediction")
 #' CNVPlot(srt, plot_type = "dim", value = "CNV_prediction")

--- a/R/RunCSIDE.R
+++ b/R/RunCSIDE.R
@@ -41,11 +41,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial$region <- ifelse(spatial$x > stats::median(spatial$x), "right", "left")
 #' spatial$CSIDE_n_sig <- ifelse(spatial$region == "right", 12, 4)
 #' spatial$CSIDE_mode <- "regions"

--- a/R/RunGiottoCluster.R
+++ b/R/RunGiottoCluster.R
@@ -33,11 +33,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' giotto_clusters <- list(
 #'   clusters = data.frame(
 #'     cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) %% 3 + 1),

--- a/R/RunGiottoSpatialMethods.R
+++ b/R/RunGiottoSpatialMethods.R
@@ -24,11 +24,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial$region <- ifelse(
 #'   spatial$x > stats::median(spatial$x),
 #'   "right",
@@ -213,11 +209,7 @@ RunGiottoCellProximity <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' giotto_genes <- list(
 #'   results = data.frame(
@@ -418,11 +410,7 @@ RunGiottoSpatialGenes <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' module_features <- rownames(spatial)[1:4]
 #' module_cor <- expand.grid(
 #'   feat_ID = module_features,

--- a/R/RunMERINGUE.R
+++ b/R/RunMERINGUE.R
@@ -26,11 +26,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' spatial@misc[["MERINGUEFeatures"]] <- rownames(spatial)[1:4]
 #' spatial@tools[["MERINGUE"]] <- list(

--- a/R/RunMistyR.R
+++ b/R/RunMistyR.R
@@ -42,11 +42,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:40]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #'
 #' if (

--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -42,11 +42,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' rctd_weights <- data.frame(
 #'   RCTD_prop_Ductal = seq(0.75, 0.15, length.out = ncol(spatial)),
 #'   RCTD_prop_Endocrine = seq(0.15, 0.65, length.out = ncol(spatial)),

--- a/R/RunSPOTlight.R
+++ b/R/RunSPOTlight.R
@@ -27,11 +27,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spotlight_weights <- data.frame(
 #'   SPOTlight_prop_Ductal = seq(0.70, 0.20, length.out = ncol(spatial)),
 #'   SPOTlight_prop_Endocrine = seq(0.20, 0.70, length.out = ncol(spatial)),

--- a/R/RunSTdeconvolve.R
+++ b/R/RunSTdeconvolve.R
@@ -30,11 +30,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' topic_weights <- data.frame(
 #'   STdeconvolve_prop_topic_1 = seq(0.75, 0.20, length.out = ncol(spatial)),
 #'   STdeconvolve_prop_topic_2 = seq(0.20, 0.70, length.out = ncol(spatial)),
@@ -231,11 +227,7 @@ RunSTdeconvolve <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' topic_weights <- data.frame(
 #'   STdeconvolve_prop_topic_1 = seq(0.75, 0.20, length.out = ncol(spatial)),
 #'   STdeconvolve_prop_topic_2 = seq(0.20, 0.70, length.out = ncol(spatial)),

--- a/R/RunSemla.R
+++ b/R/RunSemla.R
@@ -23,11 +23,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial@tools$SemlaSpatialNetwork <- list(
 #'   network = data.frame(
 #'     from = colnames(spatial)[1:6],
@@ -129,11 +125,7 @@ RunSemlaSpatialNetwork <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' features <- rownames(spatial)[1:3]
 #' spatial[[paste0(features[1], "_localG")]] <- as.numeric(scale(spatial$x))
@@ -204,11 +196,7 @@ RunSemlaLocalG <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial$region <- ifelse(
 #'   spatial$x > stats::median(spatial$x),
 #'   "right",
@@ -285,11 +273,7 @@ RunSemlaRegionNeighbors <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial$region <- ifelse(
 #'   spatial$y > stats::median(spatial$y),
 #'   "upper",

--- a/R/RunSmoothClust.R
+++ b/R/RunSmoothClust.R
@@ -44,11 +44,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial$SmoothClust_cluster <- factor(
 #'   paste0("SmoothClust", (seq_len(ncol(spatial)) - 1) %% 3 + 1)
 #' )

--- a/R/RunSpaNorm.R
+++ b/R/RunSpaNorm.R
@@ -21,11 +21,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:300]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #'
 #' SpatialSpotPlot(

--- a/R/RunSpatialEcoTyper.R
+++ b/R/RunSpatialEcoTyper.R
@@ -84,11 +84,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' srt <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' srt <- visium_human_pancreas_sub
 #' srt$CellType <- srt$coda_label
 #' srt$SpatialEcoTyper_SE <- ifelse(srt$x > stats::median(srt$x), "SE1", "SE2")
 #' srt$sample <- ifelse(srt$y > stats::median(srt$y), "slice_a", "slice_b")

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -58,11 +58,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial <- RunSpatialGradientFeatures(
 #'   spatial,
 #'   reference = "trajectory",

--- a/R/RunSpatialIntegration.R
+++ b/R/RunSpatialIntegration.R
@@ -26,11 +26,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial$sample <- ifelse(spatial$y > stats::median(spatial$y), "slice_a", "slice_b")
 #' spatial$SpatialIntegration_PRECAST_domain <- factor(
 #'   paste0("domain_", (seq_len(ncol(spatial)) - 1) %% 3 + 1)
@@ -197,11 +193,7 @@ RunSpatialIntegration <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial$sample <- ifelse(spatial$y > stats::median(spatial$y), "slice_a", "slice_b")
 #' spatial$SpatialIntegration_PRECAST_domain <- factor(
 #'   paste0("domain_", (seq_len(ncol(spatial)) - 1) %% 3 + 1)

--- a/R/RunSpatialNeighborhood.R
+++ b/R/RunSpatialNeighborhood.R
@@ -37,11 +37,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial <- RunSpatialNeighborhood(
 #'   spatial,
 #'   group.by = "coda_label",
@@ -229,11 +225,7 @@ RunSpatialNeighborhood <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial <- RunSpatialNeighborhood(
 #'   spatial,
 #'   group.by = "coda_label",

--- a/R/RunSpatialQM.R
+++ b/R/RunSpatialQM.R
@@ -37,11 +37,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:80],
-#'   features = rownames(visium_human_pancreas_sub)[1:300]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #'
 #' if (
 #'   requireNamespace("SpatialQM", quietly = TRUE) &&

--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -51,11 +51,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #' spatial$SpotSweeper_QC <- factor(
 #'   ifelse(seq_len(ncol(spatial)) %% 9 == 0, "Fail", "Pass"),
 #'   levels = c("Pass", "Fail")

--- a/R/RunStatialKontextual.R
+++ b/R/RunStatialKontextual.R
@@ -40,11 +40,7 @@
 #'
 #' @examples
 #' data(visium_human_pancreas_sub)
-#' spatial <- subset(
-#'   visium_human_pancreas_sub,
-#'   cells = colnames(visium_human_pancreas_sub)[1:120],
-#'   features = rownames(visium_human_pancreas_sub)[1:400]
-#' )
+#' spatial <- visium_human_pancreas_sub
 #'
 #' if (
 #'   requireNamespace("Statial", quietly = TRUE) &&

--- a/man/AddGiottoToSeurat.Rd
+++ b/man/AddGiottoToSeurat.Rd
@@ -36,11 +36,7 @@ Add Giotto results back to Seurat
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:200]
-)
+spatial <- visium_human_pancreas_sub
 g <- structure(
   list(
     source = list(cells = colnames(spatial)),

--- a/man/GiottoCellProximity.Rd
+++ b/man/GiottoCellProximity.Rd
@@ -62,11 +62,7 @@ if (
     identical(Sys.getenv("SCOP_RUN_SPATIAL_BACKEND_EXAMPLES"), "true")
 ) {
   data(visium_human_pancreas_sub)
-  spatial <- subset(
-    visium_human_pancreas_sub,
-    cells = colnames(visium_human_pancreas_sub)[1:80],
-    features = rownames(visium_human_pancreas_sub)[1:200]
-  )
+  spatial <- visium_human_pancreas_sub
   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
   g <- GiottoSpatialNetwork(g)
   g <- GiottoCellProximity(g, group.by = "coda_label", number_of_simulations = 100)

--- a/man/GiottoCluster.Rd
+++ b/man/GiottoCluster.Rd
@@ -46,11 +46,7 @@ Run Giotto nearest-network clustering
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:200]
-)
+spatial <- visium_human_pancreas_sub
 coords <- data.frame(
   cell_ID = colnames(spatial),
   sdimx = spatial$x,

--- a/man/GiottoHMRF.Rd
+++ b/man/GiottoHMRF.Rd
@@ -43,11 +43,7 @@ Run Giotto HMRF spatial domains
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:200]
-)
+spatial <- visium_human_pancreas_sub
 coords <- data.frame(
   cell_ID = colnames(spatial),
   sdimx = spatial$x,

--- a/man/GiottoPlot.Rd
+++ b/man/GiottoPlot.Rd
@@ -150,11 +150,7 @@ is not modified.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:300]
-)
+spatial <- visium_human_pancreas_sub
 cluster_result <- list(
   clusters = data.frame(
     cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1),

--- a/man/GiottoPreprocess.Rd
+++ b/man/GiottoPreprocess.Rd
@@ -37,7 +37,7 @@ Preprocess an internal Giotto workflow object
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(visium_human_pancreas_sub, cells = colnames(visium_human_pancreas_sub)[1:60])
+spatial <- visium_human_pancreas_sub
 g <- structure(
   list(
     source = list(

--- a/man/GiottoReduce.Rd
+++ b/man/GiottoReduce.Rd
@@ -40,11 +40,7 @@ Run Giotto dimensional reduction
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:200]
-)
+spatial <- visium_human_pancreas_sub
 embedding <- cbind(
   UMAP_1 = as.numeric(scale(spatial$x)),
   UMAP_2 = as.numeric(scale(spatial$y))

--- a/man/GiottoSpatialGenes.Rd
+++ b/man/GiottoSpatialGenes.Rd
@@ -43,11 +43,7 @@ Run Giotto spatial gene detection
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:200]
-)
+spatial <- visium_human_pancreas_sub
 coords <- data.frame(
   cell_ID = colnames(spatial),
   sdimx = spatial$x,

--- a/man/GiottoSpatialModules.Rd
+++ b/man/GiottoSpatialModules.Rd
@@ -48,11 +48,7 @@ Run Giotto spatial co-expression modules
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:200]
-)
+spatial <- visium_human_pancreas_sub
 features <- rownames(spatial)[1:6]
 module_table <- expand.grid(
   feat_ID = features,

--- a/man/GiottoSpatialNetwork.Rd
+++ b/man/GiottoSpatialNetwork.Rd
@@ -31,11 +31,7 @@ Create a Giotto spatial network
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:200]
-)
+spatial <- visium_human_pancreas_sub
 coords <- data.frame(
   cell_ID = colnames(spatial),
   sdimx = spatial$x,

--- a/man/RunBANKSY.Rd
+++ b/man/RunBANKSY.Rd
@@ -107,11 +107,7 @@ and store spatial domain or microenvironment clusters in metadata.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial$BANKSY_cluster <- factor(
   paste0("BANKSY", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1)
 )

--- a/man/RunBayesSpace.Rd
+++ b/man/RunBayesSpace.Rd
@@ -76,11 +76,7 @@ Run BayesSpace spatial clustering
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial$BayesSpace_cluster <- factor(
   paste0("domain_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1)
 )

--- a/man/RunCARD.Rd
+++ b/man/RunCARD.Rd
@@ -93,11 +93,7 @@ backend.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 card_weights <- data.frame(
   CARD_prop_Ductal = seq(0.70, 0.20, length.out = ncol(spatial)),
   CARD_prop_Endocrine = seq(0.20, 0.70, length.out = ncol(spatial)),

--- a/man/RunCNV.Rd
+++ b/man/RunCNV.Rd
@@ -123,24 +123,8 @@ srt <- RunCNV(
   gene_order = gene_order
 )
 
-# Numbat and CaSpER require allele-aware inputs from matched DNA/allele
-# preprocessing workflows.
-srt <- RunCNV(
-  srt,
-  method = "numbat",
-  allele_counts = df_allele,
-  reference_counts = lambdas_ref,
-  genome = "hg38"
-)
-srt <- RunCNV(
-  srt,
-  method = "casper",
-  reference.by = "celltype",
-  reference = "Normal",
-  gene_order = gene_order,
-  loh = baf_signal,
-  cytoband = cytoband_hg38
-)
+# Numbat and CaSpER can also be run when allele-aware preprocessing
+# outputs are available.
 
 CNVPlot(srt, plot_type = "heatmap", group.by = "CNV_prediction")
 CNVPlot(srt, plot_type = "dim", value = "CNV_prediction")

--- a/man/RunCSIDE.Rd
+++ b/man/RunCSIDE.Rd
@@ -88,11 +88,7 @@ condition-aware differential expression.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial$region <- ifelse(spatial$x > stats::median(spatial$x), "right", "left")
 spatial$CSIDE_n_sig <- ifelse(spatial$region == "right", 12, 4)
 spatial$CSIDE_mode <- "regions"

--- a/man/RunGiottoCellProximity.Rd
+++ b/man/RunGiottoCellProximity.Rd
@@ -84,11 +84,7 @@ is not modified.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial$region <- ifelse(
   spatial$x > stats::median(spatial$x),
   "right",

--- a/man/RunGiottoCluster.Rd
+++ b/man/RunGiottoCluster.Rd
@@ -89,11 +89,7 @@ the complete Giotto object together with extracted cluster results. The input
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 giotto_clusters <- list(
   clusters = data.frame(
     cluster = paste0("cluster_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1),

--- a/man/RunGiottoSpatialGenes.Rd
+++ b/man/RunGiottoSpatialGenes.Rd
@@ -88,11 +88,7 @@ standalone result; the input \code{Seurat} object is not modified.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 giotto_genes <- list(
   results = data.frame(

--- a/man/RunGiottoSpatialModules.Rd
+++ b/man/RunGiottoSpatialModules.Rd
@@ -91,11 +91,7 @@ result; the input \code{Seurat} object is not modified.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 module_features <- rownames(spatial)[1:4]
 module_cor <- expand.grid(
   feat_ID = module_features,

--- a/man/RunGiottoWorkflow.Rd
+++ b/man/RunGiottoWorkflow.Rd
@@ -49,11 +49,7 @@ converted first with [SeuratToScopGiotto()].
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:300]
-)
+spatial <- visium_human_pancreas_sub
 g <- structure(
   list(
     source = list(

--- a/man/RunMERINGUE.Rd
+++ b/man/RunMERINGUE.Rd
@@ -98,11 +98,7 @@ spatial module analysis for a spatial \code{Seurat} object.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 spatial@misc[["MERINGUEFeatures"]] <- rownames(spatial)[1:4]
 spatial@tools[["MERINGUE"]] <- list(

--- a/man/RunMistyR.Rd
+++ b/man/RunMistyR.Rd
@@ -91,11 +91,7 @@ context. \code{mistyR} is an optional Bioconductor dependency installable with
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:40]
-)
+spatial <- visium_human_pancreas_sub
 spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 
 if (

--- a/man/RunRCTD.Rd
+++ b/man/RunRCTD.Rd
@@ -88,11 +88,7 @@ using a single-cell \code{Seurat} reference and \code{spacexr} RCTD.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 rctd_weights <- data.frame(
   RCTD_prop_Ductal = seq(0.75, 0.15, length.out = ncol(spatial)),
   RCTD_prop_Endocrine = seq(0.15, 0.65, length.out = ncol(spatial)),

--- a/man/RunSPOTlight.Rd
+++ b/man/RunSPOTlight.Rd
@@ -83,11 +83,7 @@ using a single-cell \code{Seurat} reference and the optional \code{SPOTlight} pa
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spotlight_weights <- data.frame(
   SPOTlight_prop_Ductal = seq(0.70, 0.20, length.out = ncol(spatial)),
   SPOTlight_prop_Endocrine = seq(0.20, 0.70, length.out = ncol(spatial)),

--- a/man/RunSTdeconvolve.Rd
+++ b/man/RunSTdeconvolve.Rd
@@ -81,11 +81,7 @@ the optional \code{STdeconvolve} package.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 topic_weights <- data.frame(
   STdeconvolve_prop_topic_1 = seq(0.75, 0.20, length.out = ncol(spatial)),
   STdeconvolve_prop_topic_2 = seq(0.20, 0.70, length.out = ncol(spatial)),

--- a/man/RunSemlaLocalG.Rd
+++ b/man/RunSemlaLocalG.Rd
@@ -45,11 +45,7 @@ written by semla to metadata or to an assay, depending on
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 features <- rownames(spatial)[1:3]
 spatial[[paste0(features[1], "_localG")]] <- as.numeric(scale(spatial$x))

--- a/man/RunSemlaRadialDistance.Rd
+++ b/man/RunSemlaRadialDistance.Rd
@@ -41,11 +41,7 @@ regions and write the returned columns to Seurat metadata.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial$region <- ifelse(
   spatial$y > stats::median(spatial$y),
   "upper",

--- a/man/RunSemlaRegionNeighbors.Rd
+++ b/man/RunSemlaRegionNeighbors.Rd
@@ -44,11 +44,7 @@ metadata labels and write the returned columns to Seurat metadata.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial$region <- ifelse(
   spatial$x > stats::median(spatial$x),
   "right",

--- a/man/RunSemlaSpatialNetwork.Rd
+++ b/man/RunSemlaSpatialNetwork.Rd
@@ -51,11 +51,7 @@ in \code{srt@tools[[tool_name]]} when \code{store_results = TRUE}.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial@tools$SemlaSpatialNetwork <- list(
   network = data.frame(
     from = colnames(spatial)[1:6],

--- a/man/RunSmoothClust.Rd
+++ b/man/RunSmoothClust.Rd
@@ -98,11 +98,7 @@ domains with PCA and k-means.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial$SmoothClust_cluster <- factor(
   paste0("SmoothClust", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1)
 )

--- a/man/RunSpaNorm.Rd
+++ b/man/RunSpaNorm.Rd
@@ -60,11 +60,7 @@ Normalize spatial transcriptomics counts with the optional Bioconductor
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:300]
-)
+spatial <- visium_human_pancreas_sub
 spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 
 SpatialSpotPlot(

--- a/man/RunSpatialEcoTyper.Rd
+++ b/man/RunSpatialEcoTyper.Rd
@@ -179,11 +179,7 @@ object when possible.
 }
 \examples{
 data(visium_human_pancreas_sub)
-srt <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+srt <- visium_human_pancreas_sub
 srt$CellType <- srt$coda_label
 srt$SpatialEcoTyper_SE <- ifelse(srt$x > stats::median(srt$x), "SE1", "SE2")
 srt$sample <- ifelse(srt$y > stats::median(srt$y), "slice_a", "slice_b")

--- a/man/RunSpatialGradientFeatures.Rd
+++ b/man/RunSpatialGradientFeatures.Rd
@@ -141,11 +141,7 @@ is never stored.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial <- RunSpatialGradientFeatures(
   spatial,
   reference = "trajectory",

--- a/man/RunSpatialIntegration.Rd
+++ b/man/RunSpatialIntegration.Rd
@@ -72,11 +72,7 @@ aligned coordinates in a \code{Seurat} object.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial$sample <- ifelse(spatial$y > stats::median(spatial$y), "slice_a", "slice_b")
 spatial$SpatialIntegration_PRECAST_domain <- factor(
   paste0("domain_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1)

--- a/man/RunSpatialNeighborhood.Rd
+++ b/man/RunSpatialNeighborhood.Rd
@@ -81,11 +81,7 @@ to a supported backend for colocalization or local-effect statistics.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial <- RunSpatialNeighborhood(
   spatial,
   group.by = "coda_label",

--- a/man/RunSpatialQM.Rd
+++ b/man/RunSpatialQM.Rd
@@ -66,11 +66,7 @@ installable with \code{remotes::install_github("Center-for-Spatial-OMICs/Spatial
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:300]
-)
+spatial <- visium_human_pancreas_sub
 
 if (
   requireNamespace("SpatialQM", quietly = TRUE) &&

--- a/man/RunSpotSweeper.Rd
+++ b/man/RunSpotSweeper.Rd
@@ -106,11 +106,7 @@ visualized with \code{\link[=SpatialSpotPlot]{SpatialSpotPlot()}}.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial$SpotSweeper_QC <- factor(
   ifelse(seq_len(ncol(spatial)) \%\% 9 == 0, "Fail", "Pass"),
   levels = c("Pass", "Fail")

--- a/man/RunStatialKontextual.Rd
+++ b/man/RunStatialKontextual.Rd
@@ -87,11 +87,7 @@ dependency installable with \code{BiocManager::install("Statial")}.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 
 if (
   requireNamespace("Statial", quietly = TRUE) &&

--- a/man/STdeconvolvePlot.Rd
+++ b/man/STdeconvolvePlot.Rd
@@ -37,11 +37,7 @@ Plot STdeconvolve topic proportions
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 topic_weights <- data.frame(
   STdeconvolve_prop_topic_1 = seq(0.75, 0.20, length.out = ncol(spatial)),
   STdeconvolve_prop_topic_2 = seq(0.20, 0.70, length.out = ncol(spatial)),

--- a/man/SeuratToScopGiotto.Rd
+++ b/man/SeuratToScopGiotto.Rd
@@ -67,11 +67,7 @@ Seurat object is not modified.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:80],
-  features = rownames(visium_human_pancreas_sub)[1:300]
-)
+spatial <- visium_human_pancreas_sub
 g <- structure(
   list(
     giotto = list(

--- a/man/SpatialIntegrationPlot.Rd
+++ b/man/SpatialIntegrationPlot.Rd
@@ -78,11 +78,7 @@ Visualize standardized results produced by \code{\link[=RunSpatialIntegration]{R
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial$sample <- ifelse(spatial$y > stats::median(spatial$y), "slice_a", "slice_b")
 spatial$SpatialIntegration_PRECAST_domain <- factor(
   paste0("domain_", (seq_len(ncol(spatial)) - 1) \%\% 3 + 1)

--- a/man/SpatialNeighborhoodPlot.Rd
+++ b/man/SpatialNeighborhoodPlot.Rd
@@ -126,11 +126,7 @@ statistical, and network plotting conventions.
 }
 \examples{
 data(visium_human_pancreas_sub)
-spatial <- subset(
-  visium_human_pancreas_sub,
-  cells = colnames(visium_human_pancreas_sub)[1:120],
-  features = rownames(visium_human_pancreas_sub)[1:400]
-)
+spatial <- visium_human_pancreas_sub
 spatial <- RunSpatialNeighborhood(
   spatial,
   group.by = "coda_label",


### PR DESCRIPTION
## Summary

- replace object-level `subset(visium_human_pancreas_sub, ...)` examples with direct use of the bundled object
- trim CNV examples that referenced undefined allele-aware inputs
- keep this PR limited to examples and Rd files; no API defaults, dependency metadata, or plotting behavior changes

## Validation

- `git diff --check`
- `tools::checkRd('man/RunCNV.Rd')`
- rendered `vignettes/articles/spatial-main-workflow.Rmd` locally