### PR TITLE
Fix dimension plot point-size scaling

### DIFF
--- a/R/CellDimPlot.R
+++ b/R/CellDimPlot.R
@@ -27,7 +27,8 @@
 #' @param bg_color Color value for background(NA) points.
 #' @param pt.size The size of the points in the plot. Default is `NULL`, which
 #' automatically scales point diameter with the square root of the number of
-#' plotted cells.
+#' plotted cells, with a minimum of `0.3`. Raster point sizes scale with
+#' `raster.dpi`; explicitly supplied values remain unchanged.
 #' @param pt.alpha The transparency of the data points.
 #' Default is `1`.
 #' @param cells.highlight A logical or character vector specifying the cells to highlight in the plot.
@@ -832,7 +833,8 @@ CellDimPlot <- function(
   if (!is.null(cells)) {
     dat_use <- dat_use[intersect(rownames(dat_use), cells), , drop = FALSE]
   }
-  if (is.null(pt.size)) {
+  pt.size_auto <- is.null(pt.size)
+  if (pt.size_auto) {
     pt.size <- dim_plot_default_pt_size(nrow(dat_use))
   }
   raster <- raster %||% dim_plot_auto_raster(nrow(dat_use))
@@ -840,12 +842,21 @@ CellDimPlot <- function(
     check_r("scattermore", verbose = FALSE)
   }
   if (!is.null(raster.dpi)) {
-    if (!is.numeric(x = raster.dpi) || length(raster.dpi) != 2) {
+    if (!is.numeric(raster.dpi) || length(raster.dpi) != 2) {
       log_message(
         "'{.arg raster.dpi}' must be a two-length numeric vector",
         message_type = "error"
       )
     }
+  }
+  raster_scale <- if (is.null(raster.dpi)) {
+    1
+  } else {
+    sqrt(prod(raster.dpi / c(512, 512)))
+  }
+  raster_pt_size <- pt.size * raster_scale
+  if (pt.size_auto) {
+    raster_pt_size <- max(2 * raster_scale, raster_pt_size)
   }
   if (!is.null(stat.by)) {
     srt_stat <- srt
@@ -1260,7 +1271,7 @@ CellDimPlot <- function(
             data = dat[is.na(dat[, "group.by"]), , drop = FALSE],
             mapping = aes(x = .data[["x"]], y = .data[["y"]]),
             color = bg_color,
-            pointsize = ceiling(pt.size),
+            pointsize = raster_pt_size,
             alpha = pt.alpha,
             pixels = raster.dpi
           ) +
@@ -1271,7 +1282,7 @@ CellDimPlot <- function(
               y = .data[["y"]],
               color = .data[["group.by"]]
             ),
-            pointsize = ceiling(pt.size),
+            pointsize = raster_pt_size,
             alpha = pt.alpha,
             pixels = raster.dpi
           )
@@ -2736,7 +2747,7 @@ CellDimPlot3D <- function(
 }
 
 dim_plot_default_pt_size <- function(n) {
-  min(1, 0.6 * sqrt(5000 / n))
+  max(0.3, min(1, 0.6 * sqrt(5000 / n)))
 }
 
 dim_plot_auto_raster <- function(n) {

--- a/R/FeatureDimPlot.R
+++ b/R/FeatureDimPlot.R
@@ -619,7 +619,8 @@ FeatureDimPlot <- function(
     dat_use <- dat_use[intersect(rownames(dat_use), cells), , drop = FALSE]
   }
 
-  if (is.null(pt.size)) {
+  pt.size_auto <- is.null(pt.size)
+  if (pt.size_auto) {
     pt.size <- dim_plot_default_pt_size(nrow(dat_use))
   }
   raster <- raster %||% dim_plot_auto_raster(nrow(dat_use))
@@ -627,12 +628,21 @@ FeatureDimPlot <- function(
     check_r("scattermore", verbose = FALSE)
   }
   if (!is.null(raster.dpi)) {
-    if (!is.numeric(x = raster.dpi) || length(raster.dpi) != 2) {
+    if (!is.numeric(raster.dpi) || length(raster.dpi) != 2) {
       log_message(
         "{.arg raster.dpi} must be a two-length numeric vector",
         message_type = "error"
       )
     }
+  }
+  raster_scale <- if (is.null(raster.dpi)) {
+    1
+  } else {
+    sqrt(prod(raster.dpi / c(512, 512)))
+  }
+  raster_pt_size <- pt.size * raster_scale
+  if (pt.size_auto) {
+    raster_pt_size <- max(2 * raster_scale, raster_pt_size)
   }
 
   if (!is.null(lineages)) {
@@ -925,7 +935,7 @@ FeatureDimPlot <- function(
                 y = .data[["y"]],
                 color = .data[["color_blend"]]
               ),
-              pointsize = ceiling(pt.size),
+              pointsize = raster_pt_size,
               alpha = pt.alpha,
               pixels = raster.dpi
             ) +
@@ -936,7 +946,7 @@ FeatureDimPlot <- function(
                 y = .data[["y"]],
                 color = .data[["color_blend"]]
               ),
-              pointsize = ceiling(pt.size),
+              pointsize = raster_pt_size,
               alpha = pt.alpha,
               pixels = raster.dpi
             ) +
@@ -1454,7 +1464,7 @@ FeatureDimPlot <- function(
                 y = .data[["y"]],
                 color = .data[["value"]]
               ),
-              pointsize = ceiling(pt.size),
+              pointsize = raster_pt_size,
               alpha = pt.alpha,
               pixels = raster.dpi
             ) +
@@ -1465,7 +1475,7 @@ FeatureDimPlot <- function(
                 y = .data[["y"]],
                 color = .data[["value"]]
               ),
-              pointsize = ceiling(pt.size),
+              pointsize = raster_pt_size,
               alpha = pt.alpha,
               pixels = raster.dpi
             )

--- a/man/CellDimPlot.Rd
+++ b/man/CellDimPlot.Rd
@@ -175,7 +175,8 @@ If \code{FALSE}, cell points with NA level will be removed from the plot.}
 
 \item{pt.size}{The size of the points in the plot. Default is \code{NULL}, which
 automatically scales point diameter with the square root of the number of
-plotted cells.}
+plotted cells, with a minimum of \code{0.3}. Raster point sizes scale with
+\code{raster.dpi}; explicitly supplied values remain unchanged.}
 
 \item{pt.alpha}{The transparency of the data points.
 Default is \code{1}.}

--- a/man/FeatureDimPlot.Rd
+++ b/man/FeatureDimPlot.Rd
@@ -126,7 +126,8 @@ Default is \code{NULL}.}
 
 \item{pt.size}{The size of the points in the plot. Default is \code{NULL}, which
 automatically scales point diameter with the square root of the number of
-plotted cells.}
+plotted cells, with a minimum of \code{0.3}. Raster point sizes scale with
+\code{raster.dpi}; explicitly supplied values remain unchanged.}
 
 \item{pt.alpha}{The transparency of the data points.
 Default is \code{1}.}

