### PR TITLE
fix(spatial): preserve backend coordinate lineage

### DIFF
--- a/R/RunCSIDE.R
+++ b/R/RunCSIDE.R
@@ -117,6 +117,10 @@ RunCSIDE <- function(
   mode <- match.arg(mode)
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
 
+  rctd_context <- cside_rctd_context(
+    srt = srt,
+    rctd_result = rctd_result
+  )
   stored_rctd_mode <- cside_stored_rctd_mode(
     srt = srt,
     rctd_result = rctd_result
@@ -199,15 +203,24 @@ RunCSIDE <- function(
         features = features,
         prefix = prefix,
         tool_name = tool_name,
+        rctd_source = rctd_context$input_type,
+        rctd_tool_name = rctd_context$tool_name,
         backend_args = extra_args,
         condition_levels = inputs$condition_levels
-      )
+      ),
+      cells = inputs$barcodes
     )
     srt@tools[[tool_name]] <- spatial_result_build(
       bundle = srt@tools[[tool_name]],
       method = "CSIDE",
       result_type = "deconvolution",
-      provenance = list(producer = "RunCSIDE", backend_id = "spacexr")
+      source = rctd_context$source,
+      provenance = list(
+        producer = "RunCSIDE",
+        backend_id = "spacexr",
+        parent_tool = rctd_context$tool_name,
+        parent_schema_version = rctd_context$schema_version
+      )
     )
   }
 
@@ -216,6 +229,53 @@ RunCSIDE <- function(
     verbose = verbose
   )
   srt
