### PR TITLE
fix: harden spatial scientific contracts

### DIFF
--- a/R/RunMERINGUE.R
+++ b/R/RunMERINGUE.R
@@ -393,6 +393,9 @@ meringue_run_autocorrelation <- function(
     meringue_normalize_moran_result(out, feature = feature)
   })
   result <- do.call(rbind, rows)
+  if (nperm == 0L) {
+    result$p_value <- NA_real_
+  }
   result$q_value <- if (all(is.na(result$p_value))) {
     NA_real_
   } else {

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -144,6 +144,8 @@ RunSpatialGradientFeatures <- function(
   reference <- match.arg(reference)
   backend <- match.arg(backend)
   coordinate_space <- match.arg(coordinate_space)
+  requested_image <- image
+  spata_object_supplied <- !is.null(spata_object)
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
   if (!assay %in% SeuratObject::Assays(srt)) {
     log_message(
@@ -234,6 +236,14 @@ RunSpatialGradientFeatures <- function(
     )
   } else {
     sgf_require_spata2()
+    if (is.null(spata_object)) {
+      resolved_image <- spatial_image_resolve(
+        srt = srt,
+        image = image,
+        image_policy = "strict"
+      )
+      image <- resolved_image$image
+    }
     spata_object <- spata_object %||% sgf_as_spata2(
       srt = srt,
       sample_name = sample_name %||% "scop_sample",
@@ -352,11 +362,33 @@ RunSpatialGradientFeatures <- function(
   }
 
   if (isTRUE(store_results)) {
+    source <- result$source %||% list(
+      image = image,
+      coord.cols = coord.cols[seq_len(min(2L, length(coord.cols)))],
+      image_policy = "strict",
+      coordinate_space = if (identical(backend, "cpp")) coordinate_space else "backend_native"
+    )
+    if (!identical(backend, "cpp")) {
+      source$requested_coordinate_space <- coordinate_space
+    }
+    source$selection_strategy <- source$selection_strategy %||% if (spata_object_supplied) {
+      "provided_spata_object"
+    } else if (is.null(source$image)) {
+      "metadata_coord_cols"
+    } else if (!is.null(requested_image)) {
+      "explicit_image"
+    } else {
+      "single_available_image"
+    }
+    source$units <- unit %||% NA_character_
+    source$layer <- layer
     srt <- sgf_store_result(
       srt = srt,
       result_name = result_name,
       result = result,
       assay = assay,
+      backend = backend,
+      source = source,
       set_variable_features = set_variable_features
     )
   }
@@ -741,6 +773,12 @@ sgf_run_cpp_gradient <- function(
     coord.cols = coord.cols,
     coordinate_space = coordinate_space
   )
+  coordinate_source <- attr(coords, "spatial_source") %||% list(
+    image = image,
+    coord.cols = coord.cols[seq_len(min(2L, length(coord.cols)))],
+    image_policy = "strict",
+    coordinate_space = coordinate_space
+  )
   spots <- intersect(colnames(srt), rownames(coords))
   if (length(spots) == 0L) {
     log_message("No spatial coordinates match spots in {.arg srt}", message_type = "error")
@@ -809,7 +847,8 @@ sgf_run_cpp_gradient <- function(
     significance = significance,
     model_fits = model_fits,
     top_variables = top_variables,
-    parameters = sgf_parameters_df(parameters)
+    parameters = sgf_parameters_df(parameters),
+    source = coordinate_source
   )
 }
 
@@ -823,19 +862,29 @@ sgf_cpp_coords <- function(srt, image, coord.cols, coordinate_space = "legacy_di
       is.null(image) &&
       all(coord.cols %in% colnames(srt@meta.data))
   ) {
-    return(data.frame(
+    out <- data.frame(
       x = srt@meta.data[[coord.cols[1L]]],
       y = srt@meta.data[[coord.cols[2L]]],
       row.names = rownames(srt@meta.data),
       stringsAsFactors = FALSE
-    ))
+    )
+    attr(out, "spatial_source") <- list(
+      image = NULL,
+      coord.cols = coord.cols,
+      image_policy = "strict",
+      coordinate_space = coordinate_space
+    )
+    return(out)
   }
-  spatial_analysis_coords(
+  resolved <- spatial_analysis_coords(
     srt = srt,
     image = image,
     coord.cols = coord.cols,
     coordinate_space = coordinate_space
-  )$data
+  )
+  out <- resolved$data
+  attr(out, "spatial_source") <- resolved$source
+  out
 }
 
 sgf_cpp_reference_spots <- function(
@@ -1368,7 +1417,15 @@ sgf_best_model_fits <- function(model_fits) {
   do.call(rbind, best)
 }
 
-sgf_store_result <- function(srt, result_name, result, assay, set_variable_features) {
+sgf_store_result <- function(
+  srt,
+  result_name,
+  result,
+  assay,
+  backend = "cpp",
+  source = NULL,
+  set_variable_features
+) {
   expected <- c("screening", "significance", "model_fits", "top_variables", "parameters")
   missing <- setdiff(expected, names(result))
   if (length(missing) > 0L) {
@@ -1389,26 +1446,18 @@ sgf_store_result <- function(srt, result_name, result, assay, set_variable_featu
     srt@tools[["SpatialGradientFeatures"]] <- list()
   }
   srt@tools[["SpatialGradientFeatures"]][[result_name]] <- result[expected]
-  stored_parameters <- result$parameters
-  parameter_value <- function(name, default = NULL) {
-    if (!is.data.frame(stored_parameters) || !all(c("parameter", "value") %in% colnames(stored_parameters))) {
-      return(default)
-    }
-    value <- stored_parameters$value[match(name, stored_parameters$parameter)]
-    if (length(value) == 0L || is.na(value[[1L]])) default else value[[1L]]
-  }
+  source <- source %||% result$source %||% list()
+  source$assay <- assay
   srt@tools[["SpatialGradientFeatures"]] <- spatial_result_build(
     bundle = srt@tools[["SpatialGradientFeatures"]],
     method = "SpatialGradientFeatures",
     result_type = "feature_pattern",
-    source = list(
-      image = parameter_value("image", character()),
-      coordinate_space = parameter_value("coordinate_space", "legacy_display"),
-      assay = assay,
-      layer = parameter_value("layer", NA_character_)
+    source = source,
+    provenance = list(
+      producer = "RunSpatialGradientFeatures",
+      backend_id = if (identical(backend, "cpp")) "core" else "spata2"
     ),
-    provenance = list(producer = "RunSpatialGradientFeatures", backend_id = "core;spata2"),
-    parameters = list(result_name = result_name, assay = assay),
+    parameters = list(result_name = result_name, assay = assay, backend = backend),
     summary = list(active_result = result_name, n_results = length(setdiff(
       names(srt@tools[["SpatialGradientFeatures"]]),
       c("method", "schema_version", "result_type", "source", "provenance", "parameters", "summary")

--- a/R/RunSpatialVariableFeatures.R
+++ b/R/RunSpatialVariableFeatures.R
@@ -480,8 +480,10 @@ spatial_variable_get_fun <- function(pkg, fun) {
 #'
 #' @description
 #' Visualize normalized results produced by [RunSpatialVariableFeatures()]. The
-#' summary view shows feature ranks and significance, while the surface view
-#' reuses [SpatialSpotPlot()] to draw spatial expression for selected features.
+#' summary view shows feature ranks and, when finite p- or q-values are stored,
+#' significance. Results without permutation statistics are shown without a
+#' significance size mapping or legend. The surface view reuses
+#' [SpatialSpotPlot()] to draw spatial expression for selected features.
 #'
 #' @md
 #' @inheritParams SpatialSpotPlot
@@ -674,34 +676,42 @@ spatial_variable_summary_plot <- function(
   df <- result[result$feature %in% features, , drop = FALSE]
   df$feature <- factor(df$feature, levels = rev(features))
   df[[".score"]] <- suppressWarnings(as.numeric(df[[score_col]]))
+  has_significance <- ("q_value" %in% colnames(df) && any(is.finite(df$q_value))) ||
+    ("p_value" %in% colnames(df) && any(is.finite(df$p_value)))
   df[[".significance"]] <- if ("q_value" %in% colnames(df) && any(is.finite(df$q_value))) {
     -log10(pmax(df$q_value, .Machine$double.xmin))
   } else if ("p_value" %in% colnames(df) && any(is.finite(df$p_value))) {
     -log10(pmax(df$p_value, .Machine$double.xmin))
   } else {
-    rep(1, nrow(df))
+    NA_real_
   }
   cols <- palette_colors(as.character(features), palette = palette, palcolor = palcolor)
-  ggplot2::ggplot(df, ggplot2::aes(x = .data[[".score"]], y = .data[["feature"]], color = .data[["feature"]])) +
+  p <- ggplot2::ggplot(df, ggplot2::aes(x = .data[[".score"]], y = .data[["feature"]], color = .data[["feature"]])) +
     ggplot2::geom_segment(
       ggplot2::aes(x = 0, xend = .data[[".score"]], yend = .data[["feature"]]),
       linewidth = 0.35,
       alpha = 0.5,
       na.rm = TRUE
     ) +
-    ggplot2::geom_point(
-      ggplot2::aes(size = .data[[".significance"]]),
-      na.rm = TRUE
-    ) +
     ggplot2::scale_color_manual(values = cols, drop = FALSE) +
     ggplot2::labs(
       x = score_col,
       y = NULL,
-      color = "Feature",
-      size = "-log10(q/p)"
+      color = "Feature"
     ) +
     spatial_variable_plot_theme(theme_use = theme_use, theme_args = theme_args) +
     ggplot2::theme(legend.position = legend.position)
+  if (isTRUE(has_significance)) {
+    p <- p +
+      ggplot2::geom_point(
+        ggplot2::aes(size = .data[[".significance"]]),
+        na.rm = TRUE
+      ) +
+      ggplot2::labs(size = "-log10(q/p)")
+  } else {
+    p <- p + ggplot2::geom_point(na.rm = TRUE)
+  }
+  p
 }
 
 spatial_variable_surface_plot <- function(

--- a/R/standard_scop.R
+++ b/R/standard_scop.R
@@ -29,7 +29,9 @@
 #' @param do_spatial_variable_features Whether to run
 #' [RunSpatialVariableFeatures()] in the spatial workflow.
 #' @param spatial_variable_features_params Named list of additional arguments
-#' passed to [RunSpatialVariableFeatures()].
+#' passed to [RunSpatialVariableFeatures()]. The spatial workflow defaults
+#' `set_variable_features` to `FALSE` so expression-based highly variable
+#' features are preserved; pass it explicitly to override this workflow default.
 #' @param do_spatial_cluster Whether to run spatial-aware clustering in the
 #' spatial workflow.
 #' @param spatial_cluster_method Spatial clustering method. Only
@@ -113,7 +115,9 @@
 #' @param ... Additional parameters to pass to the dimensionality reduction methods.
 #'
 #' @return A `Seurat` object. Completed or partial spatial workflows store the
-#' per-stage state in `srt@tools[["standard_spatial_scop"]]`. If a stage fails,
+#' per-stage state in `srt@tools[["standard_spatial_scop"]]`. The spatial
+#' variable-feature stage records its effective `set_variable_features` value
+#' and the before/after feature counts. If a stage fails,
 #' the signaled error carries the same table in its `standard_spatial_stages`
 #' attribute with that stage marked `"failed"`.
 #'
@@ -604,14 +608,25 @@ standard_scop <- function(
           "Perform {.fn Seurat::FindClusters} with {.arg cluster_algorithm = '{cluster_algorithm}'} and {.arg cluster_resolution = {cluster_resolution}}",
           verbose = verbose
         )
-        srt <- Seurat::FindClusters(
+        cluster_args <- list(
           object = srt,
           resolution = cluster_resolution,
           algorithm = cluster_algorithm_index,
-          leiden_method = "igraph",
           graph.name = paste0(prefix, lr, "_SNN"),
           verbose = FALSE
         )
+        find_clusters_method <- utils::getS3method(
+          "FindClusters",
+          "Seurat",
+          envir = asNamespace("Seurat")
+        )
+        if (
+          identical(tolower(cluster_algorithm), "leiden") &&
+            "leiden_method" %in% names(formals(find_clusters_method))
+        ) {
+          cluster_args$leiden_method <- "igraph"
+        }
+        srt <- do.call(Seurat::FindClusters, cluster_args)
         log_message("Reorder clusters...", verbose = verbose)
         srt <- srt_reorder(
           srt,
@@ -860,6 +875,9 @@ standard_spatial_scop <- function(
     actual_method = NA_character_,
     result_tool_key = NA_character_,
     result_metadata_key = NA_character_,
+    variable_features_before = NA_integer_,
+    variable_features_after = NA_integer_,
+    set_variable_features = NA,
     reason = ifelse(
       c(
         isTRUE(do_spot_qc), isTRUE(do_spatial_variable_features),
@@ -876,6 +894,9 @@ standard_spatial_scop <- function(
     actual_method = NA_character_,
     result_tool_key = NA_character_,
     result_metadata_key = NA_character_,
+    variable_features_before = NA_integer_,
+    variable_features_after = NA_integer_,
+    set_variable_features = NA,
     reason = NA_character_
   ) {
     i <- match(stage, stages$stage)
@@ -883,6 +904,9 @@ standard_spatial_scop <- function(
     stages$actual_method[[i]] <<- actual_method
     stages$result_tool_key[[i]] <<- result_tool_key
     stages$result_metadata_key[[i]] <<- result_metadata_key
+    stages$variable_features_before[[i]] <<- variable_features_before
+    stages$variable_features_after[[i]] <<- variable_features_after
+    stages$set_variable_features[[i]] <<- set_variable_features
     stages$reason[[i]] <<- reason
     invisible(NULL)
   }
@@ -971,6 +995,7 @@ standard_spatial_scop <- function(
 
   cluster_col <- paste0(prefix, "clusters")
   if (isTRUE(do_spatial_variable_features)) {
+    variable_features_before <- length(SeuratObject::VariableFeatures(srt, assay = assay))
     svf_args <- standard_scop_merge_args(
       list(
         srt = srt,
@@ -978,6 +1003,7 @@ standard_spatial_scop <- function(
         image = image,
         coord.cols = coord.cols,
         coordinate_space = "raw",
+        set_variable_features = FALSE,
         verbose = verbose,
         seed = seed
       ),
@@ -988,6 +1014,15 @@ standard_spatial_scop <- function(
       expr = do.call(RunSpatialVariableFeatures, svf_args),
       actual_method = "RunSpatialVariableFeatures",
       result_tool_key = "SpatialVariableFeatures"
+    )
+    update_stage(
+      stage = "spatial_variable_features",
+      status = "completed",
+      actual_method = "RunSpatialVariableFeatures",
+      result_tool_key = "SpatialVariableFeatures",
+      variable_features_before = variable_features_before,
+      variable_features_after = length(SeuratObject::VariableFeatures(srt, assay = assay)),
+      set_variable_features = isTRUE(svf_args$set_variable_features)
     )
   }
 
@@ -1121,6 +1156,7 @@ standard_spatial_scop <- function(
       coord.cols = coord.cols,
       do_spot_qc = do_spot_qc,
       do_spatial_variable_features = do_spatial_variable_features,
+      spatial_variable_features_params = spatial_variable_features_params,
       do_spatial_cluster = do_spatial_cluster,
       spatial_cluster_method = spatial_cluster_method,
       spatial_q = spatial_q,

--- a/man/SpatialVariableFeaturePlot.Rd
+++ b/man/SpatialVariableFeaturePlot.Rd
@@ -98,8 +98,10 @@ A \code{ggplot} or \code{patchwork} object.
 }
 \description{
 Visualize normalized results produced by \code{\link[=RunSpatialVariableFeatures]{RunSpatialVariableFeatures()}}. The
-summary view shows feature ranks and significance, while the surface view
-reuses \code{\link[=SpatialSpotPlot]{SpatialSpotPlot()}} to draw spatial expression for selected features.
+summary view shows feature ranks and, when finite p- or q-values are stored,
+significance. Results without permutation statistics are shown without a
+significance size mapping or legend. The surface view reuses
+\code{\link[=SpatialSpotPlot]{SpatialSpotPlot()}} to draw spatial expression for selected features.
 }
 \examples{
 data(visium_human_pancreas_sub)

--- a/man/standard_scop.Rd
+++ b/man/standard_scop.Rd
@@ -86,7 +86,9 @@ when no image is available.}
 \code{\link[=RunSpatialVariableFeatures]{RunSpatialVariableFeatures()}} in the spatial workflow.}
 
 \item{spatial_variable_features_params}{Named list of additional arguments
-passed to \code{\link[=RunSpatialVariableFeatures]{RunSpatialVariableFeatures()}}.}
+passed to \code{\link[=RunSpatialVariableFeatures]{RunSpatialVariableFeatures()}}. The spatial workflow defaults
+\code{set_variable_features} to \code{FALSE} so expression-based highly variable
+features are preserved; pass it explicitly to override this workflow default.}
 
 \item{do_spatial_cluster}{Whether to run spatial-aware clustering in the
 spatial workflow.}
@@ -208,7 +210,9 @@ Default is \code{11}.}
 }
 \value{
 A \code{Seurat} object. Completed or partial spatial workflows store the
-per-stage state in \code{srt@tools[["standard_spatial_scop"]]}. If a stage fails,
+per-stage state in \code{srt@tools[["standard_spatial_scop"]]}. The spatial
+variable-feature stage records its effective \code{set_variable_features} value
+and the before/after feature counts. If a stage fails,
 the signaled error carries the same table in its \code{standard_spatial_stages}
 attribute with that stage marked \code{"failed"}.
 }

--- a/tests/testthat/test-run-meringue.R
+++ b/tests/testthat/test-run-meringue.R
@@ -89,11 +89,34 @@ test_that("RunMERINGUE stores normalized autocorrelation, cross-correlation, and
   ) %in% colnames(stored$autocorrelation)))
   expect_equal(stored$autocorrelation$rank, seq_len(nrow(stored$autocorrelation)))
   expect_equal(stored$autocorrelation$feature[[1]], "Gene2")
+  expect_true(all(is.na(stored$autocorrelation$p_value)))
+  expect_true(all(is.na(stored$autocorrelation$q_value)))
   expect_equal(out@misc[["MERINGUEFeatures"]], c("Gene2", "Gene1", "Gene4"))
   expect_true(all(c("feature1", "feature2", "rank", "correlation", "p_value") %in% colnames(stored$cross_correlation)))
   expect_true(all(c("feature", "module", "module_size", "rank") %in% colnames(stored$modules)))
   expect_true(all(vapply(stored[c("autocorrelation", "cross_correlation", "modules", "parameters")], is.data.frame, logical(1))))
   expect_false(any(vapply(stored, methods::is, logical(1), class2 = "MERINGUE")))
+})
+
+test_that("MERINGUE retains permutation p values when permutations are requested", {
+  testthat::local_mocked_bindings(
+    meringue_require_package = function(pkg) invisible(TRUE),
+    meringue_get_fun = mock_meringue_get_fun,
+    meringue_package_version = function(pkg) "mock"
+  )
+
+  out <- RunMERINGUE(
+    make_meringue_seurat(),
+    layer = "counts",
+    coord.cols = c("x", "y"),
+    mode = "autocorrelation",
+    min_spots = 1,
+    nperm = 10,
+    verbose = FALSE
+  )
+
+  expect_true(all(is.finite(out@tools$MERINGUE$autocorrelation$p_value)))
+  expect_true(all(is.finite(out@tools$MERINGUE$autocorrelation$q_value)))
 })
 
 test_that("MERINGUE module output with groups is normalized", {

--- a/tests/testthat/test-spatial-gradient.R
+++ b/tests/testthat/test-spatial-gradient.R
@@ -194,6 +194,7 @@ test_that("cpp backend stores annotation gradient result tables", {
     annotation.threshold = 0,
     layer = "counts",
     coord.cols = c("x", "y"),
+    coordinate_space = "raw",
     n_random = 0,
     n_bins = 3,
     min_spots = 1,
@@ -212,6 +213,15 @@ test_that("cpp backend stores annotation gradient result tables", {
   expect_true(all(c("norm_var", "rel_var", "linear_r2") %in% colnames(stored$significance)))
   expect_true(all(c("ascending", "descending", "peak", "valley", "linear") %in% stored$model_fits$model))
   expect_true(any(stored$significance$tot_var != stored$significance$linear_r2, na.rm = TRUE))
+  info <- SpatialResultInfo(srt, tool_name = "SpatialGradientFeatures")
+  expect_identical(info$coordinate_space, "raw")
+  expect_identical(srt@tools$SpatialGradientFeatures$source$coord.cols, c("x", "y"))
+  expect_identical(srt@tools$SpatialGradientFeatures$source$image_policy, "strict")
+  expect_identical(srt@tools$SpatialGradientFeatures$provenance$backend_id, "core")
+  expect_identical(
+    srt@tools$SpatialGradientFeatures$source$selection_strategy,
+    "metadata_coord_cols"
+  )
 })
 
 test_that("cpp backend stores trajectory gradient result tables", {

--- a/tests/testthat/test-spatial-variable-features.R
+++ b/tests/testthat/test-spatial-variable-features.R
@@ -135,6 +135,8 @@ test_that("SpatialVariableFeaturePlot uses stored result and SCOP spatial plotti
     theme_use = NULL
   )
   expect_s3_class(p_summary, "ggplot")
+  expect_null(p_summary$labels$size)
+  expect_false("size" %in% names(p_summary$layers[[2]]$mapping))
 
   p_surface <- SpatialVariableFeaturePlot(
     srt,

--- a/tests/testthat/test-standard-spatial-stages.R
+++ b/tests/testthat/test-standard-spatial-stages.R
@@ -19,14 +19,17 @@ test_that("standard spatial workflow records completed and skipped stages truthf
       srt$SpotQC <- "Pass"
       srt
     },
-    RunSpatialVariableFeatures = function(srt, ...) {
+    RunSpatialVariableFeatures = function(srt, set_variable_features, ...) {
+      expect_false(set_variable_features)
       srt@tools$SpatialVariableFeatures <- list(result = data.frame(feature = rownames(srt)))
       srt
     }
   )
 
+  input <- make_standard_spatial_stage_object()
+  SeuratObject::VariableFeatures(input) <- rownames(input)[1:2]
   out <- suppressWarnings(original(
-    make_standard_spatial_stage_object(),
+    input,
     assay = "RNA",
     do_spot_qc = TRUE,
     do_spatial_variable_features = TRUE,
@@ -50,6 +53,11 @@ test_that("standard spatial workflow records completed and skipped stages truthf
     workflow$stages$result_tool_key[workflow$stages$stage == "spatial_variable_features"],
     "SpatialVariableFeatures"
   )
+  svf <- workflow$stages[workflow$stages$stage == "spatial_variable_features", , drop = FALSE]
+  expect_identical(svf$variable_features_before, 2L)
+  expect_identical(svf$variable_features_after, 2L)
+  expect_false(svf$set_variable_features)
+  expect_identical(SeuratObject::VariableFeatures(out), rownames(input)[1:2])
   deconv <- workflow$stages[workflow$stages$stage == "deconvolution", , drop = FALSE]
   expect_true(deconv$requested)
   expect_identical(deconv$status, "skipped")


### PR DESCRIPTION
## Summary

- preserve resolved spatial provenance for gradient results, including raw/display space, coordinates, image selection strategy, units, layer, and exact backend
- make `nperm = 0` scientifically explicit for Moran/MERINGUE and remove significance size mapping when no finite p/q values exist
- preserve expression HVGs in `standard_scop(workflow = "spatial")` by default and record before/after counts plus the effective mutation setting
- route `leiden_method` only when the selected algorithm and installed Seurat method support it

## Validation

- targeted spatial gradient, MERINGUE, spatial-variable-feature, and standard spatial-stage tests pass
- DLPFC 151673 smoke: raw gradient provenance, p/q `NA` without permutations, no false significance legend, unchanged HVGs, and no unused `leiden_method` warning
- `pkgload::load_all(".", quiet = TRUE, compile = FALSE)` passes
- `R CMD check --as-cran --no-manual --no-examples --no-tests`: dependencies in R code OK; unstated dependencies in examples OK
- no environment-variable guards, global options, or direct optional Remotes namespace calls were added

## Known upstream check noise

The existing `src/Makevars` GNU-extension warning and existing CRAN incoming/code-analysis notes remain unchanged.
