### PR TITLE
fix: enforce explicit spatial image selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # scop 0.9.0
 
 * **feat**:
+  * Spatial analysis, plotting, and framework conversion now share strict image selection: objects with multiple spatial images must provide `image`, preventing silent first-slice truncation. The compatibility default remains `coordinate_space = "legacy_display"` in this release; raw-coordinate defaults are planned for the next migration step.
   * Added spatial contract schema v1 with `SpatialCoordinates()`, `GetSpatialResult()`, and `GetSpatialGraph()`. Small-method results now retain their existing top-level payload fields while adding shared source, provenance, parameter, summary, and schema metadata; legacy framework results are normalized only in read-only views.
   * Added a shared spatial method registry with `ListSpatialMethods()`, read-only `SpatialBackendStatus()`, and `SpatialResultInfo()` so users can discover the complete spatial API, inspect optional backend compatibility without installation side effects, and summarize legacy or current results stored in `@tools`.
   * Added a strict raw-coordinate contract and sparse spatial graph core. `RunSpatialNetwork()` now preserves raw distances and deterministic graph slots, while existing distance-sensitive methods retain `coordinate_space = "legacy_display"` by default and offer an explicit `"raw"` path without changing legacy behavior.

--- a/R/GiottoPlot.R
+++ b/R/GiottoPlot.R
@@ -90,8 +90,8 @@ GiottoPlot.default <- function(x, ...) {
 #' @rdname GiottoPlot
 #' @param srt Original `Seurat` object used to create the Giotto result. Required
 #' for spatial spot plots.
-#' @param image Name of the Seurat spatial image. If `NULL`, the first image is
-#' used when available.
+#' @param image Name of the Seurat spatial image. Required when multiple images
+#' are present; a single image is selected automatically when `NULL`.
 #' @param coord.cols Metadata coordinate columns used when no image is available.
 #' @param overlay_image Whether to draw the spatial image beneath spots.
 #' @param crop Whether to crop spatial panels to plotted spots.

--- a/R/RunBayesSpace.R
+++ b/R/RunBayesSpace.R
@@ -251,16 +251,10 @@ bayesspace_add_spatial_coords <- function(
 }
 
 bayesspace_get_seurat_coords <- function(srt, image = NULL) {
-  images <- tryCatch(SeuratObject::Images(srt), error = function(e) character())
-  if (length(images) == 0L) {
+  resolved <- spatial_image_resolve(srt = srt, image = image, image_policy = "strict")
+  image <- resolved$image
+  if (is.null(image)) {
     return(NULL)
-  }
-  image <- image %||% images[1]
-  if (!image %in% images) {
-    log_message(
-      "{.arg image} {.val {image}} is not present in {.cls Seurat}",
-      message_type = "error"
-    )
   }
   coords <- tryCatch(
     {

--- a/R/RunCytoSPACE.R
+++ b/R/RunCytoSPACE.R
@@ -634,62 +634,22 @@ cytospace_get_spatial_coords <- function(
   coordinate_space = c("legacy_display", "raw")
 ) {
   coordinate_space <- match.arg(coordinate_space)
-  if (identical(coordinate_space, "raw")) {
-    resolved <- spatial_coords_raw(
-      srt = srt,
-      image = image,
-      coord.cols = coord.cols,
-      image_policy = "strict"
-    )
-    matched <- match(spot_ids, resolved$data$cell_id)
-    if (anyNA(matched)) {
-      log_message("Spatial coordinates are missing for one or more requested spots", message_type = "error")
-    }
-    coords <- resolved$data[matched, c("x", "y"), drop = FALSE]
-    rownames(coords) <- spot_ids
-    attr(coords, "spatial_source") <- resolved$source
-    attr(coords, "spatial_transform") <- resolved$transform
-    return(coords)
-  }
-  meta <- srt[[]]
-  coord_cols <- intersect(
-    c(
-      "array_row",
-      "array_col",
-      "row",
-      "col",
-      "imagerow",
-      "imagecol",
-      "x",
-      "y",
-      "X",
-      "Y"
-    ),
-    colnames(meta)
+  resolved <- spatial_analysis_coords(
+    srt = srt,
+    image = image,
+    coord.cols = coord.cols,
+    coordinate_space = coordinate_space,
+    image_policy = "strict"
   )
-  if (length(coord_cols) >= 2L) {
-    coords <- meta[spot_ids, coord_cols[seq_len(2)], drop = FALSE]
-    return(coords)
+  matched <- match(spot_ids, resolved$data$cell_id)
+  if (anyNA(matched)) {
+    log_message("Spatial coordinates are missing for one or more requested spots", message_type = "error")
   }
-
-  images <- tryCatch(SeuratObject::Images(srt), error = function(e) character())
-  if (length(images) > 0L) {
-    coords <- tryCatch(
-      as.data.frame(
-        SeuratObject::GetTissueCoordinates(srt[[images[1]]]),
-        stringsAsFactors = FALSE
-      ),
-      error = function(e) NULL
-    )
-    if (!is.null(coords)) {
-      common <- intersect(spot_ids, rownames(coords))
-      if (length(common) > 0L && ncol(coords) >= 2L) {
-        return(coords[spot_ids, seq_len(2), drop = FALSE])
-      }
-    }
-  }
-
-  data.frame(row = seq_along(spot_ids), col = 1L, row.names = spot_ids)
+  coords <- resolved$data[matched, c("x", "y"), drop = FALSE]
+  rownames(coords) <- spot_ids
+  attr(coords, "spatial_source") <- resolved$source
+  attr(coords, "spatial_transform") <- resolved$transform
+  coords
 }
 
 cytospace_build_assignment_table <- function(

--- a/R/RunGiottoCluster.R
+++ b/R/RunGiottoCluster.R
@@ -402,15 +402,9 @@ giotto_prepare_input <- function(
 }
 
 giotto_spatial_coords <- function(srt, image = NULL, coord.cols = c("x", "y")) {
-  images <- tryCatch(SeuratObject::Images(srt), error = function(e) character())
-  if (length(images) > 0L) {
-    image <- image %||% images[1L]
-    if (!image %in% images) {
-      log_message(
-        "{.arg image} {.val {image}} is not present in {.cls Seurat}",
-        message_type = "error"
-      )
-    }
+  resolved <- spatial_image_resolve(srt = srt, image = image, image_policy = "strict")
+  image <- resolved$image
+  if (!is.null(image)) {
     coords <- as.data.frame(SeuratObject::GetTissueCoordinates(srt[[image]]))
     cell_col <- if ("cell" %in% colnames(coords)) "cell" else NULL
     cells <- if (is.null(cell_col)) rownames(coords) else coords[[cell_col]]

--- a/R/RunMistyR.R
+++ b/R/RunMistyR.R
@@ -15,8 +15,8 @@
 #' @param layer Assay layer used for expression values.
 #' @param features Features used by MISTy. If `NULL`, variable features are used
 #' when available; otherwise all assay features are used.
-#' @param image Name of the Seurat spatial image. If `NULL`, the first image is
-#' used when present.
+#' @param image Name of the Seurat spatial image. Required when multiple images
+#' are present; a single image is selected automatically when `NULL`.
 #' @param coord.cols Metadata coordinate columns used when no Seurat image
 #' coordinates are available.
 #' @param coordinate_space Coordinate system used to build MISTy views.

--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -626,16 +626,10 @@ rctd_get_spatial_coords <- function(
 }
 
 rctd_get_image_coords <- function(srt, image = NULL) {
-  images <- tryCatch(SeuratObject::Images(srt), error = function(e) character())
-  if (length(images) == 0L) {
+  resolved <- spatial_image_resolve(srt = srt, image = image, image_policy = "strict")
+  image <- resolved$image
+  if (is.null(image)) {
     return(NULL)
-  }
-  image <- image %||% images[1L]
-  if (!image %in% images) {
-    log_message(
-      "{.arg image} {.val {image}} is not present in {.cls Seurat}",
-      message_type = "error"
-    )
   }
   coords <- tryCatch(
     as.data.frame(SeuratObject::GetTissueCoordinates(srt[[image]])),

--- a/R/RunSmoothClust.R
+++ b/R/RunSmoothClust.R
@@ -9,8 +9,8 @@
 #' @param srt A `Seurat` object.
 #' @param assay Assay used for expression. If `NULL`, the default assay is used.
 #' @param layer Assay layer used for expression values.
-#' @param image Name of the Seurat spatial image. If `NULL`, the first image is
-#' used when present.
+#' @param image Name of the Seurat spatial image. Required when multiple images
+#' are present; a single image is selected automatically when `NULL`.
 #' @param coord.cols Metadata coordinate columns used when no Seurat image is
 #' available.
 #' @param features Features to use. If `NULL`, current variable features are

--- a/R/RunSpatialNeighborhood.R
+++ b/R/RunSpatialNeighborhood.R
@@ -13,8 +13,8 @@
 #' @param layer Assay layer used when `features` are requested.
 #' @param coord.cols Metadata coordinate columns used when no Seurat image
 #' coordinates are available.
-#' @param image Name of the Seurat spatial image. If `NULL`, the first image is
-#' used when present.
+#' @param image Name of the Seurat spatial image. Required when multiple images
+#' are present; a single image is selected automatically when `NULL`.
 #' @param coordinate_space Coordinate system used to build neighbor distances.
 #' @param sample.by Metadata column identifying images or samples. If `NULL`,
 #' all spots are treated as one sample.

--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -13,8 +13,8 @@
 #' @param layer Assay layer used for expression values.
 #' @param coord.cols Metadata coordinate columns used when no Seurat image is
 #' available.
-#' @param image Name of the Seurat spatial image. If `NULL`, the first image is
-#' used when present.
+#' @param image Name of the Seurat spatial image. Required when multiple images
+#' are present; a single image is selected automatically when `NULL`.
 #' @param coordinate_space Coordinate system used for spatial neighborhoods.
 #' @param sample.by Optional metadata column identifying samples or images.
 #' If `NULL`, all spots are treated as one sample.

--- a/R/RunStatialKontextual.R
+++ b/R/RunStatialKontextual.R
@@ -15,8 +15,8 @@
 #' @param from,to,parent Cell or spot labels passed to `Statial::Kontextual()`.
 #' Ignored when `parent_df` is supplied.
 #' @param parent_df Optional data frame from `Statial::parentCombinations()`.
-#' @param image Name of the Seurat spatial image. If `NULL`, the first image is
-#' used when present.
+#' @param image Name of the Seurat spatial image. Required when multiple images
+#' are present; a single image is selected automatically when `NULL`.
 #' @param sample.by Optional metadata column used as Statial `imageID`. If
 #' `NULL`, all cells or spots are treated as one image.
 #' @param images Optional Statial image filter passed to `Kontextual(image = )`.

--- a/R/SpatialCellPlot.R
+++ b/R/SpatialCellPlot.R
@@ -65,20 +65,13 @@ SpatialCellPlot <- function(
     boundaries <- if (is.data.frame(res)) res else res$boundaries
   }
   if (is.null(boundaries) && !is.null(object)) {
-    images <- tryCatch(SeuratObject::Images(object), error = function(e) character())
-    if (length(images) == 0L) {
-      log_message("No Seurat spatial image is available for boundary extraction", message_type = "error")
-    }
+    image <- spatial_image_resolve(
+      srt = object,
+      image = image,
+      image_policy = "strict"
+    )$image
     if (is.null(image)) {
-      if (length(images) > 1L) {
-        log_message(
-          "Multiple spatial images are available; select one with {.arg image}: {.val {images}}",
-          message_type = "error"
-        )
-      }
-      image <- images[[1L]]
-    } else if (!image %in% images) {
-      log_message("{.arg image} {.val {image}} is not present in {.cls Seurat}", message_type = "error")
+      log_message("No Seurat spatial image is available for boundary extraction", message_type = "error")
     }
     boundary_names <- tryCatch(SeuratObject::Boundaries(object[[image]]), error = function(e) character())
     if (!"segmentation" %in% boundary_names) {

--- a/R/SpatialCore.R
+++ b/R/SpatialCore.R
@@ -1,23 +1,59 @@
 # Pure coordinate and graph primitives for spatial analyses.
 
+spatial_image_resolve <- function(
+  srt,
+  image = NULL,
+  image_policy = "strict"
+) {
+  if (!inherits(srt, "Seurat")) {
+    log_message("{.arg srt} must be a {.cls Seurat} object", message_type = "error")
+  }
+  image_policy <- match.arg(image_policy, "strict")
+  if (!is.null(image) && (!is.character(image) || length(image) != 1L || is.na(image) || !nzchar(image))) {
+    log_message("{.arg image} must be one non-empty image name", message_type = "error")
+  }
+  images <- tryCatch(SeuratObject::Images(srt), error = function(e) character())
+  if (length(images) == 0L) {
+    if (!is.null(image)) {
+      log_message("{.arg image} was supplied but {.arg srt} has no spatial images", message_type = "error")
+    }
+    return(list(image = NULL, images = images, image_policy = image_policy))
+  }
+  if (is.null(image)) {
+    if (length(images) > 1L) {
+      log_message(
+        "Multiple spatial images are available; select one with {.arg image}: {.val {images}}",
+        message_type = "error"
+      )
+    }
+    image <- images[[1L]]
+  }
+  if (!image %in% images) {
+    log_message(
+      "{.arg image} {.val {image}} is not present in {.cls Seurat}; available images: {.val {images}}",
+      message_type = "error"
+    )
+  }
+  list(image = image, images = images, image_policy = image_policy)
+}
+
 spatial_coords_raw <- function(
   srt,
   image = NULL,
   coord.cols = c("col", "row"),
   image_policy = "strict"
 ) {
-  if (!inherits(srt, "Seurat")) {
-    log_message("{.arg srt} must be a {.cls Seurat} object", message_type = "error")
-  }
-  image_policy <- match.arg(image_policy, c("strict", "legacy_first"))
-  images <- tryCatch(SeuratObject::Images(srt), error = function(e) character())
-  selected_image <- image
-  if (length(images) == 0L) {
-    if (!is.null(selected_image)) {
-      log_message("{.arg image} was supplied but {.arg srt} has no spatial images", message_type = "error")
-    }
+  resolved_image <- spatial_image_resolve(
+    srt = srt,
+    image = image,
+    image_policy = image_policy
+  )
+  image_policy <- resolved_image$image_policy
+  selected_image <- resolved_image$image
+  if (is.null(selected_image)) {
     coords <- scop_spatial_metadata_coords(srt, coord.cols = coord.cols)
     cells <- rownames(coords)
+    source_coord_cols <- coord.cols[1:2]
     transform <- list(
       scale = 1,
       y_flip = FALSE,
@@ -27,21 +63,6 @@ spatial_coords_raw <- function(
       raw_y_col = coord.cols[[2L]]
     )
   } else {
-    if (is.null(selected_image)) {
-      if (length(images) > 1L && identical(image_policy, "strict")) {
-        log_message(
-          "Multiple spatial images are available; select one with {.arg image}: {.val {images}}",
-          message_type = "error"
-        )
-      }
-      selected_image <- images[[1L]]
-    }
-    if (!selected_image %in% images) {
-      log_message(
-        "{.arg image} {.val {selected_image}} is not present in {.cls Seurat}; available images: {.val {images}}",
-        message_type = "error"
-      )
-    }
     raw <- as.data.frame(SeuratObject::GetTissueCoordinates(srt[[selected_image]]))
     cell_col <- if ("cell" %in% colnames(raw)) "cell" else NULL
     cells <- if (is.null(cell_col)) rownames(raw) else as.character(raw[[cell_col]])
@@ -50,6 +71,7 @@ spatial_coords_raw <- function(
     }
     x_col <- spatial_dim_pick_col(raw, c("x", "pxl_col_in_fullres", "imagecol"))
     y_col <- spatial_dim_pick_col(raw, c("y", "pxl_row_in_fullres", "imagerow"))
+    source_coord_cols <- c(x_col, y_col)
     coords <- data.frame(
       x = suppressWarnings(as.numeric(raw[[x_col]])),
       y = suppressWarnings(as.numeric(raw[[y_col]])),
@@ -91,7 +113,7 @@ spatial_coords_raw <- function(
     transform = transform,
     source = list(
       image = selected_image,
-      coord.cols = if (is.null(selected_image)) coord.cols[1:2] else NULL,
+      coord.cols = source_coord_cols,
       image_policy = image_policy,
       coordinate_space = "raw"
     )
@@ -149,15 +171,17 @@ spatial_analysis_coords <- function(
 ) {
   coordinate_space <- match.arg(coordinate_space)
   if (identical(coordinate_space, "legacy_display")) {
+    display <- spatial_dim_coords(
+      srt = srt,
+      image = image,
+      coord.cols = coord.cols,
+      overlay_image = FALSE,
+      image_policy = image_policy
+    )
     result <- list(
-      data = spatial_dim_coords(
-        srt = srt,
-        image = image,
-        coord.cols = coord.cols,
-        overlay_image = FALSE
-      )$data,
-      transform = NULL,
-      source = list(image = image, coord.cols = coord.cols[1:2], coordinate_space = coordinate_space)
+      data = display$data,
+      transform = display$transform,
+      source = utils::modifyList(display$source, list(coordinate_space = coordinate_space))
     )
     attr(result$data, "spatial_source") <- result$source
     attr(result$data, "spatial_transform") <- result$transform
@@ -191,10 +215,10 @@ SpatialCoordinates <- function(
   image = NULL,
   coord.cols = c("col", "row"),
   space = c("raw", "display"),
-  image_policy = c("strict", "legacy_first")
+  image_policy = "strict"
 ) {
   space <- match.arg(space)
-  image_policy <- match.arg(image_policy)
+  image_policy <- match.arg(image_policy, "strict")
   result <- spatial_coords_raw(
     srt = object,
     image = image,

--- a/R/SpatialFrameworkConvert.R
+++ b/R/SpatialFrameworkConvert.R
@@ -120,35 +120,11 @@ spata2_to_srt <- function(spata2, ...) {
 }
 
 spatial_framework_image <- function(srt, image = NULL) {
-  if (!inherits(srt, "Seurat")) {
-    log_message("{.arg srt} must be a {.cls Seurat} object", message_type = "error")
-  }
-  if (!is.null(image) && (!is.character(image) || length(image) != 1L || is.na(image) || !nzchar(image))) {
-    log_message("{.arg image} must be one non-empty image name", message_type = "error")
-  }
-  images <- tryCatch(SeuratObject::Images(srt), error = function(e) character())
-  if (length(images) == 0L) {
-    if (!is.null(image)) {
-      log_message("{.arg image} was supplied but {.arg srt} has no spatial images", message_type = "error")
-    }
-    return(NULL)
-  }
-  if (is.null(image)) {
-    if (length(images) > 1L) {
-      log_message(
-        "Multiple spatial images are available; select one with {.arg image}: {.val {images}}",
-        message_type = "error"
-      )
-    }
-    return(images[[1L]])
-  }
-  if (!image %in% images) {
-    log_message(
-      "{.arg image} {.val {image}} is not present in {.cls Seurat}; available images: {.val {images}}",
-      message_type = "error"
-    )
-  }
-  image
+  spatial_image_resolve(
+    srt = srt,
+    image = image,
+    image_policy = "strict"
+  )$image
 }
 
 spatial_framework_subset_image <- function(srt, image = NULL) {

--- a/R/SpatialSpotPlot.R
+++ b/R/SpatialSpotPlot.R
@@ -20,8 +20,8 @@
 #' @param spot.by Column in `plot.data` containing spot names.
 #' @param color.by Column in `plot.data` used to color repeated spatial points.
 #' @param geom Geometry used for `plot.data`: `"point"` or `"jitter"`.
-#' @param image Name of the Seurat spatial image. If `NULL`, the first image is
-#' used when present.
+#' @param image Name of the Seurat spatial image. Required when multiple images
+#' are present; a single image is selected automatically when `NULL`.
 #' @param overlay_image Whether to draw the spatial image beneath spots.
 #' @param image.alpha Transparency of the spatial image.
 #' @param crop Whether to crop the panel to plotted spots.
@@ -743,50 +743,50 @@ spatial_dim_coords <- function(
   srt,
   image = NULL,
   coord.cols = c("col", "row"),
-  overlay_image = TRUE
+  overlay_image = TRUE,
+  image_policy = "strict"
 ) {
-  images <- tryCatch(SeuratObject::Images(srt), error = function(e) character())
+  raw <- spatial_coords_raw(
+    srt = srt,
+    image = image,
+    coord.cols = coord.cols,
+    image_policy = image_policy
+  )
+  selected_image <- raw$source$image
+  out <- spatial_coords_to_display(raw$data, raw$transform)
+  out <- out[, c("x", "y"), drop = FALSE]
+  attr(out, "spatial_source") <- utils::modifyList(
+    raw$source,
+    list(coordinate_space = "legacy_display")
+  )
+  attr(out, "spatial_transform") <- raw$transform
   image_info <- NULL
-  if (length(images) > 0L) {
-    image <- image %||% images[1L]
-    if (!image %in% images) {
-      log_message(
-        "{.arg image} {.val {image}} is not present in {.cls Seurat}",
-        message_type = "error"
+  if (!is.null(selected_image)) {
+    image_array <- tryCatch(srt[[selected_image]]@image, error = function(e) NULL)
+    if (!is.null(image_array)) {
+      image_height <- dim(image_array)[1L]
+      image_width <- dim(image_array)[2L]
+      image_info <- list(
+        image = image_array,
+        width = image_width,
+        height = image_height
       )
+      return(list(
+        data = out,
+        image = image_info,
+        uses_image = TRUE,
+        source = attr(out, "spatial_source"),
+        transform = raw$transform
+      ))
     }
-    coords <- as.data.frame(SeuratObject::GetTissueCoordinates(srt[[image]]))
-    cell_col <- if ("cell" %in% colnames(coords)) "cell" else NULL
-    cells <- if (is.null(cell_col)) rownames(coords) else coords[[cell_col]]
-    rownames(coords) <- cells
-    x_col <- spatial_dim_pick_col(
-      coords,
-      c("x", "pxl_col_in_fullres", "imagecol")
-    )
-    y_col <- spatial_dim_pick_col(
-      coords,
-      c("y", "pxl_row_in_fullres", "imagerow")
-    )
-    scale <- spatial_dim_image_scale(srt[[image]])
-    image_array <- srt[[image]]@image
-    image_height <- dim(image_array)[1L]
-    image_width <- dim(image_array)[2L]
-    out <- data.frame(
-      x = coords[[x_col]] * scale,
-      y = image_height - coords[[y_col]] * scale,
-      row.names = cells,
-      stringsAsFactors = FALSE
-    )
-    image_info <- list(
-      image = image_array,
-      width = image_width,
-      height = image_height
-    )
-    return(list(data = out, image = image_info, uses_image = TRUE))
   }
-
-  out <- scop_spatial_metadata_coords(srt, coord.cols = coord.cols)
-  list(data = out, image = image_info, uses_image = FALSE)
+  list(
+    data = out,
+    image = image_info,
+    uses_image = FALSE,
+    source = attr(out, "spatial_source"),
+    transform = raw$transform
+  )
 }
 
 spatial_dim_value_items <- function(values) {

--- a/R/standard_scop.R
+++ b/R/standard_scop.R
@@ -18,7 +18,8 @@
 #' When the object also contains `ChromatinAssay`, the default assay and
 #' additional `ChromatinAssay` will be preprocessed sequentially.
 #' @param image Name of the Seurat spatial image used by the spatial workflow.
-#' If `NULL`, the first image is used when present.
+#' Required when multiple images are present; a single image is selected
+#' automatically when `NULL`.
 #' @param coord.cols Metadata coordinate columns used by the spatial workflow
 #' when no image is available.
 #' @param do_spot_qc Whether to run [RunSpotQC()] in the spatial workflow.

--- a/man/Cell2locationPlot.Rd
+++ b/man/Cell2locationPlot.Rd
@@ -29,8 +29,8 @@ or pie plots.}
 
 \item{tool_name}{Name of the \code{srt@tools} result entry.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{overlay_image}{Whether to draw the spatial image beneath spots.}
 

--- a/man/GiottoPlot.Rd
+++ b/man/GiottoPlot.Rd
@@ -89,8 +89,8 @@ GiottoPlot(x, ...)
 \item{srt}{Original `Seurat` object used to create the Giotto result. Required
 for spatial spot plots.}
 
-\item{image}{Name of the Seurat spatial image. If `NULL`, the first image is
-used when available.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when `NULL`.}
 
 \item{coord.cols}{Metadata coordinate columns used when no image is available.}
 

--- a/man/RunGiottoCellProximity.Rd
+++ b/man/RunGiottoCellProximity.Rd
@@ -37,7 +37,8 @@ additional \code{ChromatinAssay} will be preprocessed sequentially.}
 \item{layer}{Assay layer used as the expression matrix.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used by the spatial workflow
 when no image is available.}

--- a/man/RunGiottoCluster.Rd
+++ b/man/RunGiottoCluster.Rd
@@ -40,7 +40,8 @@ additional \code{ChromatinAssay} will be preprocessed sequentially.}
 variable features are used, falling back to all assay features.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used by the spatial workflow
 when no image is available.}

--- a/man/RunGiottoSpatialGenes.Rd
+++ b/man/RunGiottoSpatialGenes.Rd
@@ -39,7 +39,8 @@ additional \code{ChromatinAssay} will be preprocessed sequentially.}
 current variable features are used, falling back to all assay features.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used by the spatial workflow
 when no image is available.}

--- a/man/RunGiottoSpatialModules.Rd
+++ b/man/RunGiottoSpatialModules.Rd
@@ -40,7 +40,8 @@ additional \code{ChromatinAssay} will be preprocessed sequentially.}
 features.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used by the spatial workflow
 when no image is available.}

--- a/man/RunMERINGUE.Rd
+++ b/man/RunMERINGUE.Rd
@@ -42,7 +42,8 @@ additional \code{ChromatinAssay} will be preprocessed sequentially.}
 \item{layer}{Assay layer used for expression values.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used by the spatial workflow
 when no image is available.}

--- a/man/RunMistyR.Rd
+++ b/man/RunMistyR.Rd
@@ -44,8 +44,8 @@ RunMistyR(
 \item{features}{Features used by MISTy. If \code{NULL}, variable features are used
 when available; otherwise all assay features are used.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used when no Seurat image
 coordinates are available.}

--- a/man/RunSmoothClust.Rd
+++ b/man/RunSmoothClust.Rd
@@ -42,8 +42,8 @@ RunSmoothClust(
 
 \item{layer}{Assay layer used for expression values.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used when no Seurat image is
 available.}

--- a/man/RunSpaNorm.Rd
+++ b/man/RunSpaNorm.Rd
@@ -30,7 +30,8 @@ additional \code{ChromatinAssay} will be preprocessed sequentially.}
 \item{layer}{Assay layer used for expression values.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used by the spatial workflow
 when no image is available.}

--- a/man/RunSpatialGradientFeatures.Rd
+++ b/man/RunSpatialGradientFeatures.Rd
@@ -84,7 +84,8 @@ features, then all assay features.}
 to \code{SPATA2::asSPATA2()} when \code{spata_object} is \code{NULL}.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used by the native \code{"cpp"}
 backend when no image coordinates are available.}

--- a/man/RunSpatialIntegration.Rd
+++ b/man/RunSpatialIntegration.Rd
@@ -45,7 +45,8 @@ when no image is available.}
 used; if no variable features are present, all assay features are used.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{reduction.name}{Name of the integrated embedding reduction. If \code{NULL},
 a method-specific name is used.}

--- a/man/RunSpatialNeighborhood.Rd
+++ b/man/RunSpatialNeighborhood.Rd
@@ -41,8 +41,8 @@ RunSpatialNeighborhood(
 \item{coord.cols}{Metadata coordinate columns used when no Seurat image
 coordinates are available.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{sample.by}{Metadata column identifying images or samples. If \code{NULL},
 all spots are treated as one sample.}

--- a/man/RunSpatialVariableFeatures.Rd
+++ b/man/RunSpatialVariableFeatures.Rd
@@ -40,7 +40,8 @@ used; if no variable features are present, all assay features are used.}
 \item{method}{Spatial variable feature detection method.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used by the spatial workflow
 when no image is available.}

--- a/man/RunSpotSweeper.Rd
+++ b/man/RunSpotSweeper.Rd
@@ -43,8 +43,8 @@ RunSpotSweeper(
 \item{coord.cols}{Metadata coordinate columns used when no Seurat image is
 available.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{sample.by}{Optional metadata column identifying samples or images.
 If \code{NULL}, all spots are treated as one sample.}

--- a/man/RunStatialKontextual.Rd
+++ b/man/RunStatialKontextual.Rd
@@ -42,8 +42,8 @@ Ignored when \code{parent_df} is supplied.}
 
 \item{parent_df}{Optional data frame from \code{Statial::parentCombinations()}.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{sample.by}{Optional metadata column used as Statial \code{imageID}. If
 \code{NULL}, all cells or spots are treated as one image.}

--- a/man/SeuratToScopGiotto.Rd
+++ b/man/SeuratToScopGiotto.Rd
@@ -36,7 +36,8 @@ Giotto expression and records SCT availability. `"none"` ignores SCT.
 `"normalized"` adds SCT normalized values as an additional expression layer.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used by the spatial workflow
 when no image is available.}

--- a/man/SpatialCoordinates.Rd
+++ b/man/SpatialCoordinates.Rd
@@ -9,7 +9,7 @@ SpatialCoordinates(
   image = NULL,
   coord.cols = c("col", "row"),
   space = c("raw", "display"),
-  image_policy = c("strict", "legacy_first")
+  image_policy = "strict"
 )
 }
 \arguments{

--- a/man/SpatialEcoTyperSpatialPlot.Rd
+++ b/man/SpatialEcoTyperSpatialPlot.Rd
@@ -26,8 +26,8 @@ SpatialEcoTyperSpatialPlot(
 \item{x.by, y.by}{Metadata coordinate columns used when no image coordinates
 are available.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{overlay_image}{Whether to draw the spatial image beneath spots.}
 

--- a/man/SpatialGradientPlot.Rd
+++ b/man/SpatialGradientPlot.Rd
@@ -51,8 +51,8 @@ result are used.}
 
 \item{layer}{Assay layer used for \code{features}.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{overlay_image}{Whether to draw the spatial image beneath spots.}
 

--- a/man/SpatialNeighborhoodPlot.Rd
+++ b/man/SpatialNeighborhoodPlot.Rd
@@ -65,8 +65,8 @@ method is used.}
 \item{pair}{Pair to visualize for \code{plot_type = "spatial"}, either
 \code{"from|to"} or a length-2 character vector.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{overlay_image}{Whether to draw the spatial image beneath spots.}
 

--- a/man/SpatialSpotPlot.Rd
+++ b/man/SpatialSpotPlot.Rd
@@ -79,8 +79,8 @@ spatial points, such as cell-to-spot assignments.}
 
 \item{geom}{Geometry used for \code{plot.data}: \code{"point"} or \code{"jitter"}.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{overlay_image}{Whether to draw the spatial image beneath spots.}
 

--- a/man/SpatialVariableFeaturePlot.Rd
+++ b/man/SpatialVariableFeaturePlot.Rd
@@ -47,8 +47,8 @@ spatial variable feature result are used.}
 
 \item{layer}{Assay layer used for \code{features}.}
 
-\item{image}{Name of the Seurat spatial image. If \code{NULL}, the first image is
-used when present.}
+\item{image}{Name of the Seurat spatial image. Required when multiple images
+are present; a single image is selected automatically when \code{NULL}.}
 
 \item{overlay_image}{Whether to draw the spatial image beneath spots.}
 

--- a/man/standard_scop.Rd
+++ b/man/standard_scop.Rd
@@ -70,7 +70,8 @@ When the object also contains \code{ChromatinAssay}, the default assay and
 additional \code{ChromatinAssay} will be preprocessed sequentially.}
 
 \item{image}{Name of the Seurat spatial image used by the spatial workflow.
-If \code{NULL}, the first image is used when present.}
+Required when multiple images are present; a single image is selected
+automatically when \code{NULL}.}
 
 \item{coord.cols}{Metadata coordinate columns used by the spatial workflow
 when no image is available.}

--- a/tests/testthat/test-cell2location.R
+++ b/tests/testthat/test-cell2location.R
@@ -201,6 +201,20 @@ test_that("Cell2locationPlot exposes all result views", {
   }
 })
 
+test_that("Cell2locationPlot requires explicit selection for multi-image objects", {
+  data("visium_mouse_brain_slices_sub", package = "scop")
+  srt <- visium_mouse_brain_slices_sub
+  srt$Cell2location_dominant_type <- rep(c("Alpha", "Beta"), length.out = ncol(srt))
+
+  expect_error(
+    Cell2locationPlot(srt, "dominant"),
+    "Multiple spatial images"
+  )
+  plotted <- Cell2locationPlot(srt, "dominant", image = "anterior1")
+  expect_s3_class(plotted, "ggplot")
+  expect_identical(nrow(plotted$data), 1000L)
+})
+
 test_that("standard spatial workflow dispatches cell2location signatures", {
   pair <- make_cell2location_pair()
   signatures <- matrix(

--- a/tests/testthat/test-spatial-core.R
+++ b/tests/testthat/test-spatial-core.R
@@ -116,8 +116,39 @@ test_that("SpatialCoordinates makes multi-image selection explicit", {
   selected <- SpatialCoordinates(srt, image = "slice2")
   expect_identical(selected$data$cell_id, c("spot3", "spot4"))
   expect_identical(selected$source$image, "slice2")
-  legacy <- SpatialCoordinates(srt, image_policy = "legacy_first")
-  expect_identical(legacy$source$image, "slice1")
+  expect_error(
+    SpatialCoordinates(srt, image_policy = "legacy_first"),
+    "should be.*strict"
+  )
+})
+
+test_that("analysis and plotting never silently select the first spatial image", {
+  data("visium_mouse_brain_slices_sub", package = "scop")
+  srt <- visium_mouse_brain_slices_sub
+  expect_identical(length(SeuratObject::Images(srt)), 2L)
+  expect_equal(ncol(srt), 2000L)
+
+  expect_error(scop:::spatial_analysis_coords(srt), "Multiple spatial images")
+  expect_error(
+    SpatialSpotPlot(srt, group.by = "orig.ident"),
+    "Multiple spatial images"
+  )
+
+  selected <- scop:::spatial_analysis_coords(srt, image = "anterior2")
+  expect_identical(nrow(selected$data), 1000L)
+  expect_identical(selected$source$image, "anterior2")
+  expect_identical(selected$source$coordinate_space, "legacy_display")
+  expect_identical(selected$source$coord.cols, c("x", "y"))
+  expect_true(all(c("scale", "y_flip", "raw_x_col", "raw_y_col") %in%
+    names(selected$transform)))
+
+  plotted <- SpatialSpotPlot(
+    srt,
+    group.by = "orig.ident",
+    image = "anterior2"
+  )
+  expect_s3_class(plotted, "ggplot")
+  expect_identical(nrow(plotted$data), 1000L)
 })
 
 test_that("schema-v1 results support custom keys and legacy read-only views", {

--- a/tests/testthat/test-spatial-static-contracts.R
+++ b/tests/testthat/test-spatial-static-contracts.R
@@ -15,6 +15,26 @@ test_that("spatial registry covers the complete public surface", {
   expect_true(all(backend_ids %in% names(scop:::spatial_backend_registry())))
 })
 
+test_that("spatial code does not bypass strict image resolution", {
+  r_dir <- testthat::test_path("..", "..", "R")
+  files <- list.files(r_dir, pattern = "\\.R$", full.names = TRUE)
+  forbidden <- c(
+    "image\\s*<-\\s*image\\s*%\\|\\|%\\s*images\\s*\\[",
+    "GetTissueCoordinates\\([^)]*images\\s*\\[",
+    "images\\s*\\[\\s*\\[?\\s*1L?\\s*\\]?\\s*\\]"
+  )
+  violations <- unlist(lapply(files, function(path) {
+    lines <- readLines(path, warn = FALSE)
+    hits <- unique(unlist(lapply(forbidden, grep, x = lines, perl = TRUE)))
+    approved <- identical(basename(path), "SpatialCore.R") &
+      trimws(lines[hits]) == "image <- images[[1L]]"
+    hits <- hits[!approved]
+    if (length(hits) == 0L) return(character())
+    paste0(basename(path), ":", hits)
+  }), use.names = FALSE)
+  expect_identical(violations, character())
+})
+
 test_that("registered small analyses emit schema-v1 result families", {
   registry <- scop:::spatial_method_registry()
   target <- registry[

--- a/tests/testthat/test-spatial-static-contracts.R
+++ b/tests/testthat/test-spatial-static-contracts.R
@@ -32,6 +32,7 @@ test_that("spatial code does not bypass strict image resolution", {
     if (length(hits) == 0L) return(character())
     paste0(basename(path), ":", hits)
   }), use.names = FALSE)
+  if (is.null(violations)) violations <- character()
   expect_identical(violations, character())
 })
 

--- a/vignettes/articles/spatial-main-workflow.Rmd
+++ b/vignettes/articles/spatial-main-workflow.Rmd
@@ -269,6 +269,10 @@ Distance-sensitive methods retain `coordinate_space = "legacy_display"` as
 the compatibility default in this release. Set `coordinate_space = "raw"`
 when radius or distance values must stay in original acquisition units. Plot
 functions continue to map results to display coordinates by cell or spot ID.
+Objects with multiple spatial images must always select one explicitly with
+`image`; analysis, plotting, and framework conversion never silently use the
+first image. A future release will make raw coordinates the default for all
+distance-sensitive producers.
 
 ```r
 spatial <- RunMistyR(


### PR DESCRIPTION
## Summary

- Centralize spatial image resolution and raw-to-display coordinate conversion.
- Require explicit `image` selection for multi-image Seurat objects across analysis, plotting, and framework bridges.
- Retain the `legacy_display` coordinate default while recording the selected image, coordinate columns, coordinate space, and transform.
- Remove CytoSPACE fake-coordinate and first-image fallbacks.
- Add two-slice regression tests and a static guard against direct first-image selection.

## Verification

- Spatial coordinate/core, Cell2location plot, registry/static contract, SVF, Neighborhood, Integration, Gradient, Giotto, MistyR, Statial, SpotSweeper, and baseline tests passed.
- 24 changed Rd files passed `tools::Rd2ex()` plus `parse()`.
- `pkgload::load_all()` passed.
- The required `_R_CHECK_FORCE_SUGGESTS_=false` check completed with 0 errors, 1 inherited Makevars warning, and 3 inherited notes.
- `checking dependencies in R code ... OK`.
- `checking for unstated dependencies in examples ... OK`.

## Migration note

`coordinate_space = "legacy_display"` remains the compatibility default for this release. A later release can switch distance-sensitive producers to raw coordinates after downstream migration.
