### PR TITLE
fix: match current GSVA PLAGE scaling

### DIFF
--- a/src/GeneSetScoring.cpp
+++ b/src/GeneSetScoring.cpp
@@ -1312,36 +1312,35 @@ NumericMatrix plage_dense(
       if (!row_needed[gene]) {
         continue;
       }
-      // GSVA::plage() preserves a sparse matrix and calls scale() only on
-      // stored values.  Structural zeros remain zero, so the PLAGE SVD must
-      // use non-zero-only means and standard deviations here.
+      // Current GSVA filters rows whose non-zero values are constant, then
+      // scales complete expression rows before PLAGE. Structural zeros
+      // therefore contribute their centered and scaled value.
       const int nonzero_count = row_counts[gene];
+      bool nonzero_variable = false;
       if (nonzero_count > 1) {
-        const double mean = row_sums[gene] / static_cast<double>(nonzero_count);
-        double var = (row_sq_sums[gene] - static_cast<double>(nonzero_count) * mean * mean) /
+        const double nonzero_mean = row_sums[gene] / static_cast<double>(nonzero_count);
+        double nonzero_var = (row_sq_sums[gene] -
+          static_cast<double>(nonzero_count) * nonzero_mean * nonzero_mean) /
           static_cast<double>(nonzero_count - 1);
-        if (var < 0.0 && var > -1e-12) {
-          var = 0.0;
+        if (nonzero_var < 0.0 && nonzero_var > -1e-12) {
+          nonzero_var = 0.0;
         }
-        if (R_finite(var) && var > 0.0) {
-          row_means[gene] = mean;
-          row_sds[gene] = std::sqrt(var);
-          row_valid[gene] = 1;
-        }
+        nonzero_variable = R_finite(nonzero_var) && nonzero_var > 0.0;
       }
 
-      // Keep the original dense-expression standardization separately for
-      // deterministic score orientation. This mirrors orient_plage_scores().
-      const double orient_mean = row_sums[gene] / static_cast<double>(n_cells);
-      double orient_var = (row_sq_sums[gene] -
-        static_cast<double>(n_cells) * orient_mean * orient_mean) /
+      const double mean = row_sums[gene] / static_cast<double>(n_cells);
+      double var = (row_sq_sums[gene] -
+        static_cast<double>(n_cells) * mean * mean) /
         static_cast<double>(n_cells - 1);
-      if (orient_var < 0.0 && orient_var > -1e-12) {
-        orient_var = 0.0;
+      if (var < 0.0 && var > -1e-12) {
+        var = 0.0;
       }
-      if (R_finite(orient_var) && orient_var > 0.0) {
-        orient_row_means[gene] = orient_mean;
-        orient_row_sds[gene] = std::sqrt(orient_var);
+      if (nonzero_variable && R_finite(var) && var > 0.0) {
+        row_means[gene] = mean;
+        row_sds[gene] = std::sqrt(var);
+        row_valid[gene] = 1;
+        orient_row_means[gene] = mean;
+        orient_row_sds[gene] = row_sds[gene];
         orient_row_valid[gene] = 1;
       }
     }
@@ -1372,10 +1371,13 @@ NumericMatrix plage_dense(
       static_cast<arma::uword>(n_cells),
       arma::fill::zeros
     );
-    // Match GSVA::plage() sparse semantics: only stored values are centered
-    // and scaled; structural zeros remain zero.
+    // Match current GSVA::plage(): center and scale the complete row while
+    // retaining sparse input traversal.
     for (int row = 0; row < effective_size; ++row) {
       const int gene = valid_genes[row];
+      z.row(static_cast<arma::uword>(row)).fill(
+        -row_means[gene] / row_sds[gene]
+      );
       const int row_start = row_ptr[gene];
       const int row_end = row_ptr[gene + 1];
       for (int ptr = row_start; ptr < row_end; ++ptr) {

--- a/tests/testthat/test-gene-set-scoring-cpp.R
+++ b/tests/testthat/test-gene-set-scoring-cpp.R
@@ -70,19 +70,12 @@ reference_plage_scores <- function(expr, gene_sets, min_size = 1L, max_size = .M
   n_genes <- nrow(expr)
   n_cells <- ncol(expr)
   scores <- matrix(NA_real_, n_cells, length(gene_sets))
-  z <- matrix(0, nrow = n_genes, ncol = n_cells)
-  row_valid <- logical(n_genes)
-  for (gene in seq_len(n_genes)) {
-    nonzero <- which(expr[gene, ] != 0 & is.finite(expr[gene, ]))
-    if (length(nonzero) <= 1L) {
-      next
-    }
-    scaled <- scale(expr[gene, nonzero])
-    if (all(is.finite(scaled))) {
-      z[gene, nonzero] <- scaled
-      row_valid[gene] <- TRUE
-    }
-  }
+  z <- t(scale(t(expr)))
+  row_valid <- vapply(seq_len(n_genes), function(gene) {
+    nonzero <- expr[gene, expr[gene, ] != 0 & is.finite(expr[gene, ])]
+    length(nonzero) > 1L && is.finite(stats::sd(nonzero)) &&
+      stats::sd(nonzero) > 0 && all(is.finite(z[gene, ]))
+  }, logical(1L))
   orient_mean <- rowMeans(expr)
   orient_sd <- apply(expr, 1L, stats::sd)
   orient_valid <- is.finite(orient_sd) & orient_sd > 0
@@ -149,8 +142,9 @@ test_that("PLAGE gene-gene covariance path matches right singular vector scores"
   expect_equal(cpp, ref, tolerance = 1e-12, ignore_attr = TRUE)
 })
 
-test_that("PLAGE sparse standardization matches GSVA", {
+test_that("PLAGE complete-row standardization matches current GSVA", {
   skip_if_not_installed("GSVA")
+  skip_if(packageVersion("GSVA") < "2.6.0", "GSVA before 2.6 used legacy sparse scaling")
   set.seed(20260711)
   expr <- matrix(stats::rpois(18 * 41, lambda = 0.9), nrow = 18)
   expr[expr < 2] <- 0


### PR DESCRIPTION
## Summary

- update the C++ PLAGE path to match complete-row standardization in current GSVA
- retain current GSVA's non-zero variability filter before complete-row scaling
- keep legacy GSVA behavior out of scope and skip the cross-version comparison before GSVA 2.6

## Root cause

The current implementation centered and scaled only stored sparse values, leaving structural zeros unchanged. Current GSVA scales the complete expression row after filtering rows with constant non-zero values. On current Linux and Windows CI this produced correlations around 0.21 instead of 1.0 in `PLAGE sparse standardization matches GSVA`.

This fix was intentionally separated from the spatial transcriptomics pull requests so their diffs remain scoped.

## Verification

- `devtools::test(filter = "gene-set-scoring-cpp", stop_on_failure = TRUE)`
- `pkgload::load_all(".", quiet = TRUE, compile = FALSE)`
- `_R_CHECK_FORCE_SUGGESTS_=false rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran", "--no-examples", "--no-tests"), error_on = "never")`
- result: 0 errors, 1 inherited GNU Makevars warning, 3 inherited notes
- `checking dependencies in R code ... OK`
- `checking for unstated dependencies in examples ... OK`
