### PR TITLE
fix(spatial): enforce strict coordinate provenance

### DIFF
--- a/R/RunBayesSpace.R
+++ b/R/RunBayesSpace.R
@@ -9,6 +9,8 @@
 #' coordinates when they are not already present in metadata. For regular
 #' Visium data with only pixel `x`/`y` coordinates, BayesSpace array
 #' coordinates are inferred from the spatial grid.
+#' @param coord.cols Two metadata columns containing raw x/y coordinates when
+#' no spatial image is available.
 #' @param use_reduction Optional Seurat reduction to pass to BayesSpace as PCA.
 #' @param dims Dimensions from `use_reduction` to use.
 #' @param preprocess Whether to run `BayesSpace::spatialPreprocess()`.
@@ -73,7 +75,8 @@ RunBayesSpace <- function(
   cluster_colname = "BayesSpace_cluster",
   init_colname = "BayesSpace_init",
   store_sce = TRUE,
-  verbose = TRUE
+  verbose = TRUE,
+  coord.cols = c("col", "row")
 ) {
   if (!inherits(srt, "Seurat")) {
     log_message(
@@ -100,12 +103,14 @@ RunBayesSpace <- function(
     verbose = verbose
   )
   sce <- Seurat::as.SingleCellExperiment(srt, assay = assay)
-  sce <- bayesspace_add_spatial_coords(
+  coordinate_input <- bayesspace_add_spatial_coords(
     srt = srt,
     sce = sce,
     image = image,
-    platform = platform
+    platform = platform,
+    coord.cols = coord.cols
   )
+  sce <- coordinate_input$sce
 
   use_dimred <- "PCA"
   d_use <- min(length(dims), n.PCs)
@@ -168,9 +173,16 @@ RunBayesSpace <- function(
       message_type = "error"
     )
   }
+  bayesspace_validate_backend_output(
+    cdata = cdata,
+    cells = colnames(srt),
+    cluster_col = "spatial.cluster",
+    init_col = if (is.null(init_colname)) NULL else "cluster.init"
+  )
+  cdata <- cdata[colnames(srt), , drop = FALSE]
   cluster_df <- data.frame(
     BayesSpace_cluster = as.character(cdata[["spatial.cluster"]]),
-    row.names = colnames(sce),
+    row.names = colnames(srt),
     stringsAsFactors = FALSE
   )
   colnames(cluster_df) <- cluster_colname
@@ -179,7 +191,7 @@ RunBayesSpace <- function(
   if ("cluster.init" %in% colnames(cdata) && !is.null(init_colname)) {
     init_df <- data.frame(
       BayesSpace_init = as.character(cdata[["cluster.init"]]),
-      row.names = colnames(sce),
+      row.names = colnames(srt),
       stringsAsFactors = FALSE
     )
     colnames(init_df) <- init_colname
@@ -192,7 +204,9 @@ RunBayesSpace <- function(
       assay = assay,
       q = q,
       platform = platform,
-      image = image,
+      image = coordinate_input$source$image,
+      coord.cols = coordinate_input$source$coord.cols,
+      coordinate_space = "raw",
       use_reduction = use_reduction,
       dims = dims,
       preprocess = preprocess,
@@ -203,7 +217,9 @@ RunBayesSpace <- function(
       spatial_cluster_params = spatial_cluster_params,
       cluster_colname = cluster_colname,
       init_colname = init_colname
-    )
+    ),
+    coords = coordinate_input$coords,
+    cells = colnames(srt)
   )
   if (isTRUE(store_sce)) {
     tool$sce <- sce
@@ -212,6 +228,7 @@ RunBayesSpace <- function(
     bundle = tool,
     method = "BayesSpace",
     result_type = "domain",
+    source = coordinate_input$source,
     provenance = list(producer = "RunBayesSpace", backend_id = "bayesspace")
   )
 
@@ -226,29 +243,163 @@ bayesspace_add_spatial_coords <- function(
   srt,
   sce,
   image = NULL,
-  platform = "Visium"
+  platform = "Visium",
+  coord.cols = c("col", "row")
 ) {
-  cdata <- as.data.frame(SummarizedExperiment::colData(sce))
-  if (all(c("array_row", "array_col") %in% colnames(cdata))) {
-    return(sce)
-  }
-
-  coords <- bayesspace_get_seurat_coords(srt, image = image)
-  if (is.null(coords)) {
-    coords <- cdata
-  }
-
-  coords <- bayesspace_normalize_coords(coords, platform = platform)
-  common <- intersect(colnames(sce), rownames(coords))
-  if (length(common) == 0L) {
+  if (length(coord.cols) < 2L) {
     log_message(
-      "Unable to match spatial coordinates to {.cls SingleCellExperiment} cells",
+      "{.arg coord.cols} must contain two coordinate columns",
       message_type = "error"
     )
   }
-  cdata[common, colnames(coords)] <- coords[common, , drop = FALSE]
+  coord.cols <- coord.cols[seq_len(2L)]
+  cdata <- as.data.frame(SummarizedExperiment::colData(sce))
+  cells <- colnames(sce)
+  if (
+    is.null(rownames(cdata)) || anyNA(rownames(cdata)) ||
+      any(!nzchar(rownames(cdata))) || anyDuplicated(rownames(cdata)) ||
+      !setequal(rownames(cdata), cells)
+  ) {
+    log_message(
+      "{.cls SingleCellExperiment} colData must have one unique row for every object cell or spot",
+      message_type = "error"
+    )
+  }
+  cdata <- cdata[cells, , drop = FALSE]
+
+  resolved_image <- spatial_image_resolve(
+    srt = srt,
+    image = image,
+    image_policy = "strict"
+  )
+  effective_coord_cols <- coord.cols
+  if (
+    is.null(resolved_image$image) &&
+      !all(effective_coord_cols %in% colnames(srt[[]])) &&
+      all(c("array_col", "array_row") %in% colnames(cdata))
+  ) {
+    effective_coord_cols <- c("array_col", "array_row")
+  }
+  raw <- spatial_coords_raw(
+    srt = srt,
+    image = resolved_image$image,
+    coord.cols = effective_coord_cols,
+    image_policy = "strict"
+  )
+  bayesspace_require_all_spots(raw$data$cell_id, cells)
+
+  coords <- if (all(c("array_row", "array_col") %in% colnames(cdata))) {
+    cdata
+  } else if (!is.null(resolved_image$image)) {
+    bayesspace_get_seurat_coords(srt, image = resolved_image$image)
+  } else {
+    srt[[]]
+  }
+  coords <- bayesspace_normalize_coords(coords, platform = platform)
+  bayesspace_require_all_spots(rownames(coords), cells)
+  coords <- coords[cells, , drop = FALSE]
+  bayesspace_validate_normalized_coords(coords)
+  cdata[, colnames(coords)] <- coords
   SummarizedExperiment::colData(sce) <- S4Vectors::DataFrame(cdata)
-  sce
+  source <- utils::modifyList(
+    raw$source,
+    list(
+      image = resolved_image$image %||% NA_character_,
+      coord.cols = raw$source$coord.cols,
+      coordinate_space = "raw",
+      unit = "native",
+      backend_coordinate_space = "array_index",
+      selection_strategy = if (is.null(resolved_image$image)) {
+        "metadata_columns"
+      } else {
+        "explicit_or_single_image"
+      },
+      transform = raw$transform
+    )
+  )
+  list(sce = sce, coords = raw$data, source = source)
+}
+
+bayesspace_require_all_spots <- function(coordinate_cells, object_cells) {
+  coordinate_cells <- as.character(coordinate_cells)
+  if (
+    anyNA(coordinate_cells) || any(!nzchar(coordinate_cells)) ||
+      anyDuplicated(coordinate_cells) ||
+      !setequal(coordinate_cells, object_cells)
+  ) {
+    missing <- setdiff(object_cells, coordinate_cells)
+    extra <- setdiff(coordinate_cells, object_cells)
+    log_message(
+      paste0(
+        "BayesSpace coordinates must contain exactly one row for every object spot",
+        "; missing: ", length(missing), ", extra: ", length(extra)
+      ),
+      message_type = "error"
+    )
+  }
+  invisible(TRUE)
+}
+
+bayesspace_validate_normalized_coords <- function(coords) {
+  required <- c("array_row", "array_col", "row", "col")
+  if (!all(required %in% colnames(coords))) {
+    log_message(
+      "Normalized BayesSpace coordinates are missing required array columns",
+      message_type = "error"
+    )
+  }
+  finite <- vapply(coords[, required, drop = FALSE], function(x) {
+    all(is.finite(suppressWarnings(as.numeric(x))))
+  }, logical(1))
+  if (!all(finite)) {
+    log_message(
+      "BayesSpace array coordinates contain missing or non-finite values",
+      message_type = "error"
+    )
+  }
+  invisible(TRUE)
+}
+
+bayesspace_validate_backend_output <- function(
+  cdata,
+  cells,
+  cluster_col,
+  init_col = NULL
+) {
+  ids <- rownames(cdata)
+  if (
+    is.null(ids) || anyNA(ids) || any(!nzchar(ids)) || anyDuplicated(ids) ||
+      !setequal(ids, cells)
+  ) {
+    log_message(
+      "BayesSpace output must contain exactly one row for every input spot",
+      message_type = "error"
+    )
+  }
+  validate_column <- function(column, label) {
+    if (!column %in% colnames(cdata)) {
+      if (identical(label, "spatial.cluster")) {
+        log_message(
+          "{.pkg BayesSpace} did not return {.val spatial.cluster}",
+          message_type = "error"
+        )
+      }
+      return(invisible(FALSE))
+    }
+    values <- as.character(cdata[cells, column])
+    if (anyNA(values) || any(!nzchar(values))) {
+      log_message(
+        "BayesSpace output column {.val {label}} contains missing or empty values",
+        message_type = "error"
+      )
+    }
+    invisible(TRUE)
+  }
+  validate_column(cluster_col, cluster_col)
+  if (!is.null(init_col) && init_col %in% colnames(cdata)) {
+    validate_column(init_col, init_col)
+  }
+  invisible(TRUE)
 }
 
 bayesspace_get_seurat_coords <- function(srt, image = NULL) {

--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -580,113 +580,24 @@ rctd_get_spatial_coords <- function(
   coordinate_space = c("legacy_display", "raw")
 ) {
   coordinate_space <- match.arg(coordinate_space)
-  if (identical(coordinate_space, "raw")) {
-    resolved <- spatial_coords_raw(
-      srt = srt,
-      image = image,
-      coord.cols = coord.cols,
-      image_policy = "strict"
-    )
-    matched <- match(spot_ids, resolved$data$cell_id)
-    if (anyNA(matched)) {
-      log_message("Spatial coordinates are missing for one or more requested spots", message_type = "error")
-    }
-    coords <- resolved$data[matched, c("x", "y"), drop = FALSE]
-    rownames(coords) <- spot_ids
-    attr(coords, "spatial_source") <- resolved$source
-    attr(coords, "spatial_transform") <- resolved$transform
-    return(coords)
-  }
-  meta <- srt[[]]
-  if (is.null(image) && all(coord.cols %in% colnames(meta))) {
-    coords <- meta[spot_ids, coord.cols, drop = FALSE]
-    coords <- rctd_validate_coords(coords, spot_ids)
-    return(coords)
-  }
-
-  image_coords <- rctd_get_image_coords(srt, image = image)
-  if (!is.null(image_coords)) {
-    common <- intersect(spot_ids, rownames(image_coords))
-    if (length(common) == length(spot_ids)) {
-      coords <- image_coords[spot_ids, , drop = FALSE]
-      coords <- rctd_validate_coords(coords, spot_ids)
-      return(coords)
-    }
-  }
-
-  if (all(coord.cols %in% colnames(meta))) {
-    coords <- meta[spot_ids, coord.cols, drop = FALSE]
-    coords <- rctd_validate_coords(coords, spot_ids)
-    return(coords)
-  }
-
-  log_message(
-    "Spatial coordinates were not found. Provide a Seurat image or metadata columns {.val {coord.cols}}.",
-    message_type = "error"
+  resolved <- spatial_analysis_coords(
+    srt = srt,
+    image = image,
+    coord.cols = coord.cols,
+    coordinate_space = coordinate_space,
+    image_policy = "strict"
   )
-}
-
-rctd_get_image_coords <- function(srt, image = NULL) {
-  resolved <- spatial_image_resolve(srt = srt, image = image, image_policy = "strict")
-  image <- resolved$image
-  if (is.null(image)) {
-    return(NULL)
-  }
-  coords <- tryCatch(
-    as.data.frame(SeuratObject::GetTissueCoordinates(srt[[image]])),
-    error = function(e) NULL
-  )
-  if (is.null(coords) || nrow(coords) == 0L) {
-    return(NULL)
-  }
-  if ("cell" %in% colnames(coords)) {
-    rownames(coords) <- coords[["cell"]]
-  }
-  x_col <- rctd_pick_col(coords, c("x", "pxl_col_in_fullres", "imagecol", "col"))
-  y_col <- rctd_pick_col(coords, c("y", "pxl_row_in_fullres", "imagerow", "row"))
-  if (is.null(x_col) || is.null(y_col)) {
-    return(NULL)
-  }
-  data.frame(
-    x = coords[[x_col]],
-    y = coords[[y_col]],
-    row.names = rownames(coords),
-    stringsAsFactors = FALSE
-  )
-}
-
-rctd_pick_col <- function(x, candidates) {
-  nm <- colnames(x)
-  hit <- candidates[tolower(candidates) %in% tolower(nm)][1L]
-  if (is.na(hit)) {
-    return(NULL)
-  }
-  nm[match(tolower(hit), tolower(nm))]
-}
-
-rctd_validate_coords <- function(coords, spot_ids) {
-  coords <- as.data.frame(coords, check.names = FALSE)
-  if (ncol(coords) < 2L) {
+  matched <- match(spot_ids, resolved$data$cell_id)
+  if (anyNA(matched)) {
     log_message(
-      "Spatial coordinates must contain at least two columns",
+      "Spatial coordinates are missing for one or more requested spots",
       message_type = "error"
     )
   }
-  coords <- coords[, seq_len(2L), drop = FALSE]
-  colnames(coords) <- c("x", "y")
-  coords[] <- lapply(coords, function(x) suppressWarnings(as.numeric(x)))
-  if (!identical(rownames(coords), spot_ids)) {
-    coords <- coords[spot_ids, , drop = FALSE]
-  }
-  keep <- stats::complete.cases(coords) &
-    is.finite(coords$x) &
-    is.finite(coords$y)
-  if (!all(keep)) {
-    log_message(
-      "Spatial coordinates contain missing or non-finite values for {.val {sum(!keep)}} spots",
-      message_type = "error"
-    )
-  }
+  coords <- resolved$data[matched, c("x", "y"), drop = FALSE]
+  rownames(coords) <- spot_ids
+  attr(coords, "spatial_source") <- resolved$source
+  attr(coords, "spatial_transform") <- resolved$transform
   coords
 }
 

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -857,30 +857,12 @@ sgf_cpp_coords <- function(srt, image, coord.cols, coordinate_space = "legacy_di
     log_message("{.arg coord.cols} must contain at least two coordinate columns", message_type = "error")
   }
   coord.cols <- coord.cols[seq_len(2L)]
-  if (
-    identical(coordinate_space, "legacy_display") &&
-      is.null(image) &&
-      all(coord.cols %in% colnames(srt@meta.data))
-  ) {
-    out <- data.frame(
-      x = srt@meta.data[[coord.cols[1L]]],
-      y = srt@meta.data[[coord.cols[2L]]],
-      row.names = rownames(srt@meta.data),
-      stringsAsFactors = FALSE
-    )
-    attr(out, "spatial_source") <- list(
-      image = NULL,
-      coord.cols = coord.cols,
-      image_policy = "strict",
-      coordinate_space = coordinate_space
-    )
-    return(out)
-  }
   resolved <- spatial_analysis_coords(
     srt = srt,
     image = image,
     coord.cols = coord.cols,
-    coordinate_space = coordinate_space
+    coordinate_space = coordinate_space,
+    image_policy = "strict"
   )
   out <- resolved$data
   attr(out, "spatial_source") <- resolved$source

--- a/man/RunBayesSpace.Rd
+++ b/man/RunBayesSpace.Rd
@@ -21,7 +21,8 @@ RunBayesSpace(
   cluster_colname = "BayesSpace_cluster",
   init_colname = "BayesSpace_init",
   store_sce = TRUE,
-  verbose = TRUE
+  verbose = TRUE,
+  coord.cols = c("col", "row")
 )
 }
 \arguments{
@@ -66,6 +67,9 @@ in \code{srt@tools}.}
 
 \item{verbose}{Whether to print the message.
 Default is \code{TRUE}.}
+
+\item{coord.cols}{Two metadata columns containing raw x/y coordinates when
+no spatial image is available.}
 }
 \value{
 A \code{Seurat} object with BayesSpace clusters in metadata and raw

--- a/tests/testthat/test-bayesspace.R
+++ b/tests/testthat/test-bayesspace.R
@@ -1,0 +1,199 @@
+make_bayesspace_object <- function() {
+  counts <- matrix(
+    c(
+      3, 1, 0, 2,
+      0, 4, 1, 0,
+      2, 1, 3, 1
+    ),
+    nrow = 3,
+    byrow = TRUE,
+    dimnames = list(paste0("Gene", 1:3), paste0("Spot", 1:4))
+  )
+  srt <- Seurat::CreateSeuratObject(
+    counts = methods::as(Matrix::Matrix(counts, sparse = TRUE), "dgCMatrix")
+  )
+  srt$col <- c(0, 2, 1, 3)
+  srt$row <- c(0, 0, 1, 1)
+  srt
+}
+
+make_bayesspace_multi_image_object <- function() {
+  srt <- make_bayesspace_object()
+  assay <- SeuratObject::DefaultAssay(srt)
+  slice1 <- data.frame(
+    x = c(0, 2), y = c(0, 0),
+    row.names = c("Spot1", "Spot2")
+  )
+  slice2 <- data.frame(
+    x = c(1, 3), y = c(1, 1),
+    row.names = c("Spot3", "Spot4")
+  )
+  srt[["slice1"]] <- SeuratObject::CreateFOV(
+    slice1, type = "centroids", assay = assay, key = "bs1_"
+  )
+  srt[["slice2"]] <- SeuratObject::CreateFOV(
+    slice2, type = "centroids", assay = assay, key = "bs2_"
+  )
+  srt
+}
+
+with_mock_bayesspace <- function(cluster_fun, code) {
+  testthat::local_mocked_bindings(
+    check_r = function(...) invisible(TRUE),
+    get_namespace_fun = function(package, name) {
+      expect_identical(package, "BayesSpace")
+      if (identical(name, "spatialCluster")) {
+        return(cluster_fun)
+      }
+      stop("unexpected BayesSpace function: ", name)
+    },
+    .package = "scop"
+  )
+  force(code)
+}
+
+mock_bayesspace_complete <- function(sce, ...) {
+  cdata <- as.data.frame(SummarizedExperiment::colData(sce))
+  cdata$spatial.cluster <- paste0("domain_", seq_len(nrow(cdata)) %% 2 + 1)
+  cdata$cluster.init <- paste0("init_", seq_len(nrow(cdata)) %% 2 + 1)
+  SummarizedExperiment::colData(sce) <- S4Vectors::DataFrame(cdata)
+  sce
+}
+
+test_that("RunBayesSpace stores raw coordinate provenance and aligned cells", {
+  srt <- make_bayesspace_object()
+  with_mock_bayesspace(mock_bayesspace_complete, {
+    out <- RunBayesSpace(
+      srt,
+      q = 2,
+      preprocess = FALSE,
+      store_sce = FALSE,
+      verbose = FALSE
+    )
+  })
+
+  result <- out@tools[["BayesSpace"]]
+  expect_identical(result$schema_version, 1L)
+  expect_identical(result$source$coordinate_space, "raw")
+  expect_identical(result$source$coord.cols, c("col", "row"))
+  expect_identical(result$source$image, NA_character_)
+  expect_identical(result$source$selection_strategy, "metadata_columns")
+  expect_identical(result$cells, colnames(out))
+  expect_identical(result$coords$cell_id, colnames(out))
+  expect_identical(rownames(result$colData), colnames(out))
+  expect_false("sce" %in% names(result))
+  expect_false(anyNA(out$BayesSpace_cluster))
+})
+
+test_that("RunBayesSpace rejects ambiguous or partial image selection atomically", {
+  srt <- make_bayesspace_multi_image_object()
+  metadata_before <- srt[[]]
+  tools_before <- srt@tools
+
+  with_mock_bayesspace(mock_bayesspace_complete, {
+    expect_error(
+      RunBayesSpace(
+        srt,
+        q = 2,
+        preprocess = FALSE,
+        store_sce = FALSE,
+        verbose = FALSE
+      ),
+      "Multiple spatial images"
+    )
+    expect_error(
+      RunBayesSpace(
+        srt,
+        q = 2,
+        image = "slice1",
+        preprocess = FALSE,
+        store_sce = FALSE,
+        verbose = FALSE
+      ),
+      "exactly one row for every object\\s+spot"
+    )
+  })
+
+  expect_identical(srt[[]], metadata_before)
+  expect_identical(srt@tools, tools_before)
+})
+
+test_that("RunBayesSpace validates backend spot alignment before mutation", {
+  srt <- make_bayesspace_object()
+  metadata_before <- srt[[]]
+  tools_before <- srt@tools
+  incomplete_backend <- function(sce, ...) {
+    sce <- sce[, -1, drop = FALSE]
+    mock_bayesspace_complete(sce)
+  }
+
+  with_mock_bayesspace(incomplete_backend, {
+    expect_error(
+      RunBayesSpace(
+        srt,
+        q = 2,
+        preprocess = FALSE,
+        store_sce = FALSE,
+        verbose = FALSE
+      ),
+      "exactly one row for every input spot"
+    )
+  })
+
+  expect_identical(srt[[]], metadata_before)
+  expect_identical(srt@tools, tools_before)
+})
+
+test_that("RunBayesSpace realigns reordered backend output by spot ID", {
+  srt <- make_bayesspace_object()
+  reordered_backend <- function(sce, ...) {
+    cdata <- as.data.frame(SummarizedExperiment::colData(sce))
+    cdata$spatial.cluster <- paste0("domain_", rownames(cdata))
+    SummarizedExperiment::colData(sce) <- S4Vectors::DataFrame(cdata)
+    sce[, rev(seq_len(ncol(sce))), drop = FALSE]
+  }
+
+  with_mock_bayesspace(reordered_backend, {
+    out <- RunBayesSpace(
+      srt,
+      q = 2,
+      preprocess = FALSE,
+      store_sce = FALSE,
+      verbose = FALSE
+    )
+  })
+
+  expect_identical(
+    as.character(out$BayesSpace_cluster),
+    paste0("domain_", colnames(out))
+  )
+  expect_identical(
+    rownames(out@tools[["BayesSpace"]]$colData),
+    colnames(out)
+  )
+})
+
+test_that("RunBayesSpace rejects missing cluster labels before mutation", {
+  srt <- make_bayesspace_object()
+  metadata_before <- srt[[]]
+  empty_label_backend <- function(sce, ...) {
+    cdata <- as.data.frame(SummarizedExperiment::colData(sce))
+    cdata$spatial.cluster <- c("domain_1", NA, "domain_2", "")
+    SummarizedExperiment::colData(sce) <- S4Vectors::DataFrame(cdata)
+    sce
+  }
+
+  with_mock_bayesspace(empty_label_backend, {
+    expect_error(
+      RunBayesSpace(
+        srt,
+        q = 2,
+        preprocess = FALSE,
+        store_sce = FALSE,
+        verbose = FALSE
+      ),
+      "missing or empty"
+    )
+  })
+  expect_identical(srt[[]], metadata_before)
+})

--- a/tests/testthat/test-spatial-coordinate-routing.R
+++ b/tests/testthat/test-spatial-coordinate-routing.R
@@ -1,0 +1,61 @@
+make_coordinate_routing_object <- function() {
+  counts <- matrix(
+    1:12,
+    nrow = 3,
+    dimnames = list(paste0("Gene", 1:3), paste0("Spot", 1:4))
+  )
+  srt <- Seurat::CreateSeuratObject(
+    counts = methods::as(Matrix::Matrix(counts, sparse = TRUE), "dgCMatrix")
+  )
+  srt$x <- c(0, 1, 2, 3)
+  srt$y <- c(0, 0, 1, 1)
+  assay <- SeuratObject::DefaultAssay(srt)
+  srt[["slice1"]] <- SeuratObject::CreateFOV(
+    data.frame(x = c(0, 1), y = c(0, 0), row.names = c("Spot1", "Spot2")),
+    type = "centroids", assay = assay, key = "cr1_"
+  )
+  srt[["slice2"]] <- SeuratObject::CreateFOV(
+    data.frame(x = c(2, 3), y = c(1, 1), row.names = c("Spot3", "Spot4")),
+    type = "centroids", assay = assay, key = "cr2_"
+  )
+  srt
+}
+
+test_that("legacy metadata paths do not bypass strict multi-image selection", {
+  srt <- make_coordinate_routing_object()
+
+  expect_error(
+    sgf_cpp_coords(
+      srt,
+      image = NULL,
+      coord.cols = c("x", "y"),
+      coordinate_space = "legacy_display"
+    ),
+    "Multiple spatial images"
+  )
+  expect_error(
+    rctd_get_spatial_coords(
+      srt,
+      spot_ids = colnames(srt),
+      image = NULL,
+      coord.cols = c("x", "y"),
+      coordinate_space = "legacy_display"
+    ),
+    "Multiple spatial images"
+  )
+})
+
+test_that("shared coordinate routing rejects partial image spot sets", {
+  srt <- make_coordinate_routing_object()
+
+  expect_error(
+    rctd_get_spatial_coords(
+      srt,
+      spot_ids = colnames(srt),
+      image = "slice1",
+      coord.cols = c("x", "y"),
+      coordinate_space = "raw"
+    ),
+    "missing for one or more requested spots"
+  )
+})


### PR DESCRIPTION
## Summary
- route RCTD/CARD/BANKSY and C++ gradient coordinates through the shared strict image resolver
- make BayesSpace record schema-v1 raw coordinate provenance, selected image/columns, units, transform, and exact input cells
- reject ambiguous multi-image input, partial image coverage, stale backend spot sets, and empty cluster labels before mutating the Seurat object
- preserve positional compatibility by adding `coord.cols` at the end of the public BayesSpace signature

## Validation
- full DLPFC 151673 coordinate smoke: 3,639/3,639 spots aligned for gradient, RCTD, and BayesSpace coordinate preparation
- real BayesSpace smoke: 150 DLPFC spots, q=3, nrep=100, schema state ready and raw provenance
- targeted tests: BayesSpace, coordinate routing, gradient C++, RCTD C++, CARD, BANKSY, spatial static contracts
- `pkgload::load_all('.', quiet=TRUE, compile=FALSE)`
- `tools::Rd2ex()` plus `parse()` for `RunBayesSpace.Rd`
- `_R_CHECK_FORCE_SUGGESTS_=false` R CMD check: 0 errors; dependency code and unstated example dependency checks both OK (remaining GNU Makevars warning and four notes pre-exist this change)