--- a/tests/testthat/test-cell-dim-plot.R
+++ b/tests/testthat/test-cell-dim-plot.R
@@ -310,8 +310,8 @@ test_that("dimension plot defaults use calibrated square-root scaling", {
       0.6 * sqrt(5000 / 3000),
       0.6,
       0.6 * sqrt(5000 / 10000),
-      0.6 * sqrt(5000 / 50000),
-      0.6 * sqrt(5000 / 100000)
+      0.3,
+      0.3
     )
   )
 })
@@ -368,8 +368,40 @@ test_that("CellDimPlot scales large non-raster plots consistently", {
 
   expect_equal(
     point_layers[[length(point_layers)]]$aes_params$size,
-    0.6 * sqrt(5000 / 50000)
+    0.3
   )
+})
+
+test_that("CellDimPlot scales raster points with resolution", {
+  skip_if_not_installed("scattermore")
+  srt <- make_cell_dim_plot_srt()
+  plot_args <- list(
+    srt = srt,
+    group.by = "celltype",
+    reduction = "umap",
+    raster = TRUE,
+    raster.dpi = c(2048, 2048),
+    show_stat = FALSE,
+    force = TRUE
+  )
+  auto_plot <- do.call(CellDimPlot, plot_args)
+  explicit_plot <- do.call(
+    CellDimPlot,
+    c(plot_args, list(pt.size = 0.3))
+  )
+  point_sizes <- function(plot) {
+    vapply(
+      Filter(
+        function(layer) inherits(layer$geom, "GeomScattermore"),
+        plot$layers
+      ),
+      function(layer) layer$geom_params$pointsize,
+      numeric(1)
+    )
+  }
+
+  expect_true(all(point_sizes(auto_plot) == 8))
+  expect_true(all(point_sizes(explicit_plot) == 1.2))
 })
 
 test_that("CellDimPlot validates atlas grid density", {


### PR DESCRIPTION
## Summary

- keep automatically sized non-raster dimension-plot points readable with square-root scaling and a `0.3` minimum
- scale raster point sizes with `raster.dpi` without rounding explicitly supplied `pt.size` values
- apply the same behavior to `CellDimPlot()` and `FeatureDimPlot()`

## Root cause

The previous automatic rule could shrink points below a readable size as cell counts increased. Raster point sizes were also rounded and did not scale with raster resolution.

## Validation

- `devtools::test(filter = "cell-dim-plot")`: 45 passed, 0 failed (one pre-existing ggplot2 deprecation warning)
- `git diff --check` passed

Refs #329