### PR TITLE
Handle empty spatial neighborhood plots

### DIFF
--- a/R/RunSpatialNeighborhood.R
+++ b/R/RunSpatialNeighborhood.R
@@ -327,10 +327,12 @@ SpatialNeighborhoodPlot <- function(
     condition = condition
   )
   if (nrow(df) == 0L) {
-    log_message(
+    return(scop_spatial_empty_plot(
       "No spatial neighborhood records remain after filtering",
-      message_type = "error"
-    )
+      title = legend.title %||% value,
+      theme_use = theme_use,
+      theme_args = theme_args
+    ))
   }
   df <- spatial_neighborhood_prepare_plot_table(
     df = df,

--- a/tests/testthat/test-spatial-neighborhood.R
+++ b/tests/testthat/test-spatial-neighborhood.R
@@ -109,6 +109,12 @@ test_that("SpatialNeighborhoodPlot returns scop-style ggplot objects", {
   p_heatmap <- SpatialNeighborhoodPlot(srt, plot_type = "heatmap", theme_use = NULL)
   p_stat <- SpatialNeighborhoodPlot(srt, plot_type = "stat", theme_use = NULL)
   p_network <- SpatialNeighborhoodPlot(srt, plot_type = "network", theme_use = NULL)
+  p_empty <- SpatialNeighborhoodPlot(
+    srt,
+    plot_type = "heatmap",
+    comparison = "missing",
+    theme_use = NULL
+  )
   p_spatial <- SpatialNeighborhoodPlot(
     srt,
     plot_type = "spatial",
@@ -121,6 +127,7 @@ test_that("SpatialNeighborhoodPlot returns scop-style ggplot objects", {
   expect_s3_class(p_heatmap, "ggplot")
   expect_s3_class(p_stat, "ggplot")
   expect_s3_class(p_network, "ggplot")
+  expect_s3_class(p_empty, "ggplot")
   expect_s3_class(p_spatial, "ggplot")
 })
 


### PR DESCRIPTION
## Summary

- return an empty ggplot when `SpatialNeighborhoodPlot()` filters to no records
- add a focused test that the empty filtered heatmap path still returns a ggplot
- keep this PR limited to neighborhood plot empty-state behavior

## Validation

- `git diff --check`
- `Rscript -e "devtools::load_all('.', quiet = TRUE); testthat::test_file('tests/testthat/test-spatial-neighborhood.R')"`