### PR TITLE
Clean up spatial examples

### DIFF
--- a/R/GiottoObject.R
+++ b/R/GiottoObject.R
@@ -161,9 +161,6 @@ giotto_do_call <- function(name, args) {
 #' GiottoPlot(g, plot_type = "cluster")
 #' GiottoPlot(g, plot_type = "network")
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #' g <- SeuratToScopGiotto(
 #'   spatial,
 #'   assay = "Spatial",
@@ -171,7 +168,6 @@ giotto_do_call <- function(name, args) {
 #'   coord.cols = c("x", "y"),
 #'   verbose = FALSE
 #' )
-#' }
 #' @export
 SeuratToScopGiotto <- function(
   srt,
@@ -446,9 +442,6 @@ giotto_validate_runtime_object <- function(x, verbose = TRUE) {
 #' )
 #' GiottoPlot(g, plot_type = "cluster")
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #' g <- RunGiottoWorkflow(
 #'   spatial,
 #'   steps = "basic",
@@ -458,7 +451,6 @@ giotto_validate_runtime_object <- function(x, verbose = TRUE) {
 #'   return_seurat = FALSE,
 #'   verbose = FALSE
 #' )
-#' }
 #' @export
 RunGiottoWorkflow <- function(
   x,
@@ -696,12 +688,8 @@ RunGiottoWorkflow <- function(
 #' )
 #' GiottoPlot(g, plot_type = "spatial")
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #' g <- SeuratToScopGiotto(spatial, assay = "Spatial", coord.cols = c("x", "y"), verbose = FALSE)
 #' g <- GiottoPreprocess(g, verbose = FALSE)
-#' }
 #' @export
 GiottoPreprocess <- function(
   x,
@@ -860,14 +848,10 @@ GiottoPreprocess <- function(
 #' )
 #' GiottoPlot(g, plot_type = "dim")
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
 #'   g <- GiottoPreprocess(g)
 #'   g <- GiottoReduce(g, reduction = "pca", dims = 1:10)
 #'   g <- GiottoReduce(g, reduction = "umap", dims = 1:10)
-#' }
 #' @export
 GiottoReduce <- function(
   x,
@@ -989,14 +973,10 @@ GiottoReduce <- function(
 #' )
 #' GiottoPlot(g, plot_type = "cluster")
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
 #'   g <- GiottoPreprocess(g)
 #'   g <- GiottoReduce(g, reduction = "pca", dims = 1:10)
 #'   g <- GiottoCluster(g, dims = 1:10, k = 8, resolution = 0.4)
-#' }
 #' @export
 GiottoCluster <- function(
   x,
@@ -1120,12 +1100,8 @@ GiottoCluster <- function(
 #' )
 #' GiottoPlot(g, plot_type = "network")
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
 #'   g <- GiottoSpatialNetwork(g, network_method = "Delaunay")
-#' }
 #' @export
 GiottoSpatialNetwork <- function(
   x,
@@ -1231,14 +1207,10 @@ giotto_get_spatial_network_table <- function(gobject, network_name, spat_unit = 
 #' )
 #' GiottoPlot(g, plot_type = "spatial_genes", top_n = 6)
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
 #'   g <- GiottoPreprocess(g)
 #'   g <- GiottoSpatialNetwork(g)
 #'   g <- GiottoSpatialGenes(g, features = rownames(spatial)[1:50], top_n = 10)
-#' }
 #' @export
 GiottoSpatialGenes <- function(
   x,
@@ -1342,14 +1314,10 @@ GiottoSpatialGenes <- function(
 #' )
 #' GiottoPlot(g, plot_type = "spatial_modules", top_n = 6)
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
 #'   g <- GiottoPreprocess(g)
 #'   g <- GiottoSpatialNetwork(g)
 #'   g <- GiottoSpatialModules(g, features = rownames(spatial)[1:50], k = 3)
-#' }
 #' @export
 GiottoSpatialModules <- function(
   x,
@@ -1455,15 +1423,11 @@ GiottoSpatialModules <- function(
 #' )
 #' GiottoPlot(g, plot_type = "cell_proximity")
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #'   data(visium_human_pancreas_sub)
 #'   spatial <- visium_human_pancreas_sub
 #'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
 #'   g <- GiottoSpatialNetwork(g)
 #'   g <- GiottoCellProximity(g, group.by = "coda_label", number_of_simulations = 100)
-#' }
 #' @export
 GiottoCellProximity <- function(
   x,
@@ -1564,14 +1528,10 @@ GiottoCellProximity <- function(
 #' )
 #' GiottoPlot(g, plot_type = "hmrf")
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #'   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
 #'   g <- GiottoPreprocess(g)
 #'   g <- GiottoSpatialNetwork(g)
 #'   g <- GiottoHMRF(g, spatial_genes = rownames(spatial)[1:30], k = 4)
-#' }
 #' @export
 GiottoHMRF <- function(
   x,

--- a/R/RunBANKSY.R
+++ b/R/RunBANKSY.R
@@ -55,9 +55,6 @@
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   requireNamespace("Banksy", quietly = TRUE)
-#' ) {
 #' spatial <- RunBANKSY(
 #'   spatial,
 #'   assay = "Spatial",
@@ -69,7 +66,6 @@
 #'   resolution = 0.6,
 #'   verbose = FALSE
 #' )
-#' }
 RunBANKSY <- function(
   srt,
   assay = NULL,

--- a/R/RunBayesSpace.R
+++ b/R/RunBayesSpace.R
@@ -41,9 +41,6 @@
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   requireNamespace("BayesSpace", quietly = TRUE)
-#' ) {
 #' spatial <- RunBayesSpace(
 #'   spatial,
 #'   q = 3,
@@ -58,7 +55,6 @@
 #'   )
 #' )
 #' table(spatial$BayesSpace_cluster)
-#' }
 RunBayesSpace <- function(
   srt,
   q,

--- a/R/RunCARD.R
+++ b/R/RunCARD.R
@@ -47,7 +47,6 @@
 #'   overlay_image = FALSE,
 #'   coord.cols = c("x", "y")
 #' )
-#' if (requireNamespace("scatterpie", quietly = TRUE)) {
 #'   SpatialSpotPlot(
 #'     spatial,
 #'     group.by = "CARD_dominant_type",
@@ -55,12 +54,7 @@
 #'     overlay_image = FALSE,
 #'     coord.cols = c("x", "y")
 #'   )
-#' }
 #'
-#' if (
-#'   (isTRUE(check_r("CARD", verbose = FALSE)) ||
-#'     isTRUE(check_r("CARDspa", verbose = FALSE)))
-#' ) {
 #' data(pancreas_sub)
 #' features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
 #' spatial <- RunCARD(
@@ -72,7 +66,6 @@
 #'   features = features_use,
 #'   verbose = FALSE
 #' )
-#' }
 RunCARD <- function(
   srt,
   reference,

--- a/R/RunCSIDE.R
+++ b/R/RunCSIDE.R
@@ -76,11 +76,6 @@
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("dmcable/spacexr", verbose = FALSE)) &&
-#'     !is.null(spatial@tools$RCTD) &&
-#'     inherits(spatial@tools$RCTD$object, "RCTD")
-#' ) {
 #'   spatial <- RunCSIDE(
 #'     spatial,
 #'     group.by = "region",
@@ -88,7 +83,6 @@
 #'     gene_threshold = 0.00005,
 #'     cell_type_threshold = 125
 #'   )
-#' }
 RunCSIDE <- function(
   srt,
   rctd_result = NULL,

--- a/R/RunGiottoCluster.R
+++ b/R/RunGiottoCluster.R
@@ -55,9 +55,6 @@
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' spatial <- Seurat::FindVariableFeatures(
 #'   spatial,
@@ -76,7 +73,6 @@
 #' )
 #'
 #' head(giotto_clusters$clusters)
-#' }
 #'
 #' @export
 RunGiottoCluster <- function(

--- a/R/RunGiottoSpatialMethods.R
+++ b/R/RunGiottoSpatialMethods.R
@@ -44,9 +44,6 @@
 #' head(proximity$enrichment)
 #' GiottoPlot(proximity)
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' proximity <- RunGiottoCellProximity(
 #'   spatial,
@@ -57,7 +54,6 @@
 #'   network_method = "Delaunay",
 #'   number_of_simulations = 100
 #' )
-#' }
 #'
 #' @export
 RunGiottoCellProximity <- function(
@@ -230,9 +226,6 @@ RunGiottoCellProximity <- function(
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #' spatial <- Seurat::FindVariableFeatures(
 #'   spatial,
 #'   assay = "Spatial",
@@ -247,7 +240,6 @@ RunGiottoCellProximity <- function(
 #'   coord.cols = c("x", "y"),
 #'   top_n = 50
 #' )
-#' }
 #'
 #' @export
 RunGiottoSpatialGenes <- function(
@@ -430,9 +422,6 @@ RunGiottoSpatialGenes <- function(
 #' names(giotto_modules$module_tables)
 #' GiottoPlot(giotto_modules, top_n = 4)
 #'
-#' if (
-#'   isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-#' ) {
 #' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' spatial <- Seurat::FindVariableFeatures(
 #'   spatial,
@@ -449,7 +438,6 @@ RunGiottoSpatialGenes <- function(
 #'   cor_method = "pearson",
 #'   k = 6
 #' )
-#' }
 #'
 #' @export
 RunGiottoSpatialModules <- function(

--- a/R/RunMERINGUE.R
+++ b/R/RunMERINGUE.R
@@ -46,9 +46,6 @@
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("JEFworks-Lab/MERINGUE", verbose = FALSE))
-#' ) {
 #' spatial <- RunMERINGUE(
 #'   spatial,
 #'   assay = "Spatial",
@@ -57,7 +54,6 @@
 #'   nfeatures = 50,
 #'   verbose = FALSE
 #' )
-#' }
 RunMERINGUE <- function(
   srt,
   assay = NULL,

--- a/R/RunMistyR.R
+++ b/R/RunMistyR.R
@@ -45,22 +45,18 @@
 #' spatial <- visium_human_pancreas_sub
 #' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #'
-#' if (
-#'   isTRUE(check_r("mistyR", verbose = FALSE))
-#' ) {
-#'   spatial <- RunMistyR(
-#'     spatial,
-#'     assay = "Spatial",
-#'     layer = "data",
-#'     features = rownames(spatial)[1:10],
-#'     coord.cols = c("x", "y"),
-#'     views = "para",
-#'     para_l = 5,
-#'     cv_folds = 3,
-#'     verbose = FALSE
-#'   )
-#'   spatial@tools$MistyR$summary
-#' }
+#' spatial <- RunMistyR(
+#'   spatial,
+#'   assay = "Spatial",
+#'   layer = "data",
+#'   features = rownames(spatial)[1:10],
+#'   coord.cols = c("x", "y"),
+#'   views = "para",
+#'   para_l = 5,
+#'   cv_folds = 3,
+#'   verbose = FALSE
+#' )
+#' spatial@tools$MistyR$summary
 RunMistyR <- function(
   srt,
   assay = NULL,

--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -64,7 +64,6 @@
 #'   overlay_image = FALSE,
 #'   coord.cols = c("x", "y")
 #' )
-#' if (requireNamespace("scatterpie", quietly = TRUE)) {
 #'   SpatialSpotPlot(
 #'     spatial,
 #'     group.by = "RCTD_dominant_type",
@@ -72,11 +71,7 @@
 #'     overlay_image = FALSE,
 #'     coord.cols = c("x", "y")
 #'   )
-#' }
 #'
-#' if (
-#'   isTRUE(check_r("dmcable/spacexr", verbose = FALSE))
-#' ) {
 #' data(pancreas_sub)
 #' features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
 #'
@@ -111,7 +106,6 @@
 #'   coord.cols = c("x", "y"),
 #'   theme_use = "theme_scop"
 #' )
-#' }
 RunRCTD <- function(
   srt,
   reference,

--- a/R/RunSPOTlight.R
+++ b/R/RunSPOTlight.R
@@ -49,7 +49,6 @@
 #'   overlay_image = FALSE,
 #'   coord.cols = c("x", "y")
 #' )
-#' if (requireNamespace("scatterpie", quietly = TRUE)) {
 #'   SpatialSpotPlot(
 #'     spatial,
 #'     group.by = "SPOTlight_dominant_type",
@@ -57,11 +56,7 @@
 #'     overlay_image = FALSE,
 #'     coord.cols = c("x", "y")
 #'   )
-#' }
 #'
-#' if (
-#'   requireNamespace("SPOTlight", quietly = TRUE)
-#' ) {
 #' data(pancreas_sub)
 #' features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
 #' spatial <- RunSPOTlight(
@@ -86,7 +81,6 @@
 #'   overlay_image = FALSE,
 #'   coord.cols = c("x", "y")
 #' )
-#' }
 RunSPOTlight <- function(
   srt,
   reference,

--- a/R/RunSTdeconvolve.R
+++ b/R/RunSTdeconvolve.R
@@ -58,18 +58,13 @@
 #'   overlay_image = FALSE,
 #'   coord.cols = c("x", "y")
 #' )
-#' if (requireNamespace("scatterpie", quietly = TRUE)) {
 #'   STdeconvolvePlot(
 #'     spatial,
 #'     plot_type = "pie",
 #'     overlay_image = FALSE,
 #'     coord.cols = c("x", "y")
 #'   )
-#' }
 #'
-#' if (
-#'   isTRUE(check_r("JEFworks-Lab/STdeconvolve", verbose = FALSE))
-#' ) {
 #' spatial <- RunSTdeconvolve(
 #'   spatial,
 #'   assay = "Spatial",
@@ -77,7 +72,6 @@
 #'   k = 3,
 #'   verbose = FALSE
 #' )
-#' }
 RunSTdeconvolve <- function(
   srt,
   assay = NULL,
@@ -247,14 +241,12 @@ RunSTdeconvolve <- function(
 #'   overlay_image = FALSE,
 #'   coord.cols = c("x", "y")
 #' )
-#' if (requireNamespace("scatterpie", quietly = TRUE)) {
 #'   STdeconvolvePlot(
 #'     spatial,
 #'     plot_type = "pie",
 #'     overlay_image = FALSE,
 #'     coord.cols = c("x", "y")
 #'   )
-#' }
 STdeconvolvePlot <- function(
   srt,
   topics = NULL,

--- a/R/RunSemla.R
+++ b/R/RunSemla.R
@@ -40,16 +40,12 @@
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("spatial-research/semla", verbose = FALSE))
-#' ) {
 #' spatial <- RunSemlaSpatialNetwork(
 #'   spatial,
 #'   nNeighbors = 6,
 #'   coords = "pixels",
 #'   verbose = FALSE
 #' )
-#' }
 #' @export
 RunSemlaSpatialNetwork <- function(
   srt,
@@ -136,16 +132,12 @@ RunSemlaSpatialNetwork <- function(
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("spatial-research/semla", verbose = FALSE))
-#' ) {
 #' spatial <- RunSemlaLocalG(
 #'   spatial,
 #'   features = features,
 #'   store_in_metadata = TRUE,
 #'   verbose = FALSE
 #' )
-#' }
 #' @export
 RunSemlaLocalG <- function(
   srt,
@@ -210,9 +202,6 @@ RunSemlaLocalG <- function(
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("spatial-research/semla", verbose = FALSE))
-#' ) {
 #' spatial <- RunSemlaRegionNeighbors(
 #'   spatial,
 #'   column_name = "region",
@@ -221,7 +210,6 @@ RunSemlaLocalG <- function(
 #'   column_key = "right_border",
 #'   verbose = FALSE
 #' )
-#' }
 #' @export
 RunSemlaRegionNeighbors <- function(
   srt,
@@ -291,9 +279,6 @@ RunSemlaRegionNeighbors <- function(
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("spatial-research/semla", verbose = FALSE))
-#' ) {
 #' spatial <- RunSemlaRadialDistance(
 #'   spatial,
 #'   column_name = "region",
@@ -301,7 +286,6 @@ RunSemlaRegionNeighbors <- function(
 #'   column_suffix = "upper_distance",
 #'   verbose = FALSE
 #' )
-#' }
 #' @export
 RunSemlaRadialDistance <- function(
   srt,

--- a/R/RunSmoothClust.R
+++ b/R/RunSmoothClust.R
@@ -56,9 +56,6 @@
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("lmweber/smoothclust", verbose = FALSE))
-#' ) {
 #' spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 #' spatial <- Seurat::FindVariableFeatures(
 #'   spatial,
@@ -78,7 +75,6 @@
 #' )
 #'
 #' table(spatial$SmoothClust_cluster)
-#' }
 RunSmoothClust <- function(
   srt,
   assay = NULL,

--- a/R/RunSpaNorm.R
+++ b/R/RunSpaNorm.R
@@ -33,10 +33,6 @@
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   requireNamespace("SpaNorm", quietly = TRUE) &&
-#'     requireNamespace("SpatialExperiment", quietly = TRUE)
-#' ) {
 #'   spatial <- RunSpaNorm(
 #'     spatial,
 #'     assay = "Spatial",
@@ -56,7 +52,6 @@
 #'     overlay_image = FALSE,
 #'     coord.cols = c("x", "y")
 #'   )
-#' }
 RunSpaNorm <- function(
   srt,
   assay = NULL,

--- a/R/RunSpatialEcoTyper.R
+++ b/R/RunSpatialEcoTyper.R
@@ -101,9 +101,6 @@
 #'   position = "fill"
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("digitalcytometry/SpatialEcoTyper", verbose = FALSE))
-#' ) {
 #' srt <- RunSpatialEcoTyper(
 #'   srt,
 #'   celltype.by = "CellType",
@@ -125,7 +122,6 @@
 #'   ncores = 1,
 #'   verbose = FALSE
 #' )
-#' }
 RunSpatialEcoTyper <- function(
   srt,
   mode = c("single", "multi", "recover", "deconvolute"),

--- a/R/RunSpatialIntegration.R
+++ b/R/RunSpatialIntegration.R
@@ -75,9 +75,6 @@
 #' SpatialIntegrationPlot(spatial, plot_type = "alignment")
 #' SpatialIntegrationPlot(spatial, plot_type = "composition")
 #'
-#' if (
-#'   isTRUE(check_r("feiyoung/PRECAST", verbose = FALSE))
-#' ) {
 #' srt <- RunSpatialIntegration(
 #'   object = spatial,
 #'   method = "PRECAST",
@@ -87,7 +84,6 @@
 #'   features = rownames(spatial)[1:300],
 #'   verbose = FALSE
 #' )
-#' }
 RunSpatialIntegration <- function(
   object,
   method = c("PRECAST", "BASS", "SpatialMNN"),

--- a/R/RunSpatialQM.R
+++ b/R/RunSpatialQM.R
@@ -39,19 +39,15 @@
 #' data(visium_human_pancreas_sub)
 #' spatial <- visium_human_pancreas_sub
 #'
-#' if (
-#'   isTRUE(check_r("SpatialQM", verbose = FALSE))
-#' ) {
-#'   spatial <- RunSpatialQM(
-#'     spatial,
-#'     assay = "Spatial",
-#'     layer = "counts",
-#'     metrics = c("n_cells", "tx_per_cell", "sparsity", "entropy"),
-#'     platform = "Visium",
-#'     verbose = FALSE
-#'   )
-#'   spatial@tools$SpatialQM$summary
-#' }
+#' spatial <- RunSpatialQM(
+#'   spatial,
+#'   assay = "Spatial",
+#'   layer = "counts",
+#'   metrics = c("n_cells", "tx_per_cell", "sparsity", "entropy"),
+#'   platform = "Visium",
+#'   verbose = FALSE
+#' )
+#' spatial@tools$SpatialQM$summary
 RunSpatialQM <- function(
   srt,
   assay = NULL,

--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -71,10 +71,6 @@
 #'   coord.cols = c("x", "y")
 #' )
 #'
-#' if (
-#'   isTRUE(check_r("MicTott/SpotSweeper", verbose = FALSE)) &&
-#'     requireNamespace("SpatialExperiment", quietly = TRUE)
-#' ) {
 #'   spatial <- RunSpotSweeper(
 #'     spatial,
 #'     assay = "Spatial",
@@ -90,7 +86,6 @@
 #'     overlay_image = FALSE,
 #'     coord.cols = c("x", "y")
 #'   )
-#' }
 RunSpotSweeper <- function(
   srt,
   assay = NULL,

--- a/R/RunStatialKontextual.R
+++ b/R/RunStatialKontextual.R
@@ -42,23 +42,19 @@
 #' data(visium_human_pancreas_sub)
 #' spatial <- visium_human_pancreas_sub
 #'
-#' if (
-#'   isTRUE(check_r("Statial", verbose = FALSE))
-#' ) {
-#'   labels <- unique(as.character(spatial$coda_label))
-#'   if (length(labels) >= 2) {
-#'     spatial <- RunStatialKontextual(
-#'       spatial,
-#'       group.by = "coda_label",
-#'       r = 50,
-#'       from = labels[1],
-#'       to = labels[2],
-#'       parent = labels[1:2],
-#'       coord.cols = c("x", "y"),
-#'       verbose = FALSE
-#'     )
-#'     spatial@tools$StatialKontextual$summary
-#'   }
+#' labels <- unique(as.character(spatial$coda_label))
+#' if (length(labels) >= 2) {
+#'   spatial <- RunStatialKontextual(
+#'     spatial,
+#'     group.by = "coda_label",
+#'     r = 50,
+#'     from = labels[1],
+#'     to = labels[2],
+#'     parent = labels[1:2],
+#'     coord.cols = c("x", "y"),
+#'     verbose = FALSE
+#'   )
+#'   spatial@tools$StatialKontextual$summary
 #' }
 RunStatialKontextual <- function(
   srt,

--- a/man/GiottoCellProximity.Rd
+++ b/man/GiottoCellProximity.Rd
@@ -57,13 +57,9 @@ g <- structure(
 )
 GiottoPlot(g, plot_type = "cell_proximity")
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
   data(visium_human_pancreas_sub)
   spatial <- visium_human_pancreas_sub
   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
   g <- GiottoSpatialNetwork(g)
   g <- GiottoCellProximity(g, group.by = "coda_label", number_of_simulations = 100)
-}
 }

--- a/man/GiottoCluster.Rd
+++ b/man/GiottoCluster.Rd
@@ -71,12 +71,8 @@ g <- structure(
 )
 GiottoPlot(g, plot_type = "cluster")
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
   g <- GiottoPreprocess(g)
   g <- GiottoReduce(g, reduction = "pca", dims = 1:10)
   g <- GiottoCluster(g, dims = 1:10, k = 8, resolution = 0.4)
-}
 }

--- a/man/GiottoHMRF.Rd
+++ b/man/GiottoHMRF.Rd
@@ -69,12 +69,8 @@ g <- structure(
 )
 GiottoPlot(g, plot_type = "hmrf")
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
   g <- GiottoPreprocess(g)
   g <- GiottoSpatialNetwork(g)
   g <- GiottoHMRF(g, spatial_genes = rownames(spatial)[1:30], k = 4)
-}
 }

--- a/man/GiottoPreprocess.Rd
+++ b/man/GiottoPreprocess.Rd
@@ -52,10 +52,6 @@ g <- structure(
 )
 GiottoPlot(g, plot_type = "spatial")
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
 g <- SeuratToScopGiotto(spatial, assay = "Spatial", coord.cols = c("x", "y"), verbose = FALSE)
 g <- GiottoPreprocess(g, verbose = FALSE)
-}
 }

--- a/man/GiottoReduce.Rd
+++ b/man/GiottoReduce.Rd
@@ -65,12 +65,8 @@ g <- structure(
 )
 GiottoPlot(g, plot_type = "dim")
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
   g <- GiottoPreprocess(g)
   g <- GiottoReduce(g, reduction = "pca", dims = 1:10)
   g <- GiottoReduce(g, reduction = "umap", dims = 1:10)
-}
 }

--- a/man/GiottoSpatialGenes.Rd
+++ b/man/GiottoSpatialGenes.Rd
@@ -69,12 +69,8 @@ g <- structure(
 )
 GiottoPlot(g, plot_type = "spatial_genes", top_n = 6)
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
   g <- GiottoPreprocess(g)
   g <- GiottoSpatialNetwork(g)
   g <- GiottoSpatialGenes(g, features = rownames(spatial)[1:50], top_n = 10)
-}
 }

--- a/man/GiottoSpatialModules.Rd
+++ b/man/GiottoSpatialModules.Rd
@@ -70,12 +70,8 @@ g <- structure(
 )
 GiottoPlot(g, plot_type = "spatial_modules", top_n = 6)
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
   g <- GiottoPreprocess(g)
   g <- GiottoSpatialNetwork(g)
   g <- GiottoSpatialModules(g, features = rownames(spatial)[1:50], k = 3)
-}
 }

--- a/man/GiottoSpatialNetwork.Rd
+++ b/man/GiottoSpatialNetwork.Rd
@@ -51,10 +51,6 @@ g <- structure(
 )
 GiottoPlot(g, plot_type = "network")
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
   g <- SeuratToScopGiotto(spatial, coord.cols = c("x", "y"))
   g <- GiottoSpatialNetwork(g, network_method = "Delaunay")
-}
 }

--- a/man/RunBANKSY.Rd
+++ b/man/RunBANKSY.Rd
@@ -119,9 +119,6 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  requireNamespace("Banksy", quietly = TRUE)
-) {
 spatial <- RunBANKSY(
   spatial,
   assay = "Spatial",
@@ -133,5 +130,4 @@ spatial <- RunBANKSY(
   resolution = 0.6,
   verbose = FALSE
 )
-}
 }

--- a/man/RunBayesSpace.Rd
+++ b/man/RunBayesSpace.Rd
@@ -88,9 +88,6 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  requireNamespace("BayesSpace", quietly = TRUE)
-) {
 spatial <- RunBayesSpace(
   spatial,
   q = 3,
@@ -105,5 +102,4 @@ spatial <- RunBayesSpace(
   )
 )
 table(spatial$BayesSpace_cluster)
-}
 }

--- a/man/RunCARD.Rd
+++ b/man/RunCARD.Rd
@@ -115,7 +115,6 @@ SpatialSpotPlot(
   overlay_image = FALSE,
   coord.cols = c("x", "y")
 )
-if (requireNamespace("scatterpie", quietly = TRUE)) {
   SpatialSpotPlot(
     spatial,
     group.by = "CARD_dominant_type",
@@ -123,12 +122,7 @@ if (requireNamespace("scatterpie", quietly = TRUE)) {
     overlay_image = FALSE,
     coord.cols = c("x", "y")
   )
-}
 
-if (
-  (isTRUE(check_r("CARD", verbose = FALSE)) ||
-    isTRUE(check_r("CARDspa", verbose = FALSE)))
-) {
 data(pancreas_sub)
 features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
 spatial <- RunCARD(
@@ -140,5 +134,4 @@ spatial <- RunCARD(
   features = features_use,
   verbose = FALSE
 )
-}
 }

--- a/man/RunCSIDE.Rd
+++ b/man/RunCSIDE.Rd
@@ -123,11 +123,6 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  isTRUE(check_r("dmcable/spacexr", verbose = FALSE)) &&
-    !is.null(spatial@tools$RCTD) &&
-    inherits(spatial@tools$RCTD$object, "RCTD")
-) {
   spatial <- RunCSIDE(
     spatial,
     group.by = "region",
@@ -135,5 +130,4 @@ if (
     gene_threshold = 0.00005,
     cell_type_threshold = 125
   )
-}
 }

--- a/man/RunGiottoCellProximity.Rd
+++ b/man/RunGiottoCellProximity.Rd
@@ -104,9 +104,6 @@ class(proximity) <- c("giotto2_cell_proximity", "giotto2_result", "list")
 head(proximity$enrichment)
 GiottoPlot(proximity)
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
 spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 proximity <- RunGiottoCellProximity(
   spatial,
@@ -117,6 +114,5 @@ proximity <- RunGiottoCellProximity(
   network_method = "Delaunay",
   number_of_simulations = 100
 )
-}
 
 }

--- a/man/RunGiottoCluster.Rd
+++ b/man/RunGiottoCluster.Rd
@@ -111,9 +111,6 @@ GiottoPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
 spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 spatial <- Seurat::FindVariableFeatures(
   spatial,
@@ -132,6 +129,5 @@ giotto_clusters <- RunGiottoCluster(
 )
 
 head(giotto_clusters$clusters)
-}
 
 }

--- a/man/RunGiottoSpatialGenes.Rd
+++ b/man/RunGiottoSpatialGenes.Rd
@@ -110,9 +110,6 @@ GiottoPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
 spatial <- Seurat::FindVariableFeatures(
   spatial,
   assay = "Spatial",
@@ -127,6 +124,5 @@ giotto_genes <- RunGiottoSpatialGenes(
   coord.cols = c("x", "y"),
   top_n = 50
 )
-}
 
 }

--- a/man/RunGiottoSpatialModules.Rd
+++ b/man/RunGiottoSpatialModules.Rd
@@ -113,9 +113,6 @@ class(giotto_modules) <- c("giotto2_spatial_modules", "giotto2_result", "list")
 names(giotto_modules$module_tables)
 GiottoPlot(giotto_modules, top_n = 4)
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
 spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 spatial <- Seurat::FindVariableFeatures(
   spatial,
@@ -132,6 +129,5 @@ giotto_modules <- RunGiottoSpatialModules(
   cor_method = "pearson",
   k = 6
 )
-}
 
 }

--- a/man/RunGiottoWorkflow.Rd
+++ b/man/RunGiottoWorkflow.Rd
@@ -75,9 +75,6 @@ g <- structure(
 )
 GiottoPlot(g, plot_type = "cluster")
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
 g <- RunGiottoWorkflow(
   spatial,
   steps = "basic",
@@ -87,5 +84,4 @@ g <- RunGiottoWorkflow(
   return_seurat = FALSE,
   verbose = FALSE
 )
-}
 }

--- a/man/RunMERINGUE.Rd
+++ b/man/RunMERINGUE.Rd
@@ -118,9 +118,6 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  isTRUE(check_r("JEFworks-Lab/MERINGUE", verbose = FALSE))
-) {
 spatial <- RunMERINGUE(
   spatial,
   assay = "Spatial",
@@ -129,5 +126,4 @@ spatial <- RunMERINGUE(
   nfeatures = 50,
   verbose = FALSE
 )
-}
 }

--- a/man/RunMistyR.Rd
+++ b/man/RunMistyR.Rd
@@ -94,20 +94,16 @@ data(visium_human_pancreas_sub)
 spatial <- visium_human_pancreas_sub
 spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 
-if (
-  isTRUE(check_r("mistyR", verbose = FALSE))
-) {
-  spatial <- RunMistyR(
-    spatial,
-    assay = "Spatial",
-    layer = "data",
-    features = rownames(spatial)[1:10],
-    coord.cols = c("x", "y"),
-    views = "para",
-    para_l = 5,
-    cv_folds = 3,
-    verbose = FALSE
-  )
-  spatial@tools$MistyR$summary
-}
+spatial <- RunMistyR(
+  spatial,
+  assay = "Spatial",
+  layer = "data",
+  features = rownames(spatial)[1:10],
+  coord.cols = c("x", "y"),
+  views = "para",
+  para_l = 5,
+  cv_folds = 3,
+  verbose = FALSE
+)
+spatial@tools$MistyR$summary
 }

--- a/man/RunRCTD.Rd
+++ b/man/RunRCTD.Rd
@@ -110,7 +110,6 @@ SpatialSpotPlot(
   overlay_image = FALSE,
   coord.cols = c("x", "y")
 )
-if (requireNamespace("scatterpie", quietly = TRUE)) {
   SpatialSpotPlot(
     spatial,
     group.by = "RCTD_dominant_type",
@@ -118,11 +117,7 @@ if (requireNamespace("scatterpie", quietly = TRUE)) {
     overlay_image = FALSE,
     coord.cols = c("x", "y")
   )
-}
 
-if (
-  isTRUE(check_r("dmcable/spacexr", verbose = FALSE))
-) {
 data(pancreas_sub)
 features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
 
@@ -157,5 +152,4 @@ SpatialSpotPlot(
   coord.cols = c("x", "y"),
   theme_use = "theme_scop"
 )
-}
 }

--- a/man/RunSPOTlight.Rd
+++ b/man/RunSPOTlight.Rd
@@ -105,7 +105,6 @@ SpatialSpotPlot(
   overlay_image = FALSE,
   coord.cols = c("x", "y")
 )
-if (requireNamespace("scatterpie", quietly = TRUE)) {
   SpatialSpotPlot(
     spatial,
     group.by = "SPOTlight_dominant_type",
@@ -113,11 +112,7 @@ if (requireNamespace("scatterpie", quietly = TRUE)) {
     overlay_image = FALSE,
     coord.cols = c("x", "y")
   )
-}
 
-if (
-  requireNamespace("SPOTlight", quietly = TRUE)
-) {
 data(pancreas_sub)
 features_use <- head(intersect(rownames(spatial), rownames(pancreas_sub)), 300)
 spatial <- RunSPOTlight(
@@ -142,5 +137,4 @@ SpatialSpotPlot(
   overlay_image = FALSE,
   coord.cols = c("x", "y")
 )
-}
 }

--- a/man/RunSTdeconvolve.Rd
+++ b/man/RunSTdeconvolve.Rd
@@ -109,18 +109,13 @@ STdeconvolvePlot(
   overlay_image = FALSE,
   coord.cols = c("x", "y")
 )
-if (requireNamespace("scatterpie", quietly = TRUE)) {
   STdeconvolvePlot(
     spatial,
     plot_type = "pie",
     overlay_image = FALSE,
     coord.cols = c("x", "y")
   )
-}
 
-if (
-  isTRUE(check_r("JEFworks-Lab/STdeconvolve", verbose = FALSE))
-) {
 spatial <- RunSTdeconvolve(
   spatial,
   assay = "Spatial",
@@ -128,5 +123,4 @@ spatial <- RunSTdeconvolve(
   k = 3,
   verbose = FALSE
 )
-}
 }

--- a/man/RunSemlaLocalG.Rd
+++ b/man/RunSemlaLocalG.Rd
@@ -57,14 +57,10 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  isTRUE(check_r("spatial-research/semla", verbose = FALSE))
-) {
 spatial <- RunSemlaLocalG(
   spatial,
   features = features,
   store_in_metadata = TRUE,
   verbose = FALSE
 )
-}
 }

--- a/man/RunSemlaRadialDistance.Rd
+++ b/man/RunSemlaRadialDistance.Rd
@@ -62,9 +62,6 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  isTRUE(check_r("spatial-research/semla", verbose = FALSE))
-) {
 spatial <- RunSemlaRadialDistance(
   spatial,
   column_name = "region",
@@ -72,5 +69,4 @@ spatial <- RunSemlaRadialDistance(
   column_suffix = "upper_distance",
   verbose = FALSE
 )
-}
 }

--- a/man/RunSemlaRegionNeighbors.Rd
+++ b/man/RunSemlaRegionNeighbors.Rd
@@ -60,9 +60,6 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  isTRUE(check_r("spatial-research/semla", verbose = FALSE))
-) {
 spatial <- RunSemlaRegionNeighbors(
   spatial,
   column_name = "region",
@@ -71,5 +68,4 @@ spatial <- RunSemlaRegionNeighbors(
   column_key = "right_border",
   verbose = FALSE
 )
-}
 }

--- a/man/RunSemlaSpatialNetwork.Rd
+++ b/man/RunSemlaSpatialNetwork.Rd
@@ -68,14 +68,10 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  isTRUE(check_r("spatial-research/semla", verbose = FALSE))
-) {
 spatial <- RunSemlaSpatialNetwork(
   spatial,
   nNeighbors = 6,
   coords = "pixels",
   verbose = FALSE
 )
-}
 }

--- a/man/RunSmoothClust.Rd
+++ b/man/RunSmoothClust.Rd
@@ -110,9 +110,6 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  isTRUE(check_r("lmweber/smoothclust", verbose = FALSE))
-) {
 spatial <- Seurat::NormalizeData(spatial, assay = "Spatial", verbose = FALSE)
 spatial <- Seurat::FindVariableFeatures(
   spatial,
@@ -132,5 +129,4 @@ spatial <- RunSmoothClust(
 )
 
 table(spatial$SmoothClust_cluster)
-}
 }

--- a/man/RunSpaNorm.Rd
+++ b/man/RunSpaNorm.Rd
@@ -72,10 +72,6 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  requireNamespace("SpaNorm", quietly = TRUE) &&
-    requireNamespace("SpatialExperiment", quietly = TRUE)
-) {
   spatial <- RunSpaNorm(
     spatial,
     assay = "Spatial",
@@ -95,5 +91,4 @@ if (
     overlay_image = FALSE,
     coord.cols = c("x", "y")
   )
-}
 }

--- a/man/RunSpatialEcoTyper.Rd
+++ b/man/RunSpatialEcoTyper.Rd
@@ -196,9 +196,6 @@ SpatialEcoTyperCompositionPlot(
   position = "fill"
 )
 
-if (
-  isTRUE(check_r("digitalcytometry/SpatialEcoTyper", verbose = FALSE))
-) {
 srt <- RunSpatialEcoTyper(
   srt,
   celltype.by = "CellType",
@@ -220,5 +217,4 @@ srt <- RunSpatialEcoTyper(
   ncores = 1,
   verbose = FALSE
 )
-}
 }

--- a/man/RunSpatialIntegration.Rd
+++ b/man/RunSpatialIntegration.Rd
@@ -121,9 +121,6 @@ SpatialIntegrationPlot(spatial, plot_type = "embedding")
 SpatialIntegrationPlot(spatial, plot_type = "alignment")
 SpatialIntegrationPlot(spatial, plot_type = "composition")
 
-if (
-  isTRUE(check_r("feiyoung/PRECAST", verbose = FALSE))
-) {
 srt <- RunSpatialIntegration(
   object = spatial,
   method = "PRECAST",
@@ -133,5 +130,4 @@ srt <- RunSpatialIntegration(
   features = rownames(spatial)[1:300],
   verbose = FALSE
 )
-}
 }

--- a/man/RunSpatialQM.Rd
+++ b/man/RunSpatialQM.Rd
@@ -69,17 +69,13 @@ installable with \code{remotes::install_github("Center-for-Spatial-OMICs/Spatial
 data(visium_human_pancreas_sub)
 spatial <- visium_human_pancreas_sub
 
-if (
-  isTRUE(check_r("SpatialQM", verbose = FALSE))
-) {
-  spatial <- RunSpatialQM(
-    spatial,
-    assay = "Spatial",
-    layer = "counts",
-    metrics = c("n_cells", "tx_per_cell", "sparsity", "entropy"),
-    platform = "Visium",
-    verbose = FALSE
-  )
-  spatial@tools$SpatialQM$summary
-}
+spatial <- RunSpatialQM(
+  spatial,
+  assay = "Spatial",
+  layer = "counts",
+  metrics = c("n_cells", "tx_per_cell", "sparsity", "entropy"),
+  platform = "Visium",
+  verbose = FALSE
+)
+spatial@tools$SpatialQM$summary
 }

--- a/man/RunSpotSweeper.Rd
+++ b/man/RunSpotSweeper.Rd
@@ -126,10 +126,6 @@ SpatialSpotPlot(
   coord.cols = c("x", "y")
 )
 
-if (
-  isTRUE(check_r("MicTott/SpotSweeper", verbose = FALSE)) &&
-    requireNamespace("SpatialExperiment", quietly = TRUE)
-) {
   spatial <- RunSpotSweeper(
     spatial,
     assay = "Spatial",
@@ -145,5 +141,4 @@ if (
     overlay_image = FALSE,
     coord.cols = c("x", "y")
   )
-}
 }

--- a/man/RunStatialKontextual.Rd
+++ b/man/RunStatialKontextual.Rd
@@ -90,22 +90,18 @@ dependency installable with \code{BiocManager::install("Statial")}.
 data(visium_human_pancreas_sub)
 spatial <- visium_human_pancreas_sub
 
-if (
-  isTRUE(check_r("Statial", verbose = FALSE))
-) {
-  labels <- unique(as.character(spatial$coda_label))
-  if (length(labels) >= 2) {
-    spatial <- RunStatialKontextual(
-      spatial,
-      group.by = "coda_label",
-      r = 50,
-      from = labels[1],
-      to = labels[2],
-      parent = labels[1:2],
-      coord.cols = c("x", "y"),
-      verbose = FALSE
-    )
-    spatial@tools$StatialKontextual$summary
-  }
+labels <- unique(as.character(spatial$coda_label))
+if (length(labels) >= 2) {
+  spatial <- RunStatialKontextual(
+    spatial,
+    group.by = "coda_label",
+    r = 50,
+    from = labels[1],
+    to = labels[2],
+    parent = labels[1:2],
+    coord.cols = c("x", "y"),
+    verbose = FALSE
+  )
+  spatial@tools$StatialKontextual$summary
 }
 }

--- a/man/STdeconvolvePlot.Rd
+++ b/man/STdeconvolvePlot.Rd
@@ -58,12 +58,10 @@ STdeconvolvePlot(
   overlay_image = FALSE,
   coord.cols = c("x", "y")
 )
-if (requireNamespace("scatterpie", quietly = TRUE)) {
   STdeconvolvePlot(
     spatial,
     plot_type = "pie",
     overlay_image = FALSE,
     coord.cols = c("x", "y")
   )
-}
 }

--- a/man/SeuratToScopGiotto.Rd
+++ b/man/SeuratToScopGiotto.Rd
@@ -107,9 +107,6 @@ g <- structure(
 GiottoPlot(g, plot_type = "cluster")
 GiottoPlot(g, plot_type = "network")
 
-if (
-  isTRUE(check_r("giotto-suite/Giotto", verbose = FALSE))
-) {
 g <- SeuratToScopGiotto(
   spatial,
   assay = "Spatial",
@@ -117,5 +114,4 @@ g <- SeuratToScopGiotto(
   coord.cols = c("x", "y"),
   verbose = FALSE
 )
-}
 }


### PR DESCRIPTION
﻿## Summary
- Remove SCOP_RUN_* environment guards from spatial roxygen examples.
- Remove requireNamespace/library-style guards from spatial optional backend examples so short examples run directly.
- Regenerate/sync affected man/*.Rd example blocks.

## Validation
- git diff --check
- Parsed 35 changed Rd example files via tools::Rd2ex() + parse()
- Rscript -e "pkgload::load_all('.', quiet=TRUE, compile=FALSE)"
- _R_CHECK_FORCE_SUGGESTS_=false rcmdcheck::rcmdcheck(args=c('--no-manual','--as-cran','--no-examples','--no-tests'), error_on='never') completed with existing DESCRIPTION/CRAN metadata issues; no SCOP_RUN guards or targeted spatial Rd requireNamespace guards remain.