+}
+
+cside_rctd_context <- function(srt, rctd_result = NULL) {
+  if (!is.null(rctd_result)) {
+    return(list(
+      input_type = "external_rctd_result",
+      tool_name = NA_character_,
+      schema_version = NA_integer_,
+      source = list(
+        image = NA_character_,
+        coordinate_space = "backend_managed",
+        selection_strategy = "external_rctd_result",
+        lineage_status = "external_input_without_scop_source"
+      )
+    ))
+  }
+
+  stored <- srt@tools[["RCTD"]]
+  has_schema <- is.list(stored) &&
+    identical(as.integer(stored$schema_version %||% NA_integer_), 1L)
+  source <- if (has_schema && is.list(stored$source)) {
+    stored$source
+  } else {
+    list(
+      image = NA_character_,
+      coordinate_space = "backend_managed",
+      selection_strategy = "stored_legacy_rctd",
+      lineage_status = "stored_rctd_without_schema_source"
+    )
+  }
+  source <- utils::modifyList(
+    source,
+    list(
+      parent_tool = "RCTD",
+      lineage_status = if (has_schema) {
+        "inherited_from_stored_rctd"
+      } else {
+        source$lineage_status
+      }
+    )
+  )
+  list(
+    input_type = "stored_rctd_result",
+    tool_name = "RCTD",
+    schema_version = if (has_schema) 1L else NA_integer_,
+    source = source
+  )
 }
 
 cside_stored_rctd_mode <- function(srt, rctd_result = NULL) {

--- a/R/RunSemla.R
+++ b/R/RunSemla.R
@@ -84,10 +84,10 @@ RunSemlaSpatialNetwork <- function(
 
   if (isTRUE(store_results)) {
     srt@tools[[tool_name]] <- spatial_result_build(
-      bundle = list(network = spatial_network),
+      bundle = list(network = spatial_network, cells = colnames(srt)),
       method = "SemlaSpatialNetwork",
       result_type = "neighborhood",
-      source = list(coordinate_space = if (coords == "array") "raw" else "legacy_display"),
+      source = semla_spatial_source(srt, coords = coords),
       provenance = list(producer = "RunSemlaSpatialNetwork", backend_id = "semla"),
       parameters = list(
         image_type = image_type,
@@ -168,22 +168,41 @@ RunSemlaLocalG <- function(
     image_type = image_type,
     verbose = verbose
   )
+  backend_args <- list(...)
   before_metadata <- colnames(srt@meta.data)
-  out <- semla_get_fun("RunLocalG")(
-    srt,
-    features = features,
-    alternative = alternative,
-    store_in_metadata = store_in_metadata,
-    assay_name = assay_name,
-    verbose = verbose,
-    ...
+  out <- do.call(
+    semla_get_fun("RunLocalG"),
+    c(
+      list(
+        object = srt,
+        features = features,
+        alternative = alternative,
+        store_in_metadata = store_in_metadata,
+        assay_name = assay_name,
+        verbose = verbose
+      ),
+      backend_args
+    )
   )
   out@tools[["SemlaLocalG"]] <- spatial_result_build(
-    bundle = list(output_columns = setdiff(colnames(out@meta.data), before_metadata)),
+    bundle = list(
+      output_columns = setdiff(colnames(out@meta.data), before_metadata),
+      cells = colnames(out)
+    ),
     method = "SemlaLocalG", result_type = "neighborhood",
-    source = list(coordinate_space = "legacy_display"),
+    source = semla_spatial_source(
+      out,
+      coords = semla_backend_coords(backend_args)
+    ),
     provenance = list(producer = "RunSemlaLocalG", backend_id = "semla"),
-    parameters = list(features = features, alternative = alternative, store_in_metadata = store_in_metadata, assay_name = assay_name, image_type = image_type)
+    parameters = list(
+      features = features,
+      alternative = alternative,
+      store_in_metadata = store_in_metadata,
+      assay_name = assay_name,
+      image_type = image_type,
+      backend_args = backend_args
+    )
   )
   out
 }
@@ -253,22 +272,41 @@ RunSemlaRegionNeighbors <- function(
     image_type = image_type,
     verbose = verbose
   )
+  backend_args <- list(...)
   before_metadata <- colnames(srt@meta.data)
-  out <- semla_get_fun("RegionNeighbors")(
-    srt,
-    column_name = column_name,
-    column_labels = column_labels,
-    mode = mode,
-    column_key = column_key,
-    verbose = verbose,
-    ...
+  out <- do.call(
+    semla_get_fun("RegionNeighbors"),
+    c(
+      list(
+        object = srt,
+        column_name = column_name,
+        column_labels = column_labels,
+        mode = mode,
+        column_key = column_key,
+        verbose = verbose
+      ),
+      backend_args
+    )
   )
   out@tools[["SemlaRegionNeighbors"]] <- spatial_result_build(
-    bundle = list(output_columns = setdiff(colnames(out@meta.data), before_metadata)),
+    bundle = list(
+      output_columns = setdiff(colnames(out@meta.data), before_metadata),
+      cells = colnames(out)
+    ),
     method = "SemlaRegionNeighbors", result_type = "neighborhood",
-    source = list(coordinate_space = "legacy_display"),
+    source = semla_spatial_source(
+      out,
+      coords = semla_backend_coords(backend_args)
+    ),
     provenance = list(producer = "RunSemlaRegionNeighbors", backend_id = "semla"),
-    parameters = list(column_name = column_name, column_labels = column_labels, mode = mode, column_key = column_key, image_type = image_type)
+    parameters = list(
+      column_name = column_name,
+      column_labels = column_labels,
+      mode = mode,
+      column_key = column_key,
+      image_type = image_type,
+      backend_args = backend_args
+    )
   )
   out
 }
@@ -339,23 +377,112 @@ RunSemlaRadialDistance <- function(
     image_type = image_type,
     verbose = verbose
   )
+  backend_args <- list(...)
   before_metadata <- colnames(srt@meta.data)
-  out <- semla_get_fun("RadialDistance")(
-    srt,
-    column_name = column_name,
-    selected_groups = selected_groups,
-    column_suffix = column_suffix,
-    verbose = verbose,
-    ...
+  out <- do.call(
+    semla_get_fun("RadialDistance"),
+    c(
+      list(
+        object = srt,
+        column_name = column_name,
+        selected_groups = selected_groups,
+        column_suffix = column_suffix,
+        verbose = verbose
+      ),
+      backend_args
+    )
   )
   out@tools[["SemlaRadialDistance"]] <- spatial_result_build(
-    bundle = list(output_columns = setdiff(colnames(out@meta.data), before_metadata)),
+    bundle = list(
+      output_columns = setdiff(colnames(out@meta.data), before_metadata),
+      cells = colnames(out)
+    ),
     method = "SemlaRadialDistance", result_type = "neighborhood",
-    source = list(coordinate_space = "legacy_display"),
+    source = semla_spatial_source(
+      out,
+      coords = "pixels",
+      output_unit = if (isTRUE(backend_args$convert_to_microns)) {
+        "micrometre"
+      } else {
+        "full_resolution_pixel"
+      }
+    ),
     provenance = list(producer = "RunSemlaRadialDistance", backend_id = "semla"),
-    parameters = list(column_name = column_name, selected_groups = selected_groups, column_suffix = column_suffix, image_type = image_type)
+    parameters = list(
+      column_name = column_name,
+      selected_groups = selected_groups,
+      column_suffix = column_suffix,
+      image_type = image_type,
+      backend_args = backend_args
+    )
   )
   out
+}
+
+semla_backend_coords <- function(backend_args) {
+  coords <- backend_args$coords %||% "pixels"
+  if (
+    !is.character(coords) || length(coords) != 1L || is.na(coords) ||
+      !coords %in% c("pixels", "array")
+  ) {
+    log_message(
+      "{.arg coords} must be one of {.val pixels} or {.val array}",
+      message_type = "error"
+    )
+  }
+  coords
+}
+
+semla_spatial_source <- function(
+  srt,
+  coords = c("pixels", "array"),
+  output_unit = NULL
+) {
+  coords <- match.arg(coords)
+  images <- tryCatch(SeuratObject::Images(srt), error = function(e) character())
+  staffli <- srt@tools[["Staffli"]]
+  staffli_metadata <- tryCatch(
+    if (isS4(staffli)) {
+      methods::slot(staffli, "meta_data")
+    } else {
+      staffli$meta_data
+    },
+    error = function(e) NULL
+  )
+  sample_ids <- tryCatch(
+    unique(as.character(staffli_metadata$sampleID)),
+    error = function(e) character()
+  )
+  sample_ids <- sample_ids[!is.na(sample_ids) & nzchar(sample_ids)]
+  list(
+    image = if (length(images) == 1L) as.character(images) else NA_character_,
+    images = images,
+    image_policy = "native_multi_image",
+    coordinate_space = "raw",
+    coord.cols = if (identical(coords, "array")) {
+      c("x", "y")
+    } else {
+      c("pxl_col_in_fullres", "pxl_row_in_fullres")
+    },
+    unit = if (identical(coords, "array")) {
+      "array_index"
+    } else {
+      "full_resolution_pixel"
+    },
+    output_unit = output_unit %||% if (identical(coords, "array")) {
+      "array_index"
+    } else {
+      "full_resolution_pixel"
+    },
+    selection_strategy = if (length(images) > 1L) {
+      "all_images_partitioned_by_staffli_sampleID"
+    } else if (length(images) == 1L) {
+      "single_image_staffli"
+    } else {
+      "existing_staffli_metadata"
+    },
+    sample_ids = sample_ids
+  )
 }
 
 semla_prepare_srt <- function(

--- a/R/RunSpatialQM.R
+++ b/R/RunSpatialQM.R
@@ -157,6 +157,12 @@ RunSpatialQM <- function(
       bundle = srt@tools[[tool_name]],
       method = "SpatialQM",
       result_type = "quality_control",
+      source = list(
+        image = NA_character_,
+        coordinate_space = "mixed",
+        selection_strategy = "backend_managed",
+        lineage_status = "coordinates_resolved_by_spatialqm_metric"
+      ),
       provenance = list(producer = "RunSpatialQM", backend_id = "spatialqm")
     )
   }

--- a/R/SpatialRegistry.R
+++ b/R/SpatialRegistry.R
@@ -45,7 +45,7 @@ spatial_method_registry <- function() {
     entry("GetSpatialGraph", "accessor", "network", "RunSpatialNetwork.R", backend_id = "core", coordinate_space_current = "raw", coordinate_requirement = "backend_managed"),
     entry("RunSpotQC", "analysis", "quality_control", "RunSpotQC.R", backend_id = "core", coordinate_space_current = "none", coordinate_space_target = "none", coordinate_requirement = "identity_only", plot_function = "SpatialSpotPlot"),
     entry("RunSpaNorm", "analysis", "normalization", "RunSpaNorm.R", "SpaNorm", "spanorm", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive", plot_function = "SpatialSpotPlot"),
-    entry("RunSpatialQM", "analysis", "quality_control", "RunSpatialQM.R", "SpatialQM", "spatialqm", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive", plot_function = "SpatialSpotPlot"),
+    entry("RunSpatialQM", "analysis", "quality_control", "RunSpatialQM.R", "SpatialQM", "spatialqm", coordinate_space_current = "mixed", coordinate_space_target = "mixed", coordinate_requirement = "backend_managed", plot_function = "SpatialSpotPlot"),
     entry("RunSpotSweeper", "analysis", "quality_control", "RunSpotSweeper.R", "SpotSweeper", "spotsweeper", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive", plot_function = "SpatialSpotPlot"),
 
     entry("srt_to_giotto", "bridge", "framework_bridge", "SpatialFrameworkConvert.R", backend_id = "giotto;giotto_class", coordinate_space_current = "raw", coordinate_requirement = "backend_managed"),
@@ -72,7 +72,7 @@ spatial_method_registry <- function() {
 
     entry("RunDeconvolution", "analysis", "deconvolution", "RunDeconvolution.R", backend_id = "music;bisquerna;bayesprism;cibersort", coordinate_space_current = "none", coordinate_space_target = "none", coordinate_requirement = "identity_only", plot_function = "DeconvolutionPlot", backend_requirement = "any"),
     entry("RunRCTD", "analysis", "deconvolution", "RunRCTD.R", "RCTD", "spacexr", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive", plot_function = "DeconvolutionPlot"),
-    entry("RunCSIDE", "analysis", "deconvolution", "RunCSIDE.R", "CSIDE", "spacexr", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive", plot_function = "DeconvolutionPlot"),
+    entry("RunCSIDE", "analysis", "deconvolution", "RunCSIDE.R", "CSIDE", "spacexr", coordinate_space_current = "mixed", coordinate_space_target = "mixed", coordinate_requirement = "backend_managed", plot_function = "DeconvolutionPlot"),
     entry("RunCARD", "analysis", "deconvolution", "RunCARD.R", "CARD", "card", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive", plot_function = "DeconvolutionPlot"),
     entry("RunSTdeconvolve", "analysis", "deconvolution", "RunSTdeconvolve.R", "STdeconvolve", "stdeconvolve", coordinate_space_current = "none", coordinate_space_target = "none", coordinate_requirement = "identity_only", plot_function = "STdeconvolvePlot"),
     entry("RunSPOTlight", "analysis", "deconvolution", "RunSPOTlight.R", "SPOTlight", "spotlight", coordinate_space_current = "none", coordinate_space_target = "none", coordinate_requirement = "identity_only", plot_function = "DeconvolutionPlot"),
@@ -94,10 +94,10 @@ spatial_method_registry <- function() {
     entry("RunStatialKontextual", "analysis", "neighborhood", "RunStatialKontextual.R", "StatialKontextual", "statial", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive", plot_function = "StatialKontextualPlot"),
     entry("RunSpatialIntegration", "analysis", "integration", "RunSpatialIntegration.R", "SpatialIntegration", "precast;bass;spatialmnn", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive", plot_function = "SpatialIntegrationPlot", backend_requirement = "any"),
     entry("RunMistyR", "analysis", "neighborhood", "RunMistyR.R", "MistyR", "mistyr", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive", plot_function = "MistyRPlot"),
-    entry("RunSemlaSpatialNetwork", "analysis", "neighborhood", "RunSemla.R", "SemlaSpatialNetwork", "semla", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive"),
-    entry("RunSemlaLocalG", "analysis", "neighborhood", "RunSemla.R", "SemlaLocalG", "semla", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive"),
-    entry("RunSemlaRadialDistance", "analysis", "neighborhood", "RunSemla.R", "SemlaRadialDistance", "semla", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive"),
-    entry("RunSemlaRegionNeighbors", "analysis", "neighborhood", "RunSemla.R", "SemlaRegionNeighbors", "semla", coordinate_space_current = "legacy_display", coordinate_space_target = "raw", coordinate_requirement = "distance_sensitive"),
+    entry("RunSemlaSpatialNetwork", "analysis", "neighborhood", "RunSemla.R", "SemlaSpatialNetwork", "semla", coordinate_space_current = "raw", coordinate_requirement = "distance_sensitive"),
+    entry("RunSemlaLocalG", "analysis", "neighborhood", "RunSemla.R", "SemlaLocalG", "semla", coordinate_space_current = "raw", coordinate_requirement = "distance_sensitive"),
+    entry("RunSemlaRadialDistance", "analysis", "neighborhood", "RunSemla.R", "SemlaRadialDistance", "semla", coordinate_space_current = "raw", coordinate_requirement = "distance_sensitive"),
+    entry("RunSemlaRegionNeighbors", "analysis", "neighborhood", "RunSemla.R", "SemlaRegionNeighbors", "semla", coordinate_space_current = "raw", coordinate_requirement = "distance_sensitive"),
 
     entry("GiottoPlot", "plot", "visualization", "GiottoPlot.R", backend_id = "giotto;giotto_class", status = "legacy", coordinate_space_current = "display", coordinate_requirement = "display_only"),
     entry("DeconvolutionPlot", "plot", "visualization", "DeconvolutionPlot.R", coordinate_space_current = "display", coordinate_requirement = "display_only"),

--- a/tests/testthat/test-run-cside.R
+++ b/tests/testthat/test-run-cside.R
@@ -19,7 +19,14 @@ make_cside_seurat <- function() {
   srt@tools$RCTD <- list(
     object = structure(list(id = "mock-rctd"), class = "RCTD"),
     backend_api = "SpatialRNA/Reference/create.RCTD/run.RCTD",
-    parameters = list(rctd_mode = "full")
+    parameters = list(rctd_mode = "full"),
+    schema_version = 1L,
+    source = list(
+      image = NA_character_,
+      coord.cols = c("col", "row"),
+      coordinate_space = "raw",
+      unit = "native"
+    )
   )
   srt
 }
@@ -123,6 +130,14 @@ test_that("RunCSIDE condition.by dispatches to single backend", {
   expect_equal(out@tools$CSIDE$result_table$significant, c(TRUE, FALSE))
   expect_equal(unique(out$CSIDE_n_sig), 1)
   expect_equal(unique(out$CSIDE_mode), "single")
+  expect_identical(out@tools$CSIDE$source$coordinate_space, "raw")
+  expect_identical(
+    out@tools$CSIDE$source$lineage_status,
+    "inherited_from_stored_rctd"
+  )
+  expect_identical(out@tools$CSIDE$provenance$parent_tool, "RCTD")
+  expect_identical(out@tools$CSIDE$provenance$parent_schema_version, 1L)
+  expect_identical(out@tools$CSIDE$cells, colnames(out))
 })
 
 test_that("RunCSIDE group.by builds region_list and dispatches to regions backend", {
@@ -215,4 +230,40 @@ test_that("RunCSIDE intercept mode and backend availability errors are clear", {
       "dmcable/spacexr"
     )
   })
+})
+
+test_that("RunCSIDE marks external RCTD lineage as backend managed", {
+  srt <- make_cside_seurat()
+  external <- srt@tools$RCTD$object
+  fake_intercept <- function(myRCTD, barcodes, cell_types, ...) {
+    expect_identical(myRCTD, external)
+    mock_cside_result()
+  }
+
+  with_mock_cside(list("run.CSIDE.intercept" = fake_intercept), {
+    out <- RunCSIDE(
+      srt,
+      rctd_result = external,
+      barcodes = c("Spot1", "Spot3"),
+      verbose = FALSE
+    )
+  })
+
+  result <- out@tools$CSIDE
+  expect_identical(result$source$coordinate_space, "backend_managed")
+  expect_identical(
+    result$source$lineage_status,
+    "external_input_without_scop_source"
+  )
+  expect_identical(result$parameters$rctd_source, "external_rctd_result")
+  expect_true(is.na(result$provenance$parent_tool))
+  expect_identical(result$cells, c("Spot1", "Spot3"))
+})
+
+test_that("CSIDE registry records inherited coordinate semantics", {
+  row <- spatial_method_registry()
+  row <- row[row$method == "RunCSIDE", , drop = FALSE]
+  expect_identical(row$coordinate_space_current, "mixed")
+  expect_identical(row$coordinate_space_target, "mixed")
+  expect_identical(row$coordinate_requirement, "backend_managed")
 })

--- a/tests/testthat/test-run-spatialqm.R
+++ b/tests/testthat/test-run-spatialqm.R
@@ -79,6 +79,15 @@ test_that("RunSpatialQM stores metric results and summary", {
   expect_equal(bundle$parameters$features, c("Gene1", "Gene2"))
   expect_equal(bundle$parameters$platform, "Xenium")
   expect_equal(bundle$parameters$backend_args$sample.p, 0.25)
+  expect_identical(bundle$source$coordinate_space, "mixed")
+})
+
+test_that("SpatialQM registry records backend-managed coordinate semantics", {
+  row <- spatial_method_registry()
+  row <- row[row$method == "RunSpatialQM", , drop = FALSE]
+  expect_identical(row$coordinate_space_current, "mixed")
+  expect_identical(row$coordinate_space_target, "mixed")
+  expect_identical(row$coordinate_requirement, "backend_managed")
 })
 
 test_that("RunSpatialQM can record failed metrics without stopping", {

--- a/tests/testthat/test-semla.R
+++ b/tests/testthat/test-semla.R
@@ -8,6 +8,27 @@ make_semla_spatial_seurat <- function(nspots = 80, nfeatures = 30) {
   srt
 }
 
+make_semla_multi_image_object <- function() {
+  counts <- matrix(
+    1:12,
+    nrow = 3,
+    dimnames = list(paste0("Gene", 1:3), paste0("Spot", 1:4))
+  )
+  srt <- SeuratObject::CreateSeuratObject(
+    methods::as(Matrix::Matrix(counts, sparse = TRUE), "dgCMatrix")
+  )
+  assay <- SeuratObject::DefaultAssay(srt)
+  srt[["slice1"]] <- SeuratObject::CreateFOV(
+    data.frame(x = c(0, 1), y = c(0, 0), row.names = c("Spot1", "Spot2")),
+    type = "centroids", assay = assay, key = "sm1_"
+  )
+  srt[["slice2"]] <- SeuratObject::CreateFOV(
+    data.frame(x = c(2, 3), y = c(1, 1), row.names = c("Spot3", "Spot4")),
+    type = "centroids", assay = assay, key = "sm2_"
+  )
+  srt
+}
+
 semla_installed_without_loading <- function() {
   "semla" %in% rownames(utils::installed.packages())
 }
@@ -70,6 +91,12 @@ test_that("RunSemlaSpatialNetwork stores semla network results", {
   expect_equal(out@tools[["SemlaSpatialNetwork"]][["parameters"]][["nNeighbors"]], 3)
   expect_equal(out@tools[["SemlaSpatialNetwork"]][["schema_version"]], 1L)
   expect_equal(out@tools[["SemlaSpatialNetwork"]][["provenance"]][["backend_id"]], "semla")
+  expect_identical(out@tools$SemlaSpatialNetwork$source$coordinate_space, "raw")
+  expect_identical(
+    out@tools$SemlaSpatialNetwork$source$unit,
+    "full_resolution_pixel"
+  )
+  expect_identical(out@tools$SemlaSpatialNetwork$cells, colnames(out))
 })
 
 test_that("RunSemlaLocalG writes local G metadata", {
@@ -86,6 +113,7 @@ test_that("RunSemlaLocalG writes local G metadata", {
   expect_true(all(paste0("Gi[", features, "]") %in% colnames(out@meta.data)))
   expect_equal(out@tools[["SemlaLocalG"]][["schema_version"]], 1L)
   expect_equal(out@tools[["SemlaLocalG"]][["provenance"]][["producer"]], "RunSemlaLocalG")
+  expect_identical(out@tools$SemlaLocalG$source$coordinate_space, "raw")
 })
 
 test_that("Semla distance producers store schema-v1 provenance", {
@@ -97,6 +125,10 @@ test_that("Semla distance producers store schema-v1 provenance", {
   )
   expect_equal(neighbors@tools[["SemlaRegionNeighbors"]][["schema_version"]], 1L)
   expect_equal(neighbors@tools[["SemlaRegionNeighbors"]][["provenance"]][["backend_id"]], "semla")
+  expect_identical(
+    neighbors@tools$SemlaRegionNeighbors$source$coordinate_space,
+    "raw"
+  )
 
   radial <- RunSemlaRadialDistance(
     srt, column_name = "semla_region", selected_groups = "A",
@@ -104,4 +136,26 @@ test_that("Semla distance producers store schema-v1 provenance", {
   )
   expect_equal(radial@tools[["SemlaRadialDistance"]][["schema_version"]], 1L)
   expect_equal(radial@tools[["SemlaRadialDistance"]][["provenance"]][["producer"]], "RunSemlaRadialDistance")
+  expect_identical(radial@tools$SemlaRadialDistance$source$unit, "full_resolution_pixel")
+})
+
+test_that("semla provenance records native multi-image partitioning", {
+  srt <- make_semla_multi_image_object()
+  staffli <- list(
+    meta_data = data.frame(
+      barcode = colnames(srt),
+      sampleID = c("1", "1", "2", "2")
+    )
+  )
+  srt@tools[["Staffli"]] <- staffli
+
+  source <- semla_spatial_source(srt, coords = "pixels")
+  expect_identical(source$image, NA_character_)
+  expect_identical(source$images, c("slice1", "slice2"))
+  expect_identical(source$image_policy, "native_multi_image")
+  expect_identical(
+    source$selection_strategy,
+    "all_images_partitioned_by_staffli_sampleID"
+  )
+  expect_identical(source$sample_ids, c("1", "2"))
 })

--- a/tests/testthat/test-spatial-static-contracts.R
+++ b/tests/testthat/test-spatial-static-contracts.R
@@ -83,8 +83,7 @@ test_that("registered small analyses emit schema-v1 result families", {
   target <- registry[
     registry$kind == "analysis" &
       registry$status == "stable" &
-      !is.na(registry$tool_key) & nzchar(registry$tool_key) &
-      !grepl("^RunSemla", registry$method),
+      !is.na(registry$tool_key) & nzchar(registry$tool_key),
     c("method", "task"),
     drop = FALSE
   ]


### PR DESCRIPTION
## Summary

- inherit schema-v1 coordinate source and parent lineage from stored RCTD results in `RunCSIDE()` while marking external or legacy RCTD inputs explicitly as backend-managed
- record truthful mixed/backend-managed coordinate semantics for SpatialQM metrics instead of claiming legacy display coordinates
- record Semla's actual Staffli raw pixel/array coordinate source, native multi-image partitioning, units, cells, and backend arguments for all four Semla producers
- admit Semla producers to the shared schema-v1 static contract test

## Validation

- targeted testthat: CSIDE 60 pass; SpatialQM 44 pass; Semla 29 pass with 1 expected installed-backend skip; spatial static contracts 34 pass
- DLPFC 151673 smoke: 3,639 spots retained stored RCTD raw lineage as `inherited_from_stored_rctd`
- actual Semla 1.4.2 producer tests ran on the bundled spatial pancreas object
- `pkgload::load_all('.', quiet=TRUE, compile=FALSE)` exits successfully
- `_R_CHECK_FORCE_SUGGESTS_=false` `rcmdcheck --no-manual --as-cran --no-examples --no-tests`: 0 errors; dependency code OK; unstated example dependencies OK; 1 pre-existing Makevars warning and 4 pre-existing notes

No dependencies, environment-variable guards, global options, or direct optional-backend namespace calls were added.
