### PR TITLE
fix: close STdeconvolve result plot workflow

### DIFF
--- a/R/RunSTdeconvolve.R
+++ b/R/RunSTdeconvolve.R
@@ -215,79 +215,224 @@ RunSTdeconvolve <- function(
 
 #' @title Plot STdeconvolve topic proportions
 #'
+#' @description
+#' Plot schema-v1 topic proportions without rerunning the optional backend.
+#' Multi-topic point maps use one shared proportion scale and reserve title
+#' space above the automatic layout.
+#'
 #' @md
 #' @inheritParams SpatialSpotPlot
 #' @param topics Topic names, topic numbers, or metadata columns to plot. If
-#' `NULL`, all `"<prefix>_prop_*"` columns are used for point plots.
-#' @param prefix Metadata prefix used by `RunSTdeconvolve()`.
+#' `NULL`, all topics in the stored result are used.
+#' @param tool_name Exact schema-v1 result key written by
+#' `RunSTdeconvolve()`.
+#' @param prefix Metadata prefix used by `RunSTdeconvolve()`. If `NULL`, the
+#' prefix is read from the stored result.
+#' @param combine Whether to combine point plots. If `FALSE`, a named list of
+#' plots is returned.
+#' @param nrow,ncol,byrow Point-plot layout controls. When both `nrow` and
+#' `ncol` are `NULL`, a near-square layout with at most three columns is used.
 #' @param ... Additional arguments passed to `SpatialSpotPlot()`.
 #'
 #' @return A `ggplot`, `patchwork`, or list of `ggplot` objects.
 #' @export
 #'
 #' @examples
+#' check_r("JEFworks-Lab/STdeconvolve", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
-#' spatial <- visium_human_pancreas_sub
-#' topic_weights <- data.frame(
-#'   STdeconvolve_prop_topic_1 = seq(0.75, 0.20, length.out = ncol(spatial)),
-#'   STdeconvolve_prop_topic_2 = seq(0.20, 0.70, length.out = ncol(spatial)),
-#'   STdeconvolve_prop_topic_3 = 0.10,
-#'   row.names = colnames(spatial)
+#' spatial <- RunSTdeconvolve(
+#'   visium_human_pancreas_sub,
+#'   assay = "Spatial",
+#'   features = rownames(visium_human_pancreas_sub)[1:300],
+#'   k = 3,
+#'   prefix = "STFull",
+#'   tool_name = "STdeconvolveFull",
+#'   verbose = FALSE
 #' )
-#' topic_weights <- topic_weights / rowSums(topic_weights)
-#' spatial <- Seurat::AddMetaData(spatial, topic_weights)
-#' spatial$STdeconvolve_dominant_type <- sub(
-#'   "^STdeconvolve_prop_",
-#'   "",
-#'   colnames(topic_weights)[max.col(topic_weights)]
-#' )
-#'
 #' STdeconvolvePlot(
 #'   spatial,
+#'   tool_name = "STdeconvolveFull",
 #'   topics = 1:2,
 #'   overlay_image = FALSE,
 #'   coord.cols = c("x", "y")
 #' )
-#'   STdeconvolvePlot(
-#'     spatial,
-#'     plot_type = "pie",
-#'     overlay_image = FALSE,
-#'     coord.cols = c("x", "y")
-#'   )
 STdeconvolvePlot <- function(
   srt,
+  tool_name = "STdeconvolve",
   topics = NULL,
-  prefix = "STdeconvolve",
+  prefix = NULL,
   plot_type = c("point", "pie"),
+  combine = TRUE,
+  nrow = NULL,
+  ncol = NULL,
+  byrow = TRUE,
   ...
 ) {
+  if (!inherits(srt, "Seurat")) {
+    log_message("{.arg srt} must be a {.cls Seurat} object", message_type = "error")
+  }
+  stdeconvolve_assert_scalar_string(tool_name, "tool_name")
   plot_type <- match.arg(plot_type)
-  prop_cols <- grep(
-    paste0("^", prefix, "_prop_"),
-    colnames(srt@meta.data),
-    value = TRUE
-  )
-  if (length(prop_cols) == 0L) {
+  stored <- GetSpatialResult(srt, tool_name = tool_name)
+  if (!identical(stored$method, "STdeconvolve")) {
     log_message(
-      "No {.pkg STdeconvolve} topic columns with prefix {.val {prefix}_prop_} were found",
+      "Stored result {.val {tool_name}} was not produced by {.fn RunSTdeconvolve}",
       message_type = "error"
     )
   }
-  dominant_col <- paste0(prefix, "_dominant_type")
-  if (identical(plot_type, "pie")) {
-    group_by <- if (dominant_col %in% colnames(srt@meta.data)) {
-      dominant_col
-    } else {
-      prop_cols
-    }
-    return(SpatialSpotPlot(srt, group.by = group_by, plot_type = "pie", ...))
-  }
-  group_by <- stdeconvolve_resolve_topic_columns(
+  prefix <- prefix %||% stored$parameters$prefix
+  stdeconvolve_assert_scalar_string(prefix, "prefix")
+  theta <- stdeconvolve_plot_theta(
+    theta = stored$theta,
+    spot_ids = colnames(srt),
+    tool_name = tool_name
+  )
+  topic_names <- stdeconvolve_resolve_plot_topics(
     topics = topics,
-    prop_cols = prop_cols,
+    topic_names = colnames(theta),
     prefix = prefix
   )
-  SpatialSpotPlot(srt, group.by = group_by, plot_type = "point", ...)
+  values <- theta[, topic_names, drop = FALSE]
+  colnames(values) <- paste0(prefix, "_prop_", make.names(topic_names))
+  if (identical(plot_type, "pie")) {
+    return(SpatialSpotPlot(srt, values = values, plot_type = "pie", ...))
+  }
+  plots <- SpatialSpotPlot(
+    srt,
+    values = values,
+    plot_type = "point",
+    combine = FALSE,
+    ...
+  )
+  if (isFALSE(combine)) {
+    return(plots)
+  }
+  if (length(plots) == 1L) {
+    return(plots[[1L]])
+  }
+  if (is.null(nrow) && is.null(ncol)) {
+    ncol <- min(3L, ceiling(sqrt(length(plots))))
+  }
+  finite_values <- values[is.finite(values)]
+  common_limit <- if (length(finite_values) == 0L) 1 else max(finite_values)
+  common_limit <- max(common_limit, .Machine$double.eps)
+  legend_title <- list(...)$legend.title %||% "Proportion"
+  plots <- Map(
+    function(plot, topic) {
+      plot <- stdeconvolve_set_point_scale(
+        plot = plot,
+        limits = c(0, common_limit),
+        title = legend_title
+      )
+      plot +
+        ggplot2::labs(title = topic) +
+        ggplot2::theme(plot.title = ggplot2::element_text(margin = ggplot2::margin(b = 4)))
+    },
+    plots,
+    topic_names
+  )
+  patchwork::wrap_plots(
+    plots,
+    nrow = nrow,
+    ncol = ncol,
+    byrow = byrow,
+    guides = "collect"
+  ) +
+    patchwork::plot_annotation(
+      title = paste0(tool_name, " topic proportions"),
+      theme = ggplot2::theme(
+        plot.title = ggplot2::element_text(margin = ggplot2::margin(b = 8))
+      )
+    )
+}
+
+stdeconvolve_set_point_scale <- function(plot, limits, title) {
+  scale_index <- which(vapply(
+    plot$scales$scales,
+    function(scale) any(scale$aesthetics %in% c("colour", "color")),
+    logical(1)
+  ))
+  if (length(scale_index) != 1L) {
+    log_message(
+      "Unable to identify the continuous topic-proportion color scale",
+      message_type = "error"
+    )
+  }
+  plot$scales$scales[[scale_index]]$limits <- limits
+  plot$scales$scales[[scale_index]]$name <- title
+  plot$labels$colour <- title
+  plot
+}
+
+stdeconvolve_plot_theta <- function(theta, spot_ids, tool_name) {
+  if (is.null(theta) || (!is.matrix(theta) && !inherits(theta, "Matrix"))) {
+    log_message(
+      "Stored result {.val {tool_name}} does not contain a matrix-like {.val theta}",
+      message_type = "error"
+    )
+  }
+  theta <- as.matrix(theta)
+  if (nrow(theta) == 0L || ncol(theta) == 0L) {
+    log_message("Stored {.val theta} is empty", message_type = "error")
+  }
+  if (
+    is.null(rownames(theta)) || anyNA(rownames(theta)) ||
+      any(!nzchar(rownames(theta))) || anyDuplicated(rownames(theta))
+  ) {
+    log_message(
+      "Stored {.val theta} must have unique, non-missing spatial spot names",
+      message_type = "error"
+    )
+  }
+  if (
+    is.null(colnames(theta)) || anyNA(colnames(theta)) ||
+      any(!nzchar(colnames(theta))) || anyDuplicated(colnames(theta))
+  ) {
+    log_message(
+      "Stored {.val theta} must have unique, non-missing topic names",
+      message_type = "error"
+    )
+  }
+  missing_spots <- setdiff(spot_ids, rownames(theta))
+  extra_spots <- setdiff(rownames(theta), spot_ids)
+  if (length(missing_spots) > 0L || length(extra_spots) > 0L) {
+    log_message(
+      "Stored {.val theta} spot identities are stale or incomplete: {.val {length(missing_spots)}} missing and {.val {length(extra_spots)}} unknown",
+      message_type = "error"
+    )
+  }
+  theta[spot_ids, , drop = FALSE]
+}
+
+stdeconvolve_resolve_plot_topics <- function(topics, topic_names, prefix) {
+  if (is.null(topics)) {
+    return(topic_names)
+  }
+  topics_chr <- as.character(topics)
+  out <- vapply(topics_chr, function(topic) {
+    if (topic %in% topic_names) {
+      return(topic)
+    }
+    if (grepl("^[0-9]+$", topic)) {
+      idx <- as.integer(topic)
+      if (idx >= 1L && idx <= length(topic_names)) {
+        return(topic_names[[idx]])
+      }
+    }
+    prefix_value <- paste0(prefix, "_prop_", make.names(topic_names))
+    hit <- match(topic, prefix_value)
+    if (!is.na(hit)) {
+      return(topic_names[[hit]])
+    }
+    NA_character_
+  }, character(1))
+  if (anyNA(out)) {
+    log_message(
+      "Requested {.arg topics} were not found: {.val {topics_chr[is.na(out)]}}",
+      message_type = "error"
+    )
+  }
+  unname(out)
 }
 
 stdeconvolve_run_backend <- function(
@@ -419,36 +564,6 @@ stdeconvolve_resolve_k <- function(k = NULL, k_candidates = 2:9) {
     )
   }
   unique(as.integer(k_use))
-}
-
-stdeconvolve_resolve_topic_columns <- function(topics, prop_cols, prefix) {
-  if (is.null(topics)) {
-    return(prop_cols)
-  }
-  topics_chr <- as.character(topics)
-  out <- vapply(topics_chr, function(topic) {
-    if (topic %in% prop_cols) {
-      return(topic)
-    }
-    if (grepl("^[0-9]+$", topic)) {
-      idx <- as.integer(topic)
-      if (idx >= 1L && idx <= length(prop_cols)) {
-        return(prop_cols[idx])
-      }
-    }
-    topic_col <- paste0(prefix, "_prop_", make.names(topic))
-    if (topic_col %in% prop_cols) {
-      return(topic_col)
-    }
-    NA_character_
-  }, character(1))
-  if (anyNA(out)) {
-    log_message(
-      "Requested {.arg topics} were not found: {.val {topics_chr[is.na(out)]}}",
-      message_type = "error"
-    )
-  }
-  unname(out)
 }
 
 stdeconvolve_validate_param_list <- function(x, arg_name) {

--- a/man/STdeconvolvePlot.Rd
+++ b/man/STdeconvolvePlot.Rd
@@ -6,19 +6,28 @@
 \usage{
 STdeconvolvePlot(
   srt,
+  tool_name = "STdeconvolve",
   topics = NULL,
-  prefix = "STdeconvolve",
+  prefix = NULL,
   plot_type = c("point", "pie"),
+  combine = TRUE,
+  nrow = NULL,
+  ncol = NULL,
+  byrow = TRUE,
   ...
 )
 }
 \arguments{
 \item{srt}{A Seurat object.}
 
-\item{topics}{Topic names, topic numbers, or metadata columns to plot. If
-\code{NULL}, all \code{"<prefix>_prop_*"} columns are used for point plots.}
+\item{tool_name}{Exact schema-v1 result key written by
+\code{RunSTdeconvolve()}.}
 
-\item{prefix}{Metadata prefix used by \code{RunSTdeconvolve()}.}
+\item{topics}{Topic names, topic numbers, or metadata columns to plot. If
+\code{NULL}, all topics in the stored result are used.}
+
+\item{prefix}{Metadata prefix used by \code{RunSTdeconvolve()}. If \code{NULL}, the
+prefix is read from the stored result.}
 
 \item{plot_type}{Plot type. \code{"point"} keeps the default spot plot behavior.
 \code{"pie"} draws spot-level pies from numeric metadata columns supplied to
@@ -27,41 +36,39 @@ STdeconvolvePlot(
 \code{"<prefix>_prop_*"} or \code{"<prefix>_frac_*"} numeric metadata columns are used
 automatically.}
 
+\item{combine}{Whether to combine point plots. If \code{FALSE}, a named list of
+plots is returned.}
+
+\item{nrow, ncol, byrow}{Point-plot layout controls. When both \code{nrow} and
+\code{ncol} are \code{NULL}, a near-square layout with at most three columns is used.}
+
 \item{...}{Additional arguments passed to \code{SpatialSpotPlot()}.}
 }
 \value{
 A \code{ggplot}, \code{patchwork}, or list of \code{ggplot} objects.
 }
 \description{
-Plot STdeconvolve topic proportions
+Plot schema-v1 topic proportions without rerunning the optional backend.
+Multi-topic point maps use one shared proportion scale and reserve title
+space above the automatic layout.
 }
 \examples{
+check_r("JEFworks-Lab/STdeconvolve", verbose = FALSE)
 data(visium_human_pancreas_sub)
-spatial <- visium_human_pancreas_sub
-topic_weights <- data.frame(
-  STdeconvolve_prop_topic_1 = seq(0.75, 0.20, length.out = ncol(spatial)),
-  STdeconvolve_prop_topic_2 = seq(0.20, 0.70, length.out = ncol(spatial)),
-  STdeconvolve_prop_topic_3 = 0.10,
-  row.names = colnames(spatial)
+spatial <- RunSTdeconvolve(
+  visium_human_pancreas_sub,
+  assay = "Spatial",
+  features = rownames(visium_human_pancreas_sub)[1:300],
+  k = 3,
+  prefix = "STFull",
+  tool_name = "STdeconvolveFull",
+  verbose = FALSE
 )
-topic_weights <- topic_weights / rowSums(topic_weights)
-spatial <- Seurat::AddMetaData(spatial, topic_weights)
-spatial$STdeconvolve_dominant_type <- sub(
-  "^STdeconvolve_prop_",
-  "",
-  colnames(topic_weights)[max.col(topic_weights)]
-)
-
 STdeconvolvePlot(
   spatial,
+  tool_name = "STdeconvolveFull",
   topics = 1:2,
   overlay_image = FALSE,
   coord.cols = c("x", "y")
 )
-  STdeconvolvePlot(
-    spatial,
-    plot_type = "pie",
-    overlay_image = FALSE,
-    coord.cols = c("x", "y")
-  )
 }

--- a/tests/testthat/test-stdeconvolve.R
+++ b/tests/testthat/test-stdeconvolve.R
@@ -112,9 +112,9 @@ test_that("RunSTdeconvolve validates inputs before backend work", {
 
 test_that("STdeconvolvePlot uses SCOP spatial plotting", {
   srt <- make_stdeconvolve_seurat()
-  srt$STdeconvolve_prop_topic_1 <- c(0.8, 0.4, 0.1, 0.6)
-  srt$STdeconvolve_prop_topic_2 <- c(0.2, 0.6, 0.9, 0.4)
-  srt$STdeconvolve_dominant_type <- c("topic_1", "topic_2", "topic_2", "topic_1")
+  with_mock_stdeconvolve({
+    srt <- RunSTdeconvolve(srt, k = 2, verbose = FALSE)
+  })
   testthat::local_mocked_bindings(
     .package = "scop",
     check_r = function(packages, ...) {
@@ -138,4 +138,108 @@ test_that("STdeconvolvePlot uses SCOP spatial plotting", {
 
   expect_s3_class(p1, "ggplot")
   expect_s3_class(p2, "ggplot")
+})
+
+test_that("STdeconvolvePlot reads custom tool names and stored prefixes", {
+  srt <- make_stdeconvolve_seurat()
+  with_mock_stdeconvolve({
+    out <- RunSTdeconvolve(
+      srt,
+      k = 2,
+      prefix = "STFull",
+      tool_name = "STdeconvolveFull",
+      verbose = FALSE
+    )
+  })
+
+  p <- STdeconvolvePlot(
+    out,
+    tool_name = "STdeconvolveFull",
+    topics = "STFull_prop_topic_2",
+    overlay_image = FALSE
+  )
+  expect_s3_class(p, "ggplot")
+  expect_identical(GetSpatialResult(out, tool_name = "STdeconvolveFull")$parameters$prefix, "STFull")
+})
+
+test_that("STdeconvolvePlot uses readable automatic layouts and supports lists", {
+  srt <- make_stdeconvolve_seurat()
+  theta <- matrix(
+    seq_len(ncol(srt) * 7),
+    nrow = ncol(srt),
+    dimnames = list(colnames(srt), paste0("topic_", 1:7))
+  )
+  theta <- theta / rowSums(theta)
+  srt@tools$STSeven <- spatial_result_build(
+    bundle = list(
+      theta = theta,
+      parameters = list(prefix = "STSeven"),
+      summary = scop_spatial_weight_summary(theta)
+    ),
+    method = "STdeconvolve",
+    result_type = "deconvolution",
+    provenance = list(producer = "RunSTdeconvolve", backend_id = "stdeconvolve")
+  )
+
+  plots <- STdeconvolvePlot(
+    srt,
+    tool_name = "STSeven",
+    combine = FALSE,
+    overlay_image = FALSE
+  )
+  combined <- STdeconvolvePlot(
+    srt,
+    tool_name = "STSeven",
+    overlay_image = FALSE
+  )
+  expect_length(plots, 7L)
+  expect_true(all(vapply(plots, inherits, logical(1), what = "ggplot")))
+  expect_s3_class(combined, "patchwork")
+  combined_plots <- combined$patches$plots
+  expect_length(combined_plots, 6L)
+  limits <- lapply(combined_plots, function(plot) {
+    color_scale <- Filter(
+      function(scale) any(scale$aesthetics %in% c("colour", "color")),
+      plot$scales$scales
+    )
+    color_scale[[1L]]$limits
+  })
+  expect_true(all(vapply(limits, identical, logical(1), limits[[1L]])))
+  expect_identical(combined$patches$annotation$title, "STSeven topic proportions")
+})
+
+test_that("STdeconvolvePlot rejects missing, stale, and malformed stored results", {
+  srt <- make_stdeconvolve_seurat()
+  expect_error(STdeconvolvePlot(srt, tool_name = "missing"), "No stored spatial result")
+
+  theta <- matrix(
+    0.5,
+    nrow = ncol(srt),
+    ncol = 2,
+    dimnames = list(colnames(srt), c("topic_1", "topic_2"))
+  )
+  make_bundle <- function(value) spatial_result_build(
+    bundle = list(theta = value, parameters = list(prefix = "Bad")),
+    method = "STdeconvolve",
+    result_type = "deconvolution",
+    provenance = list(producer = "RunSTdeconvolve", backend_id = "stdeconvolve")
+  )
+
+  srt@tools$StaleST <- make_bundle(theta[-1, , drop = FALSE])
+  expect_error(
+    STdeconvolvePlot(srt, tool_name = "StaleST", overlay_image = FALSE),
+    "stale or incomplete"
+  )
+  duplicated_theta <- theta
+  rownames(duplicated_theta)[2] <- rownames(duplicated_theta)[1]
+  srt@tools$DuplicatedST <- make_bundle(duplicated_theta)
+  expect_error(
+    STdeconvolvePlot(srt, tool_name = "DuplicatedST", overlay_image = FALSE),
+    "unique, non-missing"
+  )
+  srt@tools$EmptyST <- make_bundle(theta[0, , drop = FALSE])
+  expect_error(
+    STdeconvolvePlot(srt, tool_name = "EmptyST", overlay_image = FALSE),
+    "empty"
+  )
 })


### PR DESCRIPTION
## Summary

- make `STdeconvolvePlot()` consume the exact schema-v1 result selected by `tool_name`, including custom producer keys and stored prefixes
- validate and strictly reorder stored theta by spatial spot ID without rerunning STdeconvolve
- support 1/2/7-topic point layouts, shared proportion guides, explicit layout overrides, `combine = FALSE`, and unchanged single pie semantics
- replace synthetic metadata-only examples with a real producer -> custom tool -> plot example

## Validation

- targeted STdeconvolve producer/result/plot tests pass
- DLPFC 151673 custom-key smoke plotted seven stored topics and pie output without mutating or rerunning the backend result
- `pkgload::load_all(".", quiet = TRUE, compile = FALSE)` passes
- `R CMD check --as-cran --no-manual --no-examples --no-tests`: dependencies in R code OK; unstated dependencies in examples OK
- generated Rd examples extract and parse successfully

## Known upstream check noise

The existing `src/Makevars` GNU-extension warning and existing CRAN incoming/code-analysis notes remain unchanged.
