### PR TITLE
Harden spatial platform contracts

### DIFF
--- a/R/RunCytoSPACE.R
+++ b/R/RunCytoSPACE.R
@@ -185,6 +185,14 @@ RunCytoSPACE <- function(
     seed = seed
   )
 
+  coords <- cytospace_get_spatial_coords(
+    srt,
+    spot_ids,
+    image = image,
+    coord.cols = coord.cols,
+    coordinate_space = coordinate_space
+  )
+
   log_message(
     "Run CytoSPACE with {.val {length(features_use)}} features, {.val {ncol(ref_sample$expr)}} sampled reference cells, and {.val {ncol(st_expr)}} spatial spots",
     verbose = verbose
@@ -202,13 +210,6 @@ RunCytoSPACE <- function(
     verbose = verbose
   )
 
-  coords <- cytospace_get_spatial_coords(
-    srt,
-    spot_ids,
-    image = image,
-    coord.cols = coord.cols,
-    coordinate_space = coordinate_space
-  )
   assignments <- cytospace_build_assignment_table(
     result = result,
     sampled_cells = ref_sample$cell_ids,

--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -703,18 +703,13 @@ rctd_run_spacexr <- function(
   run_rctd_params
 ) {
   rctd_require_namespaces("spacexr")
-  ns <- asNamespace("spacexr")
-  has_new_api <- exists("createRctd", envir = ns, inherits = FALSE) &&
-    exists("runRctd", envir = ns, inherits = FALSE)
-  has_old_api <- all(vapply(
-    c("SpatialRNA", "Reference", "create.RCTD", "run.RCTD"),
-    exists,
-    logical(1),
-    envir = ns,
-    inherits = FALSE
-  ))
+  exports <- getNamespaceExports("spacexr")
+  spec <- spatial_backend_registry()[["spacexr"]]
+  selected_api <- spatial_backend_required_symbols(spec, exports = exports)
+  new_api <- spec$symbol_sets[["new"]]
+  legacy_api <- spec$symbol_sets[["legacy"]]
 
-  if (isTRUE(has_new_api)) {
+  if (all(new_api %in% exports) && identical(selected_api, new_api)) {
     return(rctd_run_spacexr_new(
       st_counts = st_counts,
       coords = coords,
@@ -728,9 +723,8 @@ rctd_run_spacexr <- function(
       run_rctd_params = run_rctd_params
     ))
   }
-  if (isTRUE(has_old_api)) {
+  if (all(legacy_api %in% exports) && identical(selected_api, legacy_api)) {
     return(rctd_run_spacexr_old(
-      ns = ns,
       st_counts = st_counts,
       coords = coords,
       st_numi = st_numi,
@@ -805,7 +799,21 @@ rctd_run_spacexr_new <- function(
 rctd_require_namespaces <- function(pkgs) {
   install_specs <- pkgs
   install_specs[install_specs == "spacexr"] <- "dmcable/spacexr"
-  available <- vapply(install_specs, check_r, logical(1), verbose = FALSE)
+  available <- unlist(
+    check_r(install_specs, verbose = FALSE),
+    use.names = TRUE
+  )
+  if (
+    !is.logical(available) || length(available) != length(pkgs) ||
+      is.null(names(available)) || anyNA(available) ||
+      !setequal(names(available), pkgs)
+  ) {
+    log_message(
+      "Package availability checks returned an invalid result for {.fn RunRCTD}",
+      message_type = "error"
+    )
+  }
+  available <- available[match(pkgs, names(available))]
   if (!all(available)) {
     log_message(
       "Please install required package(s) before running {.fn RunRCTD}: {.val {paste(pkgs[!available], collapse = ', ')}}",
@@ -816,7 +824,6 @@ rctd_require_namespaces <- function(pkgs) {
 }
 
 rctd_run_spacexr_old <- function(
-  ns,
   st_counts,
   coords,
   st_numi,
@@ -828,10 +835,10 @@ rctd_run_spacexr_old <- function(
   create_rctd_params,
   run_rctd_params
 ) {
-  spatial_rna <- get("SpatialRNA", envir = ns)
-  reference_fun <- get("Reference", envir = ns)
-  create_rctd <- get("create.RCTD", envir = ns)
-  run_rctd <- get("run.RCTD", envir = ns)
+  spatial_rna <- get_namespace_fun("spacexr", "SpatialRNA")
+  reference_fun <- get_namespace_fun("spacexr", "Reference")
+  create_rctd <- get_namespace_fun("spacexr", "create.RCTD")
+  run_rctd <- get_namespace_fun("spacexr", "run.RCTD")
   puck <- spatial_rna(coords, st_counts, st_numi)
   reference_obj <- reference_fun(ref_counts, ref_labels, ref_numi)
   create_args <- c(
@@ -845,8 +852,9 @@ rctd_run_spacexr_old <- function(
   )
   result <- do.call(run_rctd, run_args)
   weights <- result@results$weights
-  if (exists("normalize_weights", envir = ns, inherits = FALSE)) {
-    weights <- get("normalize_weights", envir = ns)(weights)
+  if ("normalize_weights" %in% getNamespaceExports("spacexr")) {
+    normalize_weights <- get_namespace_fun("spacexr", "normalize_weights")
+    weights <- normalize_weights(weights)
   }
   metadata <- tryCatch(
     as.data.frame(result@results$results_df),

--- a/R/RunSemla.R
+++ b/R/RunSemla.R
@@ -4,6 +4,8 @@
 #' Use the optional `semla` package as a backend to prepare a Staffli-enabled
 #' Seurat object and compute spot-level spatial networks. The network is stored
 #' in `srt@tools[[tool_name]]` when `store_results = TRUE`.
+#' SCOP provides no dedicated plot for this result; retrieve it with
+#' [GetSpatialResult()] and use an existing generic spatial plot when needed.
 #'
 #' @md
 #' @inheritParams thisutils::log_message
@@ -81,8 +83,12 @@ RunSemlaSpatialNetwork <- function(
   )
 
   if (isTRUE(store_results)) {
-    srt@tools[[tool_name]] <- list(
-      network = spatial_network,
+    srt@tools[[tool_name]] <- spatial_result_build(
+      bundle = list(network = spatial_network),
+      method = "SemlaSpatialNetwork",
+      result_type = "neighborhood",
+      source = list(coordinate_space = if (coords == "array") "raw" else "legacy_display"),
+      provenance = list(producer = "RunSemlaSpatialNetwork", backend_id = "semla"),
       parameters = list(
         image_type = image_type,
         nNeighbors = nNeighbors,
@@ -91,7 +97,8 @@ RunSemlaSpatialNetwork <- function(
         coords = coords,
         tool_name = tool_name,
         store_results = store_results
-      )
+      ),
+      summary = list(n_networks = length(spatial_network))
     )
   }
   log_message(
@@ -108,6 +115,8 @@ RunSemlaSpatialNetwork <- function(
 #' Use `semla::RunLocalG()` on a Staffli-enabled Seurat object. Results are
 #' written by semla to metadata or to an assay, depending on
 #' `store_in_metadata`.
+#' SCOP provides no dedicated plot for this result; retrieve its schema record
+#' with [GetSpatialResult()] and inspect the recorded output columns or assay.
 #'
 #' @md
 #' @inheritParams RunSemlaSpatialNetwork
@@ -159,7 +168,8 @@ RunSemlaLocalG <- function(
     image_type = image_type,
     verbose = verbose
   )
-  semla_get_fun("RunLocalG")(
+  before_metadata <- colnames(srt@meta.data)
+  out <- semla_get_fun("RunLocalG")(
     srt,
     features = features,
     alternative = alternative,
@@ -168,6 +178,14 @@ RunSemlaLocalG <- function(
     verbose = verbose,
     ...
   )
+  out@tools[["SemlaLocalG"]] <- spatial_result_build(
+    bundle = list(output_columns = setdiff(colnames(out@meta.data), before_metadata)),
+    method = "SemlaLocalG", result_type = "neighborhood",
+    source = list(coordinate_space = "legacy_display"),
+    provenance = list(producer = "RunSemlaLocalG", backend_id = "semla"),
+    parameters = list(features = features, alternative = alternative, store_in_metadata = store_in_metadata, assay_name = assay_name, image_type = image_type)
+  )
+  out
 }
 
 #' @title Run semla region neighbor detection
@@ -175,6 +193,8 @@ RunSemlaLocalG <- function(
 #' @description
 #' Use `semla::RegionNeighbors()` to identify neighboring spots for selected
 #' metadata labels and write the returned columns to Seurat metadata.
+#' SCOP provides no dedicated plot for this result; retrieve its schema record
+#' with [GetSpatialResult()] and inspect the recorded metadata columns.
 #'
 #' @md
 #' @inheritParams RunSemlaSpatialNetwork
@@ -233,7 +253,8 @@ RunSemlaRegionNeighbors <- function(
     image_type = image_type,
     verbose = verbose
   )
-  semla_get_fun("RegionNeighbors")(
+  before_metadata <- colnames(srt@meta.data)
+  out <- semla_get_fun("RegionNeighbors")(
     srt,
     column_name = column_name,
     column_labels = column_labels,
@@ -242,6 +263,14 @@ RunSemlaRegionNeighbors <- function(
     verbose = verbose,
     ...
   )
+  out@tools[["SemlaRegionNeighbors"]] <- spatial_result_build(
+    bundle = list(output_columns = setdiff(colnames(out@meta.data), before_metadata)),
+    method = "SemlaRegionNeighbors", result_type = "neighborhood",
+    source = list(coordinate_space = "legacy_display"),
+    provenance = list(producer = "RunSemlaRegionNeighbors", backend_id = "semla"),
+    parameters = list(column_name = column_name, column_labels = column_labels, mode = mode, column_key = column_key, image_type = image_type)
+  )
+  out
 }
 
 #' @title Run semla radial distance analysis
@@ -249,6 +278,8 @@ RunSemlaRegionNeighbors <- function(
 #' @description
 #' Use `semla::RadialDistance()` to calculate distances from selected spatial
 #' regions and write the returned columns to Seurat metadata.
+#' SCOP provides no dedicated plot for this result; retrieve its schema record
+#' with [GetSpatialResult()] and inspect the recorded metadata columns.
 #'
 #' @md
 #' @inheritParams RunSemlaSpatialNetwork
@@ -308,7 +339,8 @@ RunSemlaRadialDistance <- function(
     image_type = image_type,
     verbose = verbose
   )
-  semla_get_fun("RadialDistance")(
+  before_metadata <- colnames(srt@meta.data)
+  out <- semla_get_fun("RadialDistance")(
     srt,
     column_name = column_name,
     selected_groups = selected_groups,
@@ -316,6 +348,14 @@ RunSemlaRadialDistance <- function(
     verbose = verbose,
     ...
   )
+  out@tools[["SemlaRadialDistance"]] <- spatial_result_build(
+    bundle = list(output_columns = setdiff(colnames(out@meta.data), before_metadata)),
+    method = "SemlaRadialDistance", result_type = "neighborhood",
+    source = list(coordinate_space = "legacy_display"),
+    provenance = list(producer = "RunSemlaRadialDistance", backend_id = "semla"),
+    parameters = list(column_name = column_name, selected_groups = selected_groups, column_suffix = column_suffix, image_type = image_type)
+  )
+  out
 }
 
 semla_prepare_srt <- function(

--- a/R/RunSpatialNeighborhood.R
+++ b/R/RunSpatialNeighborhood.R
@@ -650,11 +650,15 @@ spatial_neighborhood_run_spicyr <- function(
 }
 
 spatial_neighborhood_standardize_pair_table <- function(backend, observed, method) {
+  if (identical(method, "observed")) {
+    return(observed)
+  }
   raw_df <- backend$table
   if (is.null(raw_df) || nrow(raw_df) == 0L) {
-    out <- observed
-    out$method <- method
-    return(out)
+    log_message(
+      "{.pkg spicyR} returned no neighborhood comparison results",
+      message_type = "error"
+    )
   }
 
   df <- as.data.frame(raw_df, stringsAsFactors = FALSE, check.names = FALSE)
@@ -669,22 +673,10 @@ spatial_neighborhood_standardize_pair_table <- function(backend, observed, metho
     to_col <- "to"
   }
   if (is.null(from_col) || is.null(to_col)) {
-    obs_summary <- stats::aggregate(
-      cbind(count, total, fraction) ~ from + to,
-      data = observed,
-      FUN = mean
+    log_message(
+      "{.pkg spicyR} returned an incompatible result without recognizable cell-type pair columns",
+      message_type = "error"
     )
-    obs_summary$method <- method
-    obs_summary$comparison <- "spicyR"
-    obs_summary$condition <- NA_character_
-    obs_summary$estimate <- obs_summary$fraction
-    obs_summary$statistic <- NA_real_
-    obs_summary$pval <- NA_real_
-    obs_summary$FDR <- NA_real_
-    obs_summary$direction <- "observed"
-    obs_summary$sample <- NA_character_
-    obs_summary$subject <- NA_character_
-    return(obs_summary[, colnames(observed), drop = FALSE])
   }
 
   estimate_col <- spatial_neighborhood_first_col(df, c("estimate", "coefficient", "coef", "logFC", "effect"))

--- a/R/SpatialCore.R
+++ b/R/SpatialCore.R
@@ -95,11 +95,10 @@ spatial_coords_raw <- function(
   finite <- is.finite(coords$x) & is.finite(coords$y)
   if (any(!finite)) {
     log_message(
-      "Drop {.val {sum(!finite)}} cell or spot coordinate{?s} with non-finite x or y values",
-      message_type = "warning"
+      "Spatial coordinates contain {.val {sum(!finite)}} cell or spot coordinate{?s} with non-finite x or y values",
+      message_type = "error"
     )
   }
-  coords <- coords[finite, , drop = FALSE]
   coords$cell_id <- rownames(coords)
   coords <- coords[, c("cell_id", "x", "y"), drop = FALSE]
   object_cells <- colnames(srt)
@@ -178,8 +177,41 @@ spatial_analysis_coords <- function(
       overlay_image = FALSE,
       image_policy = image_policy
     )
+    coords <- as.data.frame(display$data, stringsAsFactors = FALSE)
+    cells <- rownames(coords)
+    if (
+      is.null(cells) || anyNA(cells) || any(!nzchar(cells)) ||
+        anyDuplicated(cells)
+    ) {
+      log_message(
+        "Spatial display coordinates must have unique, non-missing cell or spot identifiers",
+        message_type = "error"
+      )
+    }
+    if (!all(c("x", "y") %in% colnames(coords))) {
+      log_message(
+        "Spatial display coordinates must contain x and y columns",
+        message_type = "error"
+      )
+    }
+    coords$x <- suppressWarnings(as.numeric(coords$x))
+    coords$y <- suppressWarnings(as.numeric(coords$y))
+    finite <- is.finite(coords$x) & is.finite(coords$y)
+    if (any(!finite)) {
+      log_message(
+        "Spatial display coordinates contain {.val {sum(!finite)}} cell or spot coordinate{?s} with non-finite x or y values",
+        message_type = "error"
+      )
+    }
+    coords$cell_id <- cells
+    object_cells <- colnames(srt)
+    keep <- object_cells[object_cells %in% coords$cell_id]
+    coords <- coords[match(keep, coords$cell_id), , drop = FALSE]
+    rownames(coords) <- coords$cell_id
+    coords$image <- display$source$image %||% NA_character_
+    coords <- coords[, c("cell_id", "x", "y", "image"), drop = FALSE]
     result <- list(
-      data = display$data,
+      data = coords,
       transform = display$transform,
       source = utils::modifyList(display$source, list(coordinate_space = coordinate_space))
     )

--- a/R/SpatialRegistry.R
+++ b/R/SpatialRegistry.R
@@ -52,6 +52,8 @@ spatial_method_registry <- function() {
     entry("giotto_to_srt", "bridge", "framework_bridge", "SpatialFrameworkConvert.R", backend_id = "giotto_class", coordinate_space_current = "raw", coordinate_requirement = "backend_managed"),
     entry("srt_to_spata2", "bridge", "framework_bridge", "SpatialFrameworkConvert.R", backend_id = "spata2", coordinate_space_current = "raw", coordinate_requirement = "backend_managed"),
     entry("spata2_to_srt", "bridge", "framework_bridge", "SpatialFrameworkConvert.R", backend_id = "spata2", coordinate_space_current = "raw", coordinate_requirement = "backend_managed"),
+    entry("srt_to_spe", "bridge", "framework_bridge", "SpatialDataConvert.R", backend_id = "core", coordinate_space_current = "raw", coordinate_requirement = "backend_managed"),
+    entry("spe_to_srt", "bridge", "framework_bridge", "SpatialDataConvert.R", backend_id = "core", coordinate_space_current = "raw", coordinate_requirement = "backend_managed"),
     entry("SeuratToScopGiotto", "bridge", "framework_bridge", "GiottoObject.R", "Giotto", "giotto;giotto_class", "legacy", "legacy_display", "legacy_display", "backend_managed"),
     entry("RunGiottoWorkflow", "workflow", "framework_workflow", "GiottoObject.R", "Giotto", "giotto;giotto_class", "legacy", "legacy_display", "legacy_display", "backend_managed", plot_function = "GiottoPlot"),
     entry("GiottoPreprocess", "analysis", "framework_workflow", "GiottoObject.R", "Giotto", "giotto", "legacy", "legacy_display", "legacy_display", "backend_managed", plot_function = "GiottoPlot"),
@@ -163,6 +165,7 @@ spatial_backend_registry <- function() {
     package,
     repository = package,
     symbols = character(),
+    symbol_sets = list(),
     runtime = "r",
     environment_modules = character(),
     requirements = character()
@@ -172,6 +175,7 @@ spatial_backend_registry <- function() {
       package = package,
       repository = repository,
       symbols = symbols,
+      symbol_sets = symbol_sets,
       runtime = runtime,
       environment_modules = environment_modules,
       requirements = requirements
@@ -209,7 +213,15 @@ spatial_backend_registry <- function() {
     bisquerna = backend("bisquerna", "BisqueRNA", symbols = "ReferenceBasedDecomposition"),
     bayesprism = backend("bayesprism", "BayesPrism", symbols = c("new.prism", "run.prism")),
     cibersort = backend("cibersort", "CIBERSORT", "Moonerss/CIBERSORT", "cibersort"),
-    spacexr = backend("spacexr", "spacexr", "dmcable/spacexr", c("createRctd", "runRctd")),
+    spacexr = backend(
+      "spacexr",
+      "spacexr",
+      "dmcable/spacexr",
+      symbol_sets = list(
+        new = c("createRctd", "runRctd"),
+        legacy = c("SpatialRNA", "Reference", "create.RCTD", "run.RCTD")
+      )
+    ),
     card = backend("card", "CARD", "YingMa0107/CARD"),
     stdeconvolve = backend("stdeconvolve", "STdeconvolve", "JEFworks-Lab/STdeconvolve", c("cleanCounts", "fitLDA")),
     spotlight = backend("spotlight", "SPOTlight", symbols = "SPOTlight"),
@@ -405,8 +417,30 @@ spatial_python_backend_status <- function(spec, envname, conda, api_check) {
   )
 }
 
-spatial_backend_required_symbols <- function(spec, method = NULL) {
+spatial_backend_required_symbols <- function(spec, method = NULL, exports = NULL) {
   symbols <- spec$symbols
+  symbol_sets <- spec$symbol_sets %||% list()
+  if (length(symbol_sets) > 0L) {
+    if (is.null(exports)) {
+      symbols <- symbol_sets[[1L]]
+    } else {
+      complete <- vapply(
+        symbol_sets,
+        function(candidate) all(candidate %in% exports),
+        logical(1)
+      )
+      if (any(complete)) {
+        symbols <- symbol_sets[[which(complete)[[1L]]]]
+      } else {
+        matched <- vapply(
+          symbol_sets,
+          function(candidate) sum(candidate %in% exports),
+          integer(1)
+        )
+        symbols <- symbol_sets[[which.max(matched)]]
+      }
+    }
+  }
   if (
     identical(spec$id, "giotto_class") &&
       !is.null(method) &&
@@ -509,6 +543,11 @@ SpatialBackendStatus <- function(
         if (is.null(exports)) {
           availability <- "namespace_error"
         } else {
+          symbols <- spatial_backend_required_symbols(
+            spec,
+            method = method,
+            exports = exports
+          )
           missing_symbols <- setdiff(symbols, exports)
           availability <- if (length(missing_symbols) == 0L) "available" else "api_incompatible"
         }

--- a/R/standard_scop.R
+++ b/R/standard_scop.R
@@ -977,6 +977,7 @@ standard_spatial_scop <- function(
         assay = assay,
         image = image,
         coord.cols = coord.cols,
+        coordinate_space = "raw",
         verbose = verbose,
         seed = seed
       ),
@@ -1085,6 +1086,7 @@ standard_spatial_scop <- function(
             )
             deconv_defaults$image <- image
             deconv_defaults$coord.cols <- coord.cols
+            deconv_defaults$coordinate_space <- "raw"
           }
           deconv_args <- standard_scop_merge_args(
             deconv_defaults,

--- a/man/RunSemlaLocalG.Rd
+++ b/man/RunSemlaLocalG.Rd
@@ -42,6 +42,8 @@ A \code{Seurat} object.
 Use \code{semla::RunLocalG()} on a Staffli-enabled Seurat object. Results are
 written by semla to metadata or to an assay, depending on
 \code{store_in_metadata}.
+SCOP provides no dedicated plot for this result; retrieve its schema record
+with \code{\link[=GetSpatialResult]{GetSpatialResult()}} and inspect the recorded output columns or assay.
 }
 \examples{
 data(visium_human_pancreas_sub)

--- a/man/RunSemlaRadialDistance.Rd
+++ b/man/RunSemlaRadialDistance.Rd
@@ -38,6 +38,8 @@ A \code{Seurat} object.
 \description{
 Use \code{semla::RadialDistance()} to calculate distances from selected spatial
 regions and write the returned columns to Seurat metadata.
+SCOP provides no dedicated plot for this result; retrieve its schema record
+with \code{\link[=GetSpatialResult]{GetSpatialResult()}} and inspect the recorded metadata columns.
 }
 \examples{
 data(visium_human_pancreas_sub)

--- a/man/RunSemlaRegionNeighbors.Rd
+++ b/man/RunSemlaRegionNeighbors.Rd
@@ -41,6 +41,8 @@ A \code{Seurat} object.
 \description{
 Use \code{semla::RegionNeighbors()} to identify neighboring spots for selected
 metadata labels and write the returned columns to Seurat metadata.
+SCOP provides no dedicated plot for this result; retrieve its schema record
+with \code{\link[=GetSpatialResult]{GetSpatialResult()}} and inspect the recorded metadata columns.
 }
 \examples{
 data(visium_human_pancreas_sub)

--- a/man/RunSemlaSpatialNetwork.Rd
+++ b/man/RunSemlaSpatialNetwork.Rd
@@ -48,6 +48,8 @@ A \code{Seurat} object.
 Use the optional \code{semla} package as a backend to prepare a Staffli-enabled
 Seurat object and compute spot-level spatial networks. The network is stored
 in \code{srt@tools[[tool_name]]} when \code{store_results = TRUE}.
+SCOP provides no dedicated plot for this result; retrieve it with
+\code{\link[=GetSpatialResult]{GetSpatialResult()}} and use an existing generic spatial plot when needed.
 }
 \examples{
 data(visium_human_pancreas_sub)

--- a/tests/testthat/test-rctd-cpp.R
+++ b/tests/testthat/test-rctd-cpp.R
@@ -123,3 +123,41 @@ test_that("RCTD finalize helper matches separate normalization and metadata help
   expect_equal(out$dominant, expected_meta$dominant)
   expect_equal(out$max_prop, expected_meta$max_prop)
 })
+
+test_that("RCTD normalizes check_r list results without adding a backend helper", {
+  testthat::local_mocked_bindings(
+    check_r = function(pkgs, verbose = FALSE) {
+      stats::setNames(as.list(rep(TRUE, length(pkgs))), c("spacexr", pkgs[-1L]))
+    },
+    .package = "scop"
+  )
+  expect_invisible(scop:::rctd_require_namespaces(c("spacexr", "S4Vectors")))
+
+  testthat::local_mocked_bindings(
+    check_r = function(pkgs, verbose = FALSE) list(unexpected = TRUE),
+    .package = "scop"
+  )
+  expect_error(
+    scop:::rctd_require_namespaces("spacexr"),
+    "invalid result"
+  )
+})
+
+test_that("spacexr API variants prefer new and accept complete legacy exports", {
+  spec <- scop:::spatial_backend_registry()[["spacexr"]]
+  expect_identical(
+    scop:::spatial_backend_required_symbols(spec, exports = spec$symbol_sets$new),
+    spec$symbol_sets$new
+  )
+  expect_identical(
+    scop:::spatial_backend_required_symbols(spec, exports = spec$symbol_sets$legacy),
+    spec$symbol_sets$legacy
+  )
+  expect_identical(
+    scop:::spatial_backend_required_symbols(
+      spec,
+      exports = c(spec$symbol_sets$new, spec$symbol_sets$legacy)
+    ),
+    spec$symbol_sets$new
+  )
+})

--- a/tests/testthat/test-semla.R
+++ b/tests/testthat/test-semla.R
@@ -68,6 +68,8 @@ test_that("RunSemlaSpatialNetwork stores semla network results", {
   expect_false(is.null(out@tools[["SemlaSpatialNetwork"]]))
   expect_type(out@tools[["SemlaSpatialNetwork"]][["network"]], "list")
   expect_equal(out@tools[["SemlaSpatialNetwork"]][["parameters"]][["nNeighbors"]], 3)
+  expect_equal(out@tools[["SemlaSpatialNetwork"]][["schema_version"]], 1L)
+  expect_equal(out@tools[["SemlaSpatialNetwork"]][["provenance"]][["backend_id"]], "semla")
 })
 
 test_that("RunSemlaLocalG writes local G metadata", {
@@ -82,4 +84,24 @@ test_that("RunSemlaLocalG writes local G metadata", {
   )
   expect_s4_class(out, "Seurat")
   expect_true(all(paste0("Gi[", features, "]") %in% colnames(out@meta.data)))
+  expect_equal(out@tools[["SemlaLocalG"]][["schema_version"]], 1L)
+  expect_equal(out@tools[["SemlaLocalG"]][["provenance"]][["producer"]], "RunSemlaLocalG")
+})
+
+test_that("Semla distance producers store schema-v1 provenance", {
+  skip_if_no_semla_backend()
+  srt <- make_semla_spatial_seurat()
+  neighbors <- RunSemlaRegionNeighbors(
+    srt, column_name = "semla_region", column_labels = "A",
+    mode = "outer", column_key = "A_neighbor", verbose = FALSE
+  )
+  expect_equal(neighbors@tools[["SemlaRegionNeighbors"]][["schema_version"]], 1L)
+  expect_equal(neighbors@tools[["SemlaRegionNeighbors"]][["provenance"]][["backend_id"]], "semla")
+
+  radial <- RunSemlaRadialDistance(
+    srt, column_name = "semla_region", selected_groups = "A",
+    column_suffix = "A_distance", verbose = FALSE
+  )
+  expect_equal(radial@tools[["SemlaRadialDistance"]][["schema_version"]], 1L)
+  expect_equal(radial@tools[["SemlaRadialDistance"]][["provenance"]][["producer"]], "RunSemlaRadialDistance")
 })

--- a/tests/testthat/test-smoothclust.R
+++ b/tests/testthat/test-smoothclust.R
@@ -104,28 +104,37 @@ test_that("RunSmoothClust stores clusters and normalized schema", {
   expect_equal(store$parameters$n_clusters, 2)
 })
 
-test_that("RunSmoothClust uses variance features and leaves bad-coordinate spots as NA", {
+test_that("RunSmoothClust rejects non-finite coordinates without mutating input", {
   srt <- make_smoothclust_seurat()
   srt$x[5] <- NA
+  before_metadata <- srt@meta.data
+  before_tools <- srt@tools
+  before_assays <- srt@assays
+  before_reductions <- srt@reductions
+  before_graphs <- srt@graphs
   with_mock_smoothclust({
-    out <- RunSmoothClust(
-      srt,
-      layer = "counts",
-      coord.cols = c("x", "y"),
-      nfeatures = 3,
-      min_spots = 1,
-      smooth_method = "knn",
-      k = 2,
-      n_clusters = 2,
-      n_pcs = 2,
-      verbose = FALSE
+    expect_error(
+      RunSmoothClust(
+        srt,
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        nfeatures = 3,
+        min_spots = 1,
+        smooth_method = "knn",
+        k = 2,
+        n_clusters = 2,
+        n_pcs = 2,
+        verbose = FALSE
+      ),
+      "non-finite"
     )
   })
 
-  expect_true(is.na(out$SmoothClust_cluster[5]))
-  expect_equal(length(out@tools$SmoothClust$features), 3)
-  expect_equal(unique(out@tools$SmoothClust$feature_selection$source), "variance")
-  expect_false("smoothed" %in% names(out@tools$SmoothClust))
+  expect_identical(srt@meta.data, before_metadata)
+  expect_identical(srt@tools, before_tools)
+  expect_identical(srt@assays, before_assays)
+  expect_identical(srt@reductions, before_reductions)
+  expect_identical(srt@graphs, before_graphs)
 })
 
 test_that("RunSmoothClust validates feature and coordinate filters clearly", {

--- a/tests/testthat/test-spatial-core.R
+++ b/tests/testthat/test-spatial-core.R
@@ -93,8 +93,56 @@ test_that("SpatialCoordinates returns ordered raw and display contracts", {
   expect_identical(SpatialCoordinates(renamed)$data$cell_id, colnames(renamed))
 
   srt$col[[2L]] <- NA_real_
-  filtered <- suppressMessages(SpatialCoordinates(srt))
-  expect_false("spot2" %in% filtered$data$cell_id)
+  expect_error(SpatialCoordinates(srt), "non-finite")
+})
+
+test_that("analysis coordinates keep one payload contract across spaces", {
+  counts <- matrix(
+    seq_len(12), nrow = 3,
+    dimnames = list(paste0("gene", 1:3), paste0("spot", 1:4))
+  )
+  srt <- suppressWarnings(SeuratObject::CreateSeuratObject(counts))
+  srt$col <- c(2, 0, 3, 1)
+  srt$row <- c(0, 1, 1, 0)
+
+  legacy <- scop:::spatial_analysis_coords(srt, coordinate_space = "legacy_display")
+  raw <- scop:::spatial_analysis_coords(srt, coordinate_space = "raw")
+  required <- c("cell_id", "x", "y", "image")
+  expect_identical(colnames(legacy$data), required)
+  expect_identical(colnames(raw$data), required)
+  expect_identical(legacy$data$cell_id, colnames(srt))
+  expect_identical(raw$data$cell_id, colnames(srt))
+  expect_identical(legacy$data$image, rep(NA_character_, ncol(srt)))
+})
+
+test_that("CytoSPACE resolves coordinates before assignment work", {
+  data("visium_human_pancreas_sub", package = "scop")
+  srt <- visium_human_pancreas_sub
+  spot_ids <- colnames(srt)
+  legacy <- scop:::cytospace_get_spatial_coords(
+    srt,
+    spot_ids,
+    coordinate_space = "legacy_display"
+  )
+  raw <- scop:::cytospace_get_spatial_coords(
+    srt,
+    spot_ids,
+    coordinate_space = "raw"
+  )
+  expect_identical(rownames(legacy), spot_ids)
+  expect_identical(rownames(raw), spot_ids)
+
+  bad_counts <- matrix(
+    seq_len(12), nrow = 3,
+    dimnames = list(paste0("gene", 1:3), paste0("bad", 1:4))
+  )
+  bad <- suppressWarnings(SeuratObject::CreateSeuratObject(bad_counts))
+  bad$col <- c(0, 1, NA_real_, 3)
+  bad$row <- c(0, 1, 2, 3)
+  expect_error(
+    scop:::cytospace_get_spatial_coords(bad, colnames(bad)),
+    "non-finite"
+  )
 })
 
 test_that("SpatialCoordinates makes multi-image selection explicit", {

--- a/tests/testthat/test-spatial-data-convert.R
+++ b/tests/testthat/test-spatial-data-convert.R
@@ -21,3 +21,17 @@ test_that("Seurat and SpatialExperiment converters preserve coordinates", {
   expect_equal(unname(out$x), unname(srt$x))
   expect_equal(unname(out$y), unname(srt$y))
 })
+
+test_that("SpatialExperiment bridges are registered and discoverable", {
+  registry <- scop:::spatial_method_registry()
+  bridges <- registry[registry$method %in% c("srt_to_spe", "spe_to_srt"), ]
+  expect_setequal(bridges$method, c("srt_to_spe", "spe_to_srt"))
+  expect_true(all(bridges$kind == "bridge"))
+  expect_true(all(bridges$task == "framework_bridge"))
+  expect_setequal(
+    ListSpatialMethods(kind = "bridge")$method[
+      ListSpatialMethods(kind = "bridge")$method %in% c("srt_to_spe", "spe_to_srt")
+    ],
+    c("srt_to_spe", "spe_to_srt")
+  )
+})

--- a/tests/testthat/test-spatial-neighborhood.R
+++ b/tests/testthat/test-spatial-neighborhood.R
@@ -115,6 +115,40 @@ test_that("RunSpatialNeighborhood refuses to impersonate an unrun spicyR backend
   expect_false("SpatialNeighborhood" %in% names(srt@tools))
 })
 
+test_that("spicyR empty and malformed outputs cannot impersonate observed results", {
+  observed <- data.frame(
+    method = "observed", comparison = "A", condition = "A",
+    from = "T", to = "B", estimate = 0.5, statistic = NA_real_,
+    pval = NA_real_, FDR = NA_real_, direction = "observed",
+    sample = "s1", subject = "s1", count = 1, total = 2,
+    fraction = 0.5, stringsAsFactors = FALSE
+  )
+  expect_error(
+    scop:::spatial_neighborhood_standardize_pair_table(
+      list(raw = list(), table = data.frame()),
+      observed,
+      "spicyR"
+    ),
+    "returned no"
+  )
+  expect_error(
+    scop:::spatial_neighborhood_standardize_pair_table(
+      list(raw = list(), table = data.frame(estimate = 1)),
+      observed,
+      "spicyR"
+    ),
+    "incompatible result"
+  )
+  expect_identical(
+    scop:::spatial_neighborhood_standardize_pair_table(
+      list(raw = NULL, table = NULL),
+      observed,
+      "observed"
+    ),
+    observed
+  )
+})
+
 test_that("SpatialNeighborhoodPlot returns scop-style ggplot objects", {
   srt <- make_spatial_neighborhood_seurat()
   with_mock_spicyr({


### PR DESCRIPTION
## Summary
- unify raw and legacy coordinate payloads and validate CytoSPACE coordinates before backend execution
- support new and legacy spacexr symbol sets using check_r() and get_namespace_fun()
- reject empty or incompatible spicyR output instead of relabeling observed results
- register SpatialExperiment bridges and add schema-v1 provenance for Semla producers
- make standard spatial stages explicitly request raw coordinates while preserving user overrides

## Validation
- spatial-focused test suite: 566 passed, 0 failed (6 existing Windows encoding warnings, 2 conditional skips)
- Semla public backend tests: 18 passed, 0 failed
- modified Semla Rd files: Rd2ex + parse passed
- pkgload::load_all('.', quiet=TRUE, compile=FALSE): passed
- rcmdcheck --no-manual --as-cran --no-examples --no-tests: 0 errors, existing 1 warning / 3 notes
- checking dependencies in R code ... OK
- checking for unstated dependencies in examples ... OK

No dependencies, environment variables, global options, public APIs, test files, or datasets were added.