### PR TITLE
Fix heatmap row label wrapping

### DIFF
--- a/R/FeatureHeatmap.R
+++ b/R/FeatureHeatmap.R
@@ -158,6 +158,7 @@ FeatureHeatmap <- function(
   cluster_row_slices = FALSE,
   cluster_column_slices = FALSE,
   show_row_names = FALSE,
+  row_names_wrap = NULL,
   show_column_names = FALSE,
   row_names_side = ifelse(flip, "left", "right"),
   column_names_side = ifelse(flip, "bottom", "top"),
@@ -1324,13 +1325,20 @@ FeatureHeatmap <- function(
     }
   }
   if (length(index) > 0) {
+    mark_labels <- feature_metadata[
+      which(rownames(feature_metadata) %in% features_ordered[index]),
+      "features"
+    ]
+    if (!is.null(row_names_wrap)) {
+      mark_labels <- heatmap_wrap_row_labels(
+        mark_labels,
+        width = row_names_wrap
+      )
+    }
     ha_mark <- ComplexHeatmap::HeatmapAnnotation(
       gene = ComplexHeatmap::anno_mark(
         at = which(rownames(feature_metadata) %in% features_ordered[index]),
-        labels = feature_metadata[
-          which(rownames(feature_metadata) %in% features_ordered[index]),
-          "features"
-        ],
+        labels = mark_labels,
         side = ifelse(flip, "top", "left"),
         labels_gp = grid::gpar(fontsize = label_size, col = label_color),
         link_gp = grid::gpar(fontsize = label_size, col = label_color),
@@ -1512,9 +1520,14 @@ FeatureHeatmap <- function(
       right_annotation <- NULL
     }
 
+    matrix_use <- if (flip) {
+      Matrix::t(mat_list[[cell_group]])
+    } else {
+      mat_list[[cell_group]]
+    }
     ht_args <- list(
       name = cell_group,
-      matrix = if (flip) Matrix::t(mat_list[[cell_group]]) else mat_list[[cell_group]],
+      matrix = matrix_use,
       col = colors,
       row_title = row_title %||%
         if (flip) {
@@ -1585,6 +1598,19 @@ FeatureHeatmap <- function(
         NULL
       }
     )
+    if (!is.null(row_names_wrap)) {
+      row_labels <- heatmap_wrap_row_labels(
+        rownames(matrix_use),
+        width = row_names_wrap
+      )
+      ht_args[["row_labels"]] <- row_labels
+      if (!"row_names_max_width" %in% names(ht_params)) {
+        ht_args[["row_names_max_width"]] <- heatmap_row_labels_max_width(
+          row_labels,
+          gp = ht_params[["row_names_gp"]]
+        )
+      }
+    }
     if (!is.null(split.by) && isFALSE(cluster_column_slices)) {
       n_slices <- length(levels(column_split_list[[cell_group]]))
       groups_order <- sapply(

--- a/R/GroupHeatmap.R
+++ b/R/GroupHeatmap.R
@@ -76,6 +76,11 @@
 #' Default is `FALSE`.
 #' @param show_row_names Whether to show row names in the heatmap.
 #' Default is `FALSE`.
+#' @param row_names_wrap Maximum number of characters per displayed row-name
+#' line. When set to a positive number, underscores are displayed as spaces and
+#' labels are wrapped without changing the underlying feature identifiers.
+#' This also applies to feature labels selected by `nlabel` or
+#' `features_label`. `NULL` disables wrapping.
 #' @param show_column_names Whether to show column names in the heatmap.
 #' Default is `FALSE`.
 #' @param row_names_side A character vector specifying the side to place row names.
@@ -475,6 +480,7 @@ GroupHeatmap <- function(
   cluster_row_slices = FALSE,
   cluster_column_slices = FALSE,
   show_row_names = FALSE,
+  row_names_wrap = NULL,
   show_column_names = FALSE,
   row_names_side = ifelse(flip, "left", "right"),
   column_names_side = ifelse(flip, "bottom", "top"),
@@ -1886,13 +1892,20 @@ GroupHeatmap <- function(
   }
 
   if (length(index) > 0) {
+    mark_labels <- feature_metadata[
+      which(rownames(feature_metadata) %in% features_ordered[index]),
+      "features"
+    ]
+    if (!is.null(row_names_wrap)) {
+      mark_labels <- heatmap_wrap_row_labels(
+        mark_labels,
+        width = row_names_wrap
+      )
+    }
     ha_mark <- ComplexHeatmap::HeatmapAnnotation(
       gene = ComplexHeatmap::anno_mark(
         at = which(rownames(feature_metadata) %in% features_ordered[index]),
-        labels = feature_metadata[
-          which(rownames(feature_metadata) %in% features_ordered[index]),
-          "features"
-        ],
+        labels = mark_labels,
         side = ifelse(flip, "top", "left"),
         labels_gp = grid::gpar(fontsize = label_size, col = label_color),
         link_gp = grid::gpar(fontsize = label_size, col = label_color),
@@ -2237,13 +2250,14 @@ GroupHeatmap <- function(
       ),
       envir = environment()
     )
+    matrix_use <- if (flip) {
+      Matrix::t(mat_list[[cell_group]])
+    } else {
+      mat_list[[cell_group]]
+    }
     ht_args <- list(
       name = cell_group,
-      matrix = if (flip) {
-        Matrix::t(mat_list[[cell_group]])
-      } else {
-        mat_list[[cell_group]]
-      },
+      matrix = matrix_use,
       col = colors,
       layer_fun = methods::getFunction(
         "layer_fun",
@@ -2326,6 +2340,19 @@ GroupHeatmap <- function(
         NULL
       }
     )
+    if (!is.null(row_names_wrap)) {
+      row_labels <- heatmap_wrap_row_labels(
+        rownames(matrix_use),
+        width = row_names_wrap
+      )
+      ht_args[["row_labels"]] <- row_labels
+      if (!"row_names_max_width" %in% names(ht_params)) {
+        ht_args[["row_names_max_width"]] <- heatmap_row_labels_max_width(
+          row_labels,
+          gp = ht_params[["row_names_gp"]]
+        )
+      }
+    }
 
     if (any(names(ht_params) %in% names(ht_args))) {
       log_message(

--- a/R/NMFHeatmap.R
+++ b/R/NMFHeatmap.R
@@ -17,6 +17,10 @@
 #' cell mode.
 #' @param feature_annotation Feature metadata columns to show as column
 #' annotations in feature mode.
+#' @param row_names_wrap Maximum number of characters per displayed row-name
+#' line. When set to a positive number, underscores are displayed as spaces and
+#' labels are wrapped without changing the underlying item identifiers.
+#' `NULL` disables wrapping.
 #' @param cluster_palette Palette used for NMF cluster/program annotations.
 #' @param cluster_palcolor Optional custom colors for NMF cluster/program
 #' annotations.
@@ -87,6 +91,7 @@ NMFHeatmap <- function(
   cell_annotation_border_size = 1,
   feature_annotation_border_size = 1,
   show_row_names = FALSE,
+  row_names_wrap = NULL,
   show_column_names = FALSE,
   row_names_side = "left",
   column_names_side = "top",
@@ -374,38 +379,57 @@ NMFHeatmap <- function(
     "Building {.pkg ComplexHeatmap} object for {.fn NMFHeatmap} ...",
     verbose = verbose
   )
-  ht_args <- c(
-    list(
-      matrix = similarity,
-      name = ht_name,
-      col = heatmap_col,
-      top_annotation = top_annotation,
-      left_annotation = left_annotation,
-      right_annotation = enrichment[["ha_right"]],
-      cluster_rows = FALSE,
-      cluster_columns = FALSE,
-      show_row_names = show_row_names,
-      show_column_names = show_column_names,
-      show_row_dend = FALSE,
-      show_column_dend = FALSE,
-      row_names_side = row_names_side,
-      column_names_side = column_names_side,
-      row_names_rot = row_names_rot,
-      column_names_rot = column_names_rot,
-      row_title = row_title,
-      column_title = column_title,
-      border = heatmap_border,
-      border_gp = heatmap_border_gp(heatmap_border, heatmap_border_color, heatmap_border_size),
-      use_raster = use_raster,
-      raster_device = raster_device,
-      raster_by_magick = raster_by_magick,
-      heatmap_legend_param = list(
-        at = c(0, 0.5, 1),
-        labels = c("0", "0.5", "1.0")
-      )
-    ),
-    ht_params
+  ht_args <- list(
+    matrix = similarity,
+    name = ht_name,
+    col = heatmap_col,
+    top_annotation = top_annotation,
+    left_annotation = left_annotation,
+    right_annotation = enrichment[["ha_right"]],
+    cluster_rows = FALSE,
+    cluster_columns = FALSE,
+    show_row_names = show_row_names,
+    show_column_names = show_column_names,
+    show_row_dend = FALSE,
+    show_column_dend = FALSE,
+    row_names_side = row_names_side,
+    column_names_side = column_names_side,
+    row_names_rot = row_names_rot,
+    column_names_rot = column_names_rot,
+    row_title = row_title,
+    column_title = column_title,
+    border = heatmap_border,
+    border_gp = heatmap_border_gp(heatmap_border, heatmap_border_color, heatmap_border_size),
+    use_raster = use_raster,
+    raster_device = raster_device,
+    raster_by_magick = raster_by_magick,
+    heatmap_legend_param = list(
+      at = c(0, 0.5, 1),
+      labels = c("0", "0.5", "1.0")
+    )
   )
+  if (!is.null(row_names_wrap)) {
+    row_labels <- heatmap_wrap_row_labels(
+      rownames(similarity),
+      width = row_names_wrap
+    )
+    ht_args[["row_labels"]] <- row_labels
+    if (!"row_names_max_width" %in% names(ht_params)) {
+      ht_args[["row_names_max_width"]] <- heatmap_row_labels_max_width(
+        row_labels,
+        gp = ht_params[["row_names_gp"]]
+      )
+    }
+  }
+  if (any(names(ht_params) %in% names(ht_args))) {
+    log_message(
+      "ht_params: ",
+      paste0(intersect(names(ht_params), names(ht_args)), collapse = ","),
+      " were duplicated and will not be used.",
+      message_type = "warning"
+    )
+  }
+  ht_args <- c(ht_args, ht_params[setdiff(names(ht_params), names(ht_args))])
   ht_list <- do.call(ComplexHeatmap::Heatmap, args = ht_args)
 
   plot <- nmf_heatmap_render_plot(

--- a/R/plot_heatmap.R
+++ b/R/plot_heatmap.R
@@ -20,6 +20,48 @@ compact_heatmap_feature_annotation <- function(values, annotation_name) {
   out
 }
 
+heatmap_wrap_row_labels <- function(labels, width = NULL) {
+  if (is.null(width)) {
+    return(labels)
+  }
+  if (
+    length(width) != 1L ||
+      !is.numeric(width) ||
+      is.na(width) ||
+      !is.finite(width) ||
+      width < 1
+  ) {
+    cli::cli_abort(
+      "{.arg row_names_wrap} must be a single positive number or {.code NULL}."
+    )
+  }
+  width <- as.integer(floor(width))
+  wrapped <- vapply(as.character(labels), function(label) {
+    if (is.na(label)) {
+      return(NA_character_)
+    }
+    display_label <- gsub("_", " ", label, fixed = TRUE)
+    paragraphs <- strsplit(display_label, "\n", fixed = TRUE)[[1]]
+    lines <- unlist(lapply(paragraphs, function(paragraph) {
+      out <- strwrap(paragraph, width = width)
+      if (length(out) == 0L) "" else out
+    }), use.names = FALSE)
+    paste(lines, collapse = "\n")
+  }, character(1))
+  names(wrapped) <- names(labels)
+  wrapped
+}
+
+heatmap_row_labels_max_width <- function(labels, gp = NULL) {
+  gp <- gp %||% grid::gpar(fontsize = 10)
+  lines <- unlist(strsplit(as.character(labels), "\n", fixed = TRUE), use.names = FALSE)
+  lines <- lines[!is.na(lines)]
+  if (length(lines) == 0L) {
+    return(grid::unit(0, "mm"))
+  }
+  ComplexHeatmap::max_text_width(lines, gp = gp) + grid::unit(2, "mm")
+}
+
 heatmap_enrichment <- function(
   geneID,
   geneID_groups,

--- a/man/FeatureHeatmap.Rd
+++ b/man/FeatureHeatmap.Rd
@@ -44,6 +44,7 @@ FeatureHeatmap(
   cluster_row_slices = FALSE,
   cluster_column_slices = FALSE,
   show_row_names = FALSE,
+  row_names_wrap = NULL,
   show_column_names = FALSE,
   row_names_side = ifelse(flip, "left", "right"),
   column_names_side = ifelse(flip, "bottom", "top"),
@@ -238,6 +239,12 @@ Default is \code{FALSE}.}
 
 \item{show_row_names}{Whether to show row names in the heatmap.
 Default is \code{FALSE}.}
+
+\item{row_names_wrap}{Maximum number of characters per displayed row-name
+line. When set to a positive number, underscores are displayed as spaces and
+labels are wrapped without changing the underlying feature identifiers.
+This also applies to feature labels selected by \code{nlabel} or
+\code{features_label}. \code{NULL} disables wrapping.}
 
 \item{show_column_names}{Whether to show column names in the heatmap.
 Default is \code{FALSE}.}

--- a/man/GroupHeatmap.Rd
+++ b/man/GroupHeatmap.Rd
@@ -46,6 +46,7 @@ GroupHeatmap(
   cluster_row_slices = FALSE,
   cluster_column_slices = FALSE,
   show_row_names = FALSE,
+  row_names_wrap = NULL,
   show_column_names = FALSE,
   row_names_side = ifelse(flip, "left", "right"),
   column_names_side = ifelse(flip, "bottom", "top"),
@@ -256,6 +257,12 @@ Default is \code{FALSE}.}
 
 \item{show_row_names}{Whether to show row names in the heatmap.
 Default is \code{FALSE}.}
+
+\item{row_names_wrap}{Maximum number of characters per displayed row-name
+line. When set to a positive number, underscores are displayed as spaces and
+labels are wrapped without changing the underlying feature identifiers.
+This also applies to feature labels selected by \code{nlabel} or
+\code{features_label}. \code{NULL} disables wrapping.}
 
 \item{show_column_names}{Whether to show column names in the heatmap.
 Default is \code{FALSE}.}

--- a/man/NMFHeatmap.Rd
+++ b/man/NMFHeatmap.Rd
@@ -26,6 +26,7 @@ NMFHeatmap(
   cell_annotation_border_size = 1,
   feature_annotation_border_size = 1,
   show_row_names = FALSE,
+  row_names_wrap = NULL,
   show_column_names = FALSE,
   row_names_side = "left",
   column_names_side = "top",
@@ -138,6 +139,11 @@ Default is \code{1}.}
 
 \item{show_row_names}{Whether to show row names in the heatmap.
 Default is \code{FALSE}.}
+
+\item{row_names_wrap}{Maximum number of characters per displayed row-name
+line. When set to a positive number, underscores are displayed as spaces and
+labels are wrapped without changing the underlying item identifiers.
+\code{NULL} disables wrapping.}
 
 \item{show_column_names}{Whether to show column names in the heatmap.
 Default is \code{FALSE}.}

--- a/tests/testthat/test-heatmap-row-label-wrap.R
+++ b/tests/testthat/test-heatmap-row-label-wrap.R
@@ -1,0 +1,50 @@
+test_that("heatmap row labels remain unchanged when wrapping is disabled", {
+  labels <- stats::setNames(
+    c("GO_LONG_PATHWAY_NAME", "Gene_symbol"),
+    c("pathway", "gene")
+  )
+
+  expect_identical(heatmap_wrap_row_labels(labels), labels)
+})
+
+test_that("heatmap row labels wrap display text without changing identifiers", {
+  labels <- stats::setNames(
+    c(
+      "GO_POSITIVE_REGULATION_OF_LEUKOCYTE_ACTIVATION",
+      "REACTOME_SIGNALING_BY_TGF_BETA_RECEPTOR_COMPLEX"
+    ),
+    c("pathway_1", "pathway_2")
+  )
+  original <- labels
+
+  wrapped <- heatmap_wrap_row_labels(labels, width = 24)
+
+  expect_identical(labels, original)
+  expect_identical(names(wrapped), names(labels))
+  expect_true(all(grepl("\n", wrapped, fixed = TRUE)))
+  expect_false(any(grepl("_", wrapped, fixed = TRUE)))
+})
+
+test_that("heatmap row label wrapping validates its width", {
+  expect_error(heatmap_wrap_row_labels("label", width = 0), "positive number")
+  expect_error(heatmap_wrap_row_labels("label", width = c(10, 20)), "positive number")
+  expect_error(heatmap_wrap_row_labels("label", width = "20"), "positive number")
+})
+
+test_that("wrapped row labels receive enough layout width", {
+  labels <- heatmap_wrap_row_labels(
+    "REACTOME_ANTIGEN_PROCESSING_CROSS_PRESENTATION",
+    width = 24
+  )
+
+  width <- heatmap_row_labels_max_width(labels)
+
+  expect_s3_class(width, "unit")
+  expect_gt(grid::convertWidth(width, "mm", valueOnly = TRUE), 0)
+})
+
+test_that("public heatmap functions expose optional row-name wrapping", {
+  expect_null(formals(GroupHeatmap)[["row_names_wrap"]])
+  expect_null(formals(FeatureHeatmap)[["row_names_wrap"]])
+  expect_null(formals(NMFHeatmap)[["row_names_wrap"]])
+})


### PR DESCRIPTION
## Summary

- add `row_names_wrap` to `GroupHeatmap()`, `FeatureHeatmap()`, and `NMFHeatmap()`
- wrap both ordinary row names and the feature callouts produced by `nlabel` / `features_label`
- preserve original feature and item identifiers while wrapping display labels only
- size the row-name area from the wrapped labels without changing `legend.position`

## Validation

- targeted test file: 13 expectations passed
- clean package installation completed
- rendered real `GroupHeatmap()`, `FeatureHeatmap()`, and `NMFHeatmap()` examples with long labels

Refs #200