### PR TITLE
fix: harden CHOIR and Cell2fate runtime boundaries

### DIFF
--- a/R/PrepareEnv.R
+++ b/R/PrepareEnv.R
@@ -1433,7 +1433,8 @@ env_info <- function(conda, envname, verbose = TRUE) {
 #' @md
 #' @inheritParams thisutils::log_message
 #' @param version The Python version of the environment.
-#' Default is `"3.10-1"`.
+#' Default is `"3.10-1"`. Python `"3.9-1"` is reserved for the standalone
+#' `"cell2fate"` module.
 #' @param include_optional Whether to include optional Python dependencies.
 #' @param modules Optional requirement modules to include. Supported values are
 #' `"scanpy"`, `"scvi"`, `"scanorama"`, `"bbknn"`, `"celltypist"`,
@@ -1491,6 +1492,12 @@ env_requirements <- function(
       )
     }
     version <- "3.9-1"
+  }
+  if (identical(version, "3.9-1") && !"cell2fate" %in% modules) {
+    log_message(
+      "{.arg version = '3.9-1'} is only supported for the standalone {.val cell2fate} module.",
+      message_type = "error"
+    )
   }
 
   base_requirements <- if (any(c("scenic", "cell2fate") %in% modules)) {

--- a/R/RunCHOIR.R
+++ b/R/RunCHOIR.R
@@ -27,8 +27,9 @@
 #' @param n_trees Number of trees in each random forest.
 #' @param min_accuracy Minimum classifier accuracy required to keep clusters
 #'   separate.
-#' @param max_clusters Maximum extent of the initial clustering tree. The
-#'   upstream default `"auto"` is recommended.
+#' @param max_clusters Must be `"auto"`. Numeric limits are rejected because
+#'   the pinned upstream backend can fail to terminate when the number of
+#'   clusters plateaus.
 #' @param normalization_method Normalization performed inside CHOIR. Use
 #'   `"none"` for previously normalized data or `"SCTransform"` with a counts
 #'   layer.
@@ -113,6 +114,7 @@ RunCHOIR <- function(
   p_adjust <- match.arg(p_adjust)
   feature_set <- match.arg(feature_set)
   normalization_method <- match.arg(normalization_method)
+  max_clusters <- choir_validate_max_clusters(max_clusters)
   alpha <- choir_assert_probability(alpha, "alpha", open = TRUE)
   min_accuracy <- choir_assert_probability(min_accuracy, "min_accuracy")
   n_iterations <- validate_scalar_integer(n_iterations, "n_iterations")
@@ -694,6 +696,24 @@ choir_assert_probability <- function(x, arg, open = FALSE) {
     )
   }
   as.numeric(x)
+}
+
+choir_validate_max_clusters <- function(x) {
+  if (is.character(x) && length(x) == 1L && !is.na(x) &&
+      identical(x, "auto")) {
+    return(x)
+  }
+  if (is.numeric(x) && length(x) == 1L && is.finite(x) &&
+      x >= 1 && x == floor(x)) {
+    log_message(
+      "Numeric {.arg max_clusters} is unsafe with the pinned {.pkg CHOIR} backend because its full-tree loop may not terminate when the cluster count plateaus. Use {.val 'auto'}.",
+      message_type = "error"
+    )
+  }
+  log_message(
+    "{.arg max_clusters} must be {.val 'auto'}",
+    message_type = "error"
+  )
 }
 
 choir_escape_regex <- function(x) {

--- a/R/RunCell2fate.R
+++ b/R/RunCell2fate.R
@@ -193,9 +193,9 @@ RunCell2fate <- function(
     store_velocity = store_velocity
   )
   config_path <- file.path(workdir, "config.json")
-  cell2fate_write_json(config, config_path)
+  runner_write_json(config, config_path)
 
-  runner <- cell2fate_runner_path()
+  runner <- runner_script_path("cell2fate_runner.py", "Cell2fate")
   stdout_path <- file.path(logs_dir, "cell2fate_stdout.log")
   stderr_path <- file.path(logs_dir, "cell2fate_stderr.log")
   cache_dir <- file.path(result_dir, ".cache")
@@ -205,7 +205,7 @@ RunCell2fate <- function(
     "Run {.pkg Cell2fate} with {.val {length(prepared$features)}} genes and {.val {ncol(prepared$spliced)}} cells",
     verbose = verbose
   )
-  status <- cell2fate_run_system2(
+  status <- runner_system2(
     command = python,
     args = c(shQuote(runner), "--config", shQuote(config_path)),
     env = c(
@@ -216,7 +216,12 @@ RunCell2fate <- function(
     stderr = stderr_path
   )
   if (!identical(status, 0L)) {
-    cell2fate_runner_error(status, stdout_path, stderr_path)
+    runner_error(
+      status,
+      stdout_path,
+      stderr_path,
+      backend = "Cell2fate"
+    )
   }
 
   files <- cell2fate_result_files(result_dir)
@@ -233,9 +238,10 @@ RunCell2fate <- function(
     )
   }
 
-  metadata <- cell2fate_read_csv(
+  metadata <- runner_read_csv(
     files$cell_metadata,
-    "posterior metadata"
+    "posterior metadata",
+    backend = "Cell2fate"
   )
   metadata <- cell2fate_align_cells(
     metadata,
@@ -258,14 +264,18 @@ RunCell2fate <- function(
 
   velocity <- NULL
   if (isTRUE(store_velocity)) {
-    velocity <- cell2fate_read_numeric_csv(files$velocity, "velocity")
+    velocity <- runner_read_numeric_csv(
+      files$velocity,
+      "velocity",
+      backend = "Cell2fate"
+    )
     velocity <- cell2fate_align_cells(
       velocity,
       cells = colnames(srt),
       label = "velocity"
     )
   }
-  manifest <- cell2fate_read_json(files$manifest)
+  manifest <- runner_read_json(files$manifest)
   srt_out@tools[[tool_name]] <- list(
     method = "Cell2fate",
     result_type = "rna_velocity",
@@ -518,70 +528,6 @@ cell2fate_check_python <- function(envname = NULL, verbose = TRUE) {
   normalizePath(python, winslash = "/", mustWork = TRUE)
 }
 
-cell2fate_runner_path <- function() {
-  candidates <- c(
-    system.file("python", "cell2fate_runner.py", package = "scop", mustWork = FALSE),
-    file.path("inst", "python", "cell2fate_runner.py")
-  )
-  candidates <- candidates[nzchar(candidates) & file.exists(candidates)]
-  if (length(candidates) == 0L) {
-    log_message(
-      "Bundled Cell2fate Python runner was not found",
-      message_type = "error"
-    )
-  }
-  normalizePath(candidates[[1]], winslash = "/", mustWork = TRUE)
-}
-
-cell2fate_write_json <- function(x, path) {
-  check_r("jsonlite", verbose = FALSE)
-  to_json <- get_namespace_fun("jsonlite", "toJSON")
-  writeLines(
-    as.character(to_json(
-      x,
-      auto_unbox = TRUE,
-      null = "null",
-      digits = NA,
-      pretty = TRUE
-    )),
-    con = path,
-    useBytes = TRUE
-  )
-}
-
-cell2fate_read_json <- function(path) {
-  check_r("jsonlite", verbose = FALSE)
-  get_namespace_fun("jsonlite", "fromJSON")(path, simplifyVector = FALSE)
-}
-
-cell2fate_run_system2 <- function(command, args, env, stdout, stderr) {
-  if (is.null(names(env)) || any(!nzchar(names(env)))) {
-    log_message(
-      "Cell2fate subprocess environment variables must be named",
-      message_type = "error"
-    )
-  }
-  env_names <- names(env)
-  old_env <- Sys.getenv(env_names, unset = NA_character_)
-  names(old_env) <- env_names
-  do.call(Sys.setenv, as.list(env))
-  on.exit({
-    restore <- !is.na(old_env)
-    if (any(restore)) {
-      do.call(Sys.setenv, as.list(old_env[restore]))
-    }
-    if (any(!restore)) {
-      Sys.unsetenv(names(old_env)[!restore])
-    }
-  }, add = TRUE)
-  system2(
-    command = command,
-    args = args,
-    stdout = stdout,
-    stderr = stderr
-  )
-}
-
 cell2fate_result_files <- function(result_dir) {
   list(
     cell_metadata = file.path(result_dir, "tables", "cell_metadata.csv"),
@@ -590,87 +536,6 @@ cell2fate_result_files <- function(result_dir) {
     model = file.path(result_dir, "model"),
     manifest = file.path(result_dir, "manifest.json")
   )
-}
-
-cell2fate_read_numeric_csv <- function(path, label) {
-  value <- cell2fate_read_csv(path, label)
-  value <- as.matrix(value)
-  storage.mode(value) <- "double"
-  if (
-    is.null(rownames(value)) ||
-      is.null(colnames(value)) ||
-      anyDuplicated(rownames(value)) ||
-      anyDuplicated(colnames(value)) ||
-      any(!is.finite(value))
-  ) {
-    log_message(
-      "{.pkg Cell2fate} returned invalid {.val {label}} output",
-      message_type = "error"
-    )
-  }
-  value
-}
-
-cell2fate_read_csv <- function(path, label) {
-  header <- tryCatch(
-    utils::read.csv(
-      path,
-      nrows = 0L,
-      row.names = NULL,
-      check.names = FALSE,
-      stringsAsFactors = FALSE
-    ),
-    error = function(e) {
-      log_message(
-        "Unable to read {.pkg Cell2fate} {.val {label}} output: {conditionMessage(e)}",
-        message_type = "error"
-      )
-    }
-  )
-  if (ncol(header) < 2L) {
-    log_message(
-      "{.pkg Cell2fate} returned invalid {.val {label}} output",
-      message_type = "error"
-    )
-  }
-  column_classes <- rep(NA_character_, ncol(header))
-  column_classes[[1L]] <- "character"
-  value <- tryCatch(
-    utils::read.csv(
-      path,
-      row.names = NULL,
-      check.names = FALSE,
-      stringsAsFactors = FALSE,
-      colClasses = column_classes,
-      na.strings = character()
-    ),
-    error = function(e) {
-      log_message(
-        "Unable to read {.pkg Cell2fate} {.val {label}} output: {conditionMessage(e)}",
-        message_type = "error"
-      )
-    }
-  )
-  cell_names <- value[[1L]]
-  value <- value[-1L]
-  value[] <- lapply(
-    value,
-    utils::type.convert,
-    na.strings = "NA",
-    as.is = TRUE
-  )
-  if (
-    anyNA(cell_names) ||
-      any(!nzchar(cell_names)) ||
-      anyDuplicated(cell_names)
-  ) {
-    log_message(
-      "{.pkg Cell2fate} {.val {label}} must have unique non-empty cell names",
-      message_type = "error"
-    )
-  }
-  rownames(value) <- cell_names
-  value
 }
 
 cell2fate_align_cells <- function(x, cells, label) {
@@ -704,25 +569,4 @@ cell2fate_expand_metadata <- function(metadata, cells, prefix) {
   }
   output[[paste0(prefix, "_selected")]] <- cells %in% rownames(metadata)
   output
-}
-
-cell2fate_runner_error <- function(status, stdout_path, stderr_path) {
-  stderr <- if (file.exists(stderr_path)) readLines(stderr_path, warn = FALSE) else character()
-  stdout <- if (file.exists(stdout_path)) readLines(stdout_path, warn = FALSE) else character()
-  stderr <- stderr[nzchar(trimws(stderr))]
-  stdout <- stdout[nzchar(trimws(stdout))]
-  details <- c(
-    if (length(stderr) > 0L) {
-      c("Python stderr:", utils::tail(stderr, 20L))
-    },
-    if (length(stdout) > 0L) {
-      c("Python stdout:", utils::tail(stdout, 20L))
-    }
-  )
-  message <- if (length(details) > 0L) {
-    paste(details, collapse = "\n")
-  } else {
-    paste0("Cell2fate runner exited with status ", status)
-  }
-  log_message(message, message_type = "error")
 }

--- a/R/RunCell2fate.R
+++ b/R/RunCell2fate.R
@@ -233,11 +233,9 @@ RunCell2fate <- function(
     )
   }
 
-  metadata <- utils::read.csv(
+  metadata <- cell2fate_read_csv(
     files$cell_metadata,
-    row.names = 1,
-    check.names = FALSE,
-    stringsAsFactors = FALSE
+    "posterior metadata"
   )
   metadata <- cell2fate_align_cells(
     metadata,
@@ -595,12 +593,7 @@ cell2fate_result_files <- function(result_dir) {
 }
 
 cell2fate_read_numeric_csv <- function(path, label) {
-  value <- utils::read.csv(
-    path,
-    row.names = 1,
-    check.names = FALSE,
-    stringsAsFactors = FALSE
-  )
+  value <- cell2fate_read_csv(path, label)
   value <- as.matrix(value)
   storage.mode(value) <- "double"
   if (
@@ -615,6 +608,68 @@ cell2fate_read_numeric_csv <- function(path, label) {
       message_type = "error"
     )
   }
+  value
+}
+
+cell2fate_read_csv <- function(path, label) {
+  header <- tryCatch(
+    utils::read.csv(
+      path,
+      nrows = 0L,
+      row.names = NULL,
+      check.names = FALSE,
+      stringsAsFactors = FALSE
+    ),
+    error = function(e) {
+      log_message(
+        "Unable to read {.pkg Cell2fate} {.val {label}} output: {conditionMessage(e)}",
+        message_type = "error"
+      )
+    }
+  )
+  if (ncol(header) < 2L) {
+    log_message(
+      "{.pkg Cell2fate} returned invalid {.val {label}} output",
+      message_type = "error"
+    )
+  }
+  column_classes <- rep(NA_character_, ncol(header))
+  column_classes[[1L]] <- "character"
+  value <- tryCatch(
+    utils::read.csv(
+      path,
+      row.names = NULL,
+      check.names = FALSE,
+      stringsAsFactors = FALSE,
+      colClasses = column_classes,
+      na.strings = character()
+    ),
+    error = function(e) {
+      log_message(
+        "Unable to read {.pkg Cell2fate} {.val {label}} output: {conditionMessage(e)}",
+        message_type = "error"
+      )
+    }
+  )
+  cell_names <- value[[1L]]
+  value <- value[-1L]
+  value[] <- lapply(
+    value,
+    utils::type.convert,
+    na.strings = "NA",
+    as.is = TRUE
+  )
+  if (
+    anyNA(cell_names) ||
+      any(!nzchar(cell_names)) ||
+      anyDuplicated(cell_names)
+  ) {
+    log_message(
+      "{.pkg Cell2fate} {.val {label}} must have unique non-empty cell names",
+      message_type = "error"
+    )
+  }
+  rownames(value) <- cell_names
   value
 }
 
@@ -654,11 +709,16 @@ cell2fate_expand_metadata <- function(metadata, cells, prefix) {
 cell2fate_runner_error <- function(status, stdout_path, stderr_path) {
   stderr <- if (file.exists(stderr_path)) readLines(stderr_path, warn = FALSE) else character()
   stdout <- if (file.exists(stdout_path)) readLines(stdout_path, warn = FALSE) else character()
-  details <- c(stderr, stdout)
-  details <- details[nzchar(trimws(details))]
-  if (length(details) > 20L) {
-    details <- utils::tail(details, 20L)
-  }
+  stderr <- stderr[nzchar(trimws(stderr))]
+  stdout <- stdout[nzchar(trimws(stdout))]
+  details <- c(
+    if (length(stderr) > 0L) {
+      c("Python stderr:", utils::tail(stderr, 20L))
+    },
+    if (length(stdout) > 0L) {
+      c("Python stdout:", utils::tail(stdout, 20L))
+    }
+  )
   message <- if (length(details) > 0L) {
     paste(details, collapse = "\n")
   } else {

--- a/R/RunCell2location.R
+++ b/R/RunCell2location.R
@@ -256,8 +256,8 @@ RunCell2location <- function(
     overwrite = overwrite
   )
   config_path <- file.path(workdir, "config.json")
-  cell2location_write_json(config, config_path)
-  runner <- cell2location_runner_path()
+  runner_write_json(config, config_path)
+  runner <- runner_script_path("cell2location_runner.py", "cell2location")
   stdout_path <- file.path(logs_dir, "cell2location_stdout.log")
   stderr_path <- file.path(logs_dir, "cell2location_stderr.log")
   cache_dir <- file.path(result_dir, ".cache")
@@ -268,19 +268,24 @@ RunCell2location <- function(
     "Run {.pkg cell2location} with {.val {length(prepared$features)}} shared genes and {.val {ncol(prepared$spatial)}} spatial locations",
     verbose = verbose
   )
-  status <- cell2location_run_system2(
+  status <- runner_system2(
     command = python,
     args = c(shQuote(runner), "--config", shQuote(config_path)),
     env = c(
-      "PYTHONNOUSERSITE=1",
-      paste0("NUMBA_CACHE_DIR=", file.path(cache_dir, "numba")),
-      paste0("MPLCONFIGDIR=", file.path(cache_dir, "matplotlib"))
+      PYTHONNOUSERSITE = "1",
+      NUMBA_CACHE_DIR = file.path(cache_dir, "numba"),
+      MPLCONFIGDIR = file.path(cache_dir, "matplotlib")
     ),
     stdout = stdout_path,
     stderr = stderr_path
   )
   if (!identical(status, 0L)) {
-    cell2location_runner_error(status, stdout_path, stderr_path)
+    runner_error(
+      status,
+      stdout_path,
+      stderr_path,
+      backend = "cell2location"
+    )
   }
 
   files <- cell2location_result_files(result_dir)
@@ -292,9 +297,21 @@ RunCell2location <- function(
       message_type = "error"
     )
   }
-  abundance <- cell2location_read_numeric_csv(files$abundance, "abundance")
-  proportions <- cell2location_read_numeric_csv(files$proportions, "proportions")
-  signatures <- cell2location_read_numeric_csv(files$signatures, "reference signatures")
+  abundance <- runner_read_numeric_csv(
+    files$abundance,
+    "abundance",
+    backend = "cell2location"
+  )
+  proportions <- runner_read_numeric_csv(
+    files$proportions,
+    "proportions",
+    backend = "cell2location"
+  )
+  signatures <- runner_read_numeric_csv(
+    files$signatures,
+    "reference signatures",
+    backend = "cell2location"
+  )
   abundance <- cell2location_align_result(abundance, colnames(prepared$spatial), "abundance")
   proportions <- cell2location_align_result(proportions, colnames(prepared$spatial), "proportions")
   if (!identical(colnames(abundance), colnames(proportions))) {
@@ -330,7 +347,7 @@ RunCell2location <- function(
   )
 
   if (isTRUE(store_results)) {
-    manifest <- cell2location_read_json(files$manifest)
+    manifest <- runner_read_json(files$manifest)
     result_parameters <- list(
       assay = prepared$assay,
       reference_assay = prepared$reference_assay,
@@ -487,30 +504,6 @@ Cell2locationPlot <- function(
     defaults$plot_type <- if (identical(plot_type, "pie")) "pie" else "point"
   }
   do.call(SpatialSpotPlot, merge_call_args(defaults, list(...)))
-}
-
-cell2location_run_system2 <- function(command, args, env, stdout, stderr) {
-  env_names <- sub("=.*$", "", env)
-  env_values <- sub("^[^=]*=", "", env)
-  old_values <- Sys.getenv(env_names, unset = NA_character_)
-  names(old_values) <- env_names
-  do.call(Sys.setenv, stats::setNames(as.list(env_values), env_names))
-  on.exit({
-    restore <- old_values[!is.na(old_values)]
-    remove <- names(old_values)[is.na(old_values)]
-    if (length(restore) > 0L) {
-      do.call(Sys.setenv, as.list(restore))
-    }
-    if (length(remove) > 0L) {
-      Sys.unsetenv(remove)
-    }
-  }, add = TRUE)
-  system2(
-    command = command,
-    args = args,
-    stdout = stdout,
-    stderr = stderr
-  )
 }
 
 cell2location_prepare_inputs <- function(
@@ -702,33 +695,6 @@ cell2location_check_python <- function(envname = NULL, verbose = TRUE) {
   normalizePath(python, winslash = "/", mustWork = TRUE)
 }
 
-cell2location_runner_path <- function() {
-  candidates <- c(
-    system.file("python", "cell2location_runner.py", package = "scop", mustWork = FALSE),
-    file.path("inst", "python", "cell2location_runner.py")
-  )
-  candidates <- candidates[nzchar(candidates) & file.exists(candidates)]
-  if (length(candidates) == 0L) {
-    log_message("Bundled cell2location Python runner was not found", message_type = "error")
-  }
-  normalizePath(candidates[1L], winslash = "/", mustWork = TRUE)
-}
-
-cell2location_write_json <- function(x, path) {
-  check_r("jsonlite", verbose = FALSE)
-  to_json <- get_namespace_fun("jsonlite", "toJSON")
-  writeLines(
-    as.character(to_json(x, auto_unbox = TRUE, null = "null", digits = NA, pretty = TRUE)),
-    con = path,
-    useBytes = TRUE
-  )
-}
-
-cell2location_read_json <- function(path) {
-  check_r("jsonlite", verbose = FALSE)
-  get_namespace_fun("jsonlite", "fromJSON")(path, simplifyVector = FALSE)
-}
-
 cell2location_result_files <- function(result_dir) {
   list(
     abundance = file.path(result_dir, "tables", "abundance_q05.csv"),
@@ -744,17 +710,6 @@ cell2location_result_files <- function(result_dir) {
   )
 }
 
-cell2location_read_numeric_csv <- function(path, label) {
-  x <- utils::read.csv(path, row.names = 1, check.names = FALSE)
-  if (nrow(x) == 0L || ncol(x) == 0L || any(!vapply(x, is.numeric, logical(1)))) {
-    log_message("cell2location {.val {label}} output must be a non-empty numeric table", message_type = "error")
-  }
-  if (any(!is.finite(as.matrix(x))) || is.null(rownames(x)) || is.null(colnames(x))) {
-    log_message("cell2location {.val {label}} output contains invalid values or names", message_type = "error")
-  }
-  x
-}
-
 cell2location_align_result <- function(x, spot_ids, label) {
   if (anyDuplicated(rownames(x)) || anyDuplicated(colnames(x))) {
     log_message("cell2location {.val {label}} output names must be unique", message_type = "error")
@@ -768,19 +723,6 @@ cell2location_align_result <- function(x, spot_ids, label) {
     )
   }
   x[spot_ids, , drop = FALSE]
-}
-
-cell2location_runner_error <- function(status, stdout_path, stderr_path) {
-  read_tail <- function(path) {
-    if (!file.exists(path)) return(character())
-    utils::tail(readLines(path, warn = FALSE), 30L)
-  }
-  lines <- c(read_tail(stderr_path), read_tail(stdout_path))
-  if (length(lines) == 0L) lines <- "<no Python output captured>"
-  log_message(
-    "{.pkg cell2location} Python runner failed with status {.val {status}}:\n{.code {paste(lines, collapse = '\n')}}",
-    message_type = "error"
-  )
 }
 
 cell2location_metadata_matrix <- function(srt, prefix) {

--- a/R/RunnerUtils.R
+++ b/R/RunnerUtils.R
@@ -1,0 +1,174 @@
+runner_script_path <- function(script, backend) {
+  candidates <- c(
+    system.file("python", script, package = "scop", mustWork = FALSE),
+    file.path("inst", "python", script)
+  )
+  candidates <- candidates[nzchar(candidates) & file.exists(candidates)]
+  if (!length(candidates)) {
+    log_message(
+      "Bundled {.pkg {backend}} Python runner was not found",
+      message_type = "error"
+    )
+  }
+  normalizePath(candidates[[1L]], winslash = "/", mustWork = TRUE)
+}
+
+runner_write_json <- function(x, path) {
+  check_r("jsonlite", verbose = FALSE)
+  to_json <- get_namespace_fun("jsonlite", "toJSON")
+  writeLines(
+    as.character(to_json(
+      x,
+      auto_unbox = TRUE,
+      null = "null",
+      digits = NA,
+      pretty = TRUE
+    )),
+    con = path,
+    useBytes = TRUE
+  )
+}
+
+runner_read_json <- function(path) {
+  check_r("jsonlite", verbose = FALSE)
+  get_namespace_fun("jsonlite", "fromJSON")(path, simplifyVector = FALSE)
+}
+
+runner_system2 <- function(command, args, env, stdout, stderr) {
+  if (length(env) && (is.null(names(env)) || any(!nzchar(names(env))))) {
+    log_message(
+      "Subprocess environment variables must be named",
+      message_type = "error"
+    )
+  }
+  old_env <- Sys.getenv(names(env), unset = NA_character_)
+  names(old_env) <- names(env)
+  if (length(env)) {
+    do.call(Sys.setenv, as.list(env))
+  }
+  on.exit({
+    restore <- !is.na(old_env)
+    if (any(restore)) {
+      do.call(Sys.setenv, as.list(old_env[restore]))
+    }
+    if (any(!restore)) {
+      Sys.unsetenv(names(old_env)[!restore])
+    }
+  }, add = TRUE)
+  system2(
+    command = command,
+    args = args,
+    stdout = stdout,
+    stderr = stderr
+  )
+}
+
+runner_read_csv <- function(path, label, backend) {
+  read_output <- function(...) {
+    tryCatch(
+      utils::read.csv(...),
+      error = function(e) {
+        log_message(
+          "Unable to read {.pkg {backend}} {.val {label}} output: {conditionMessage(e)}",
+          message_type = "error"
+        )
+      }
+    )
+  }
+  header <- read_output(
+    path,
+    nrows = 0L,
+    row.names = NULL,
+    check.names = FALSE,
+    stringsAsFactors = FALSE
+  )
+  if (ncol(header) < 2L) {
+    log_message(
+      "{.pkg {backend}} returned invalid {.val {label}} output",
+      message_type = "error"
+    )
+  }
+  column_classes <- rep(NA_character_, ncol(header))
+  column_classes[[1L]] <- "character"
+  value <- read_output(
+    path,
+    row.names = NULL,
+    check.names = FALSE,
+    stringsAsFactors = FALSE,
+    colClasses = column_classes,
+    na.strings = character()
+  )
+  row_names <- value[[1L]]
+  value <- value[-1L]
+  value[] <- lapply(
+    value,
+    utils::type.convert,
+    na.strings = "NA",
+    as.is = TRUE
+  )
+  if (
+    anyNA(row_names) ||
+      any(!nzchar(row_names)) ||
+      anyDuplicated(row_names)
+  ) {
+    log_message(
+      "{.pkg {backend}} {.val {label}} must have unique non-empty row names",
+      message_type = "error"
+    )
+  }
+  rownames(value) <- row_names
+  value
+}
+
+runner_read_numeric_csv <- function(path, label, backend) {
+  value <- as.matrix(runner_read_csv(path, label, backend))
+  suppressWarnings(storage.mode(value) <- "double")
+  if (
+    nrow(value) == 0L ||
+      ncol(value) == 0L ||
+      is.null(rownames(value)) ||
+      is.null(colnames(value)) ||
+      anyDuplicated(rownames(value)) ||
+      anyDuplicated(colnames(value)) ||
+      any(!is.finite(value))
+  ) {
+    log_message(
+      "{.pkg {backend}} returned invalid {.val {label}} output",
+      message_type = "error"
+    )
+  }
+  value
+}
+
+runner_error <- function(
+  status,
+  stdout_path,
+  stderr_path,
+  backend,
+  max_lines = 20L
+) {
+  read_output <- function(path) {
+    if (!file.exists(path)) {
+      return(character())
+    }
+    lines <- readLines(path, warn = FALSE)
+    lines[nzchar(trimws(lines))]
+  }
+  stderr <- read_output(stderr_path)
+  stdout <- read_output(stdout_path)
+  details <- c(
+    if (length(stderr)) {
+      c("Python stderr:", utils::tail(stderr, max_lines))
+    },
+    if (length(stdout)) {
+      c("Python stdout:", utils::tail(stdout, max_lines))
+    }
+  )
+  if (!length(details)) {
+    details <- "<no Python output captured>"
+  }
+  log_message(
+    "{.pkg {backend}} Python runner failed with status {.val {status}}:\n{.code {paste(details, collapse = '\n')}}",
+    message_type = "error"
+  )
+}

--- a/inst/python/cell2fate_runner.py
+++ b/inst/python/cell2fate_runner.py
@@ -176,7 +176,12 @@ def _can_resume(
         for path in _expected_outputs(paths, require_velocity=require_velocity)
     ):
         return False
-    manifest = _read_json(paths["manifest"])
+    try:
+        manifest = _read_json(paths["manifest"])
+    except (OSError, TypeError, ValueError):
+        return False
+    if not isinstance(manifest, dict):
+        return False
     return (
         manifest.get("producer") == PRODUCER
         and manifest.get("runner_schema_version") == RUNNER_SCHEMA_VERSION

--- a/man/RunCHOIR.Rd
+++ b/man/RunCHOIR.Rd
@@ -62,8 +62,9 @@ RunCHOIR(
 \item{min_accuracy}{Minimum classifier accuracy required to keep clusters
 separate.}
 
-\item{max_clusters}{Maximum extent of the initial clustering tree. The
-upstream default \code{"auto"} is recommended.}
+\item{max_clusters}{Must be \code{"auto"}. Numeric limits are rejected because
+the pinned upstream backend can fail to terminate when the number of
+clusters plateaus.}
 
 \item{normalization_method}{Normalization performed inside CHOIR. Use
 \code{"none"} for previously normalized data or \code{"SCTransform"} with a counts

--- a/man/env_requirements.Rd
+++ b/man/env_requirements.Rd
@@ -13,7 +13,8 @@ env_requirements(
 }
 \arguments{
 \item{version}{The Python version of the environment.
-Default is \code{"3.10-1"}.}
+Default is \code{"3.10-1"}. Python \code{"3.9-1"} is reserved for the standalone
+\code{"cell2fate"} module.}
 
 \item{include_optional}{Whether to include optional Python dependencies.}
 

--- a/tests/testthat/test-cell2fate.R
+++ b/tests/testthat/test-cell2fate.R
@@ -57,6 +57,14 @@ test_that("cell2fate environment is isolated and pinned to the upstream stack", 
     ),
     "standalone"
   )
+  expect_error(
+    env_requirements(version = "3.9-1"),
+    "only supported"
+  )
+  expect_error(
+    env_requirements(version = "3.9-1", modules = "scanpy"),
+    "only supported"
+  )
 })
 
 test_that("cell2fate environment check uses the pinned GitHub backend", {
@@ -279,6 +287,132 @@ test_that("RunCell2fate maps posterior summaries back to Seurat", {
   expect_identical(
     out@tools$Cell2fate$provenance$backend_commit,
     "c03d1ca0bb963f550001c6070d4986a61ec8456a"
+  )
+})
+
+test_that("Cell2fate CSV readers preserve character cell names", {
+  metadata_path <- tempfile(fileext = ".csv")
+  velocity_path <- tempfile(fileext = ".csv")
+  writeLines(
+    c(
+      ",Cell2fate_time,Cell2fate_module_0_state",
+      "NA,0.5,Induction",
+      "001,1.5,ON",
+      "010,2.5,OFF"
+    ),
+    metadata_path
+  )
+  writeLines(
+    c(
+      ",Gene1,Gene2",
+      "NA,0.5,1.5",
+      "001,1.5,2.5",
+      "010,3.5,4.5"
+    ),
+    velocity_path
+  )
+
+  metadata <- getFromNamespace("cell2fate_read_csv", "scop")(
+    metadata_path,
+    "posterior metadata"
+  )
+  velocity <- getFromNamespace("cell2fate_read_numeric_csv", "scop")(
+    velocity_path,
+    "velocity"
+  )
+
+  expect_identical(rownames(metadata), c("NA", "001", "010"))
+  expect_identical(metadata$Cell2fate_time, c(0.5, 1.5, 2.5))
+  expect_identical(rownames(velocity), c("NA", "001", "010"))
+  expect_identical(unname(velocity[, "Gene1"]), c(0.5, 1.5, 3.5))
+})
+
+test_that("Cell2fate runner errors retain stderr when stdout is long", {
+  stdout_path <- tempfile()
+  stderr_path <- tempfile()
+  writeLines(paste("stdout line", seq_len(40)), stdout_path)
+  writeLines(
+    c("Traceback (most recent call last):", "cell2fate traceback sentinel"),
+    stderr_path
+  )
+
+  expect_error(
+    getFromNamespace("cell2fate_runner_error", "scop")(
+      2L,
+      stdout_path,
+      stderr_path
+    ),
+    "cell2fate traceback\\s+sentinel"
+  )
+})
+
+test_that("Cell2fate runner treats a malformed resume manifest as a cache miss", {
+  python <- unname(Sys.which(c("python3", "python")))
+  python <- python[nzchar(python)][1]
+  skip_if(is.na(python), "Python is not available")
+  python_version <- suppressWarnings(
+    system2(python, "--version", stdout = TRUE, stderr = TRUE)
+  )
+  skip_if(
+    length(python_version) == 0L || is.na(python_version[[1L]]),
+    "Python version could not be determined"
+  )
+  version_match <- regmatches(
+    python_version[[1L]],
+    regexec("^Python ([0-9]+)\\.([0-9]+)", python_version[[1L]])
+  )[[1]]
+  skip_if(length(version_match) < 3L, "Python version could not be determined")
+  python_major <- as.integer(version_match[[2L]])
+  python_minor <- as.integer(version_match[[3L]])
+  skip_if(
+    python_major < 3L || (python_major == 3L && python_minor < 9L),
+    "Python 3.9 or newer is required"
+  )
+
+  runner <- getFromNamespace("cell2fate_runner_path", "scop")()
+  script <- tempfile(fileext = ".py")
+  output <- tempfile()
+  writeLines(
+    c(
+      "import runpy",
+      "import sys",
+      "import tempfile",
+      "import types",
+      "from pathlib import Path",
+      "for name in ('anndata', 'numpy', 'pandas'):",
+      "    sys.modules[name] = types.ModuleType(name)",
+      "module = runpy.run_path(sys.argv[1], run_name='cell2fate_runner_test')",
+      "with tempfile.TemporaryDirectory() as temporary:",
+      "    paths = module['_output_paths'](Path(temporary))",
+      "    paths['model'].mkdir(parents=True)",
+      "    paths['posterior'].mkdir(parents=True)",
+      "    paths['tables'].mkdir(parents=True)",
+      "    module['_write_json']({",
+      "        'producer': module['PRODUCER'],",
+      "        'runner_schema_version': module['RUNNER_SCHEMA_VERSION'],",
+      "        'backend_commit': module['BACKEND_COMMIT'],",
+      "    }, paths['owner'])",
+      "    (paths['posterior'] / 'cell2fate_posterior.h5ad').touch()",
+      "    (paths['tables'] / 'cell_metadata.csv').touch()",
+      "    paths['complete'].touch()",
+      "    paths['manifest'].write_text('{', encoding='utf-8')",
+      "    assert module['_can_resume'](",
+      "        paths, 'fingerprint', {}, require_velocity=False",
+      "    ) is False"
+    ),
+    script
+  )
+  status <- system2(
+    python,
+    c(shQuote(script), shQuote(runner)),
+    stdout = output,
+    stderr = output
+  )
+
+  expect_identical(
+    status,
+    0L,
+    info = paste(readLines(output, warn = FALSE), collapse = "\n")
   )
 })
 

--- a/tests/testthat/test-cell2fate.R
+++ b/tests/testthat/test-cell2fate.R
@@ -116,7 +116,7 @@ test_that("Cell2fate subprocess environment supports paths with spaces", {
   output <- tempfile()
   error_output <- tempfile()
   old_value <- Sys.getenv("CELL2FATE_SPACE_TEST", unset = NA_character_)
-  status <- getFromNamespace("cell2fate_run_system2", "scop")(
+  status <- getFromNamespace("runner_system2", "scop")(
     command = rscript,
     args = c(
       "-e",
@@ -228,13 +228,13 @@ test_that("RunCell2fate maps posterior summaries back to Seurat", {
   testthat::local_mocked_bindings(
     .package = "scop",
     cell2fate_check_python = function(...) "python",
-    cell2fate_runner_path = function() "cell2fate_runner.py",
+    runner_script_path = function(...) "cell2fate_runner.py",
     cell2fate_write_input = function(prepared, path, ...) {
       file.create(path)
       invisible(path)
     },
-    cell2fate_write_json = function(...) invisible(NULL),
-    cell2fate_run_system2 = function(command, args, env, stdout, stderr) {
+    runner_write_json = function(...) invisible(NULL),
+    runner_system2 = function(command, args, env, stdout, stderr) {
       files <- getFromNamespace("cell2fate_result_files", "scop")(result_dir)
       dir.create(dirname(files$cell_metadata), recursive = TRUE, showWarnings = FALSE)
       dir.create(dirname(files$posterior), recursive = TRUE, showWarnings = FALSE)
@@ -312,13 +312,15 @@ test_that("Cell2fate CSV readers preserve character cell names", {
     velocity_path
   )
 
-  metadata <- getFromNamespace("cell2fate_read_csv", "scop")(
+  metadata <- getFromNamespace("runner_read_csv", "scop")(
     metadata_path,
-    "posterior metadata"
+    "posterior metadata",
+    backend = "Cell2fate"
   )
-  velocity <- getFromNamespace("cell2fate_read_numeric_csv", "scop")(
+  velocity <- getFromNamespace("runner_read_numeric_csv", "scop")(
     velocity_path,
-    "velocity"
+    "velocity",
+    backend = "Cell2fate"
   )
 
   expect_identical(rownames(metadata), c("NA", "001", "010"))
@@ -337,10 +339,11 @@ test_that("Cell2fate runner errors retain stderr when stdout is long", {
   )
 
   expect_error(
-    getFromNamespace("cell2fate_runner_error", "scop")(
+    getFromNamespace("runner_error", "scop")(
       2L,
       stdout_path,
-      stderr_path
+      stderr_path,
+      backend = "Cell2fate"
     ),
     "cell2fate traceback\\s+sentinel"
   )
@@ -369,7 +372,10 @@ test_that("Cell2fate runner treats a malformed resume manifest as a cache miss",
     "Python 3.9 or newer is required"
   )
 
-  runner <- getFromNamespace("cell2fate_runner_path", "scop")()
+  runner <- getFromNamespace("runner_script_path", "scop")(
+    "cell2fate_runner.py",
+    "Cell2fate"
+  )
   script <- tempfile(fileext = ".py")
   output <- tempfile()
   writeLines(
@@ -442,13 +448,13 @@ test_that("RunCell2fate leaves the input unchanged when Python fails", {
   testthat::local_mocked_bindings(
     .package = "scop",
     cell2fate_check_python = function(...) "python",
-    cell2fate_runner_path = function() "cell2fate_runner.py",
+    runner_script_path = function(...) "cell2fate_runner.py",
     cell2fate_write_input = function(prepared, path, ...) {
       file.create(path)
       invisible(path)
     },
-    cell2fate_write_json = function(...) invisible(NULL),
-    cell2fate_run_system2 = function(command, args, env, stdout, stderr) {
+    runner_write_json = function(...) invisible(NULL),
+    runner_system2 = function(command, args, env, stdout, stderr) {
       writeLines("synthetic Cell2fate backend failure", stderr)
       file.create(stdout)
       2L
@@ -462,7 +468,7 @@ test_that("RunCell2fate leaves the input unchanged when Python fails", {
       cluster.by = "celltype",
       verbose = FALSE
     ),
-    "[Ss]ynthetic Cell2fate backend failure"
+    "[Ss]ynthetic\\s+Cell2fate\\s+backend\\s+failure"
   )
   expect_identical(before@meta.data, srt@meta.data)
   expect_identical(before@tools, srt@tools)

--- a/tests/testthat/test-cell2location.R
+++ b/tests/testthat/test-cell2location.R
@@ -96,14 +96,14 @@ test_that("RunCell2location writes abundance, proportions, and reproducible tool
   testthat::local_mocked_bindings(
     .package = "scop",
     cell2location_check_python = function(...) "python",
-    cell2location_runner_path = function() "cell2location_runner.py",
-    cell2location_write_json = function(...) invisible(NULL),
-    cell2location_read_json = function(...) list(status = "complete"),
+    runner_script_path = function(...) "cell2location_runner.py",
+    runner_write_json = function(...) invisible(NULL),
+    runner_read_json = function(...) list(status = "complete"),
     srt_to_h5ad = function(srt, path, ...) {
       file.create(path)
       invisible(path)
     },
-    cell2location_run_system2 = function(command, args, env, stdout, stderr) {
+    runner_system2 = function(command, args, env, stdout, stderr) {
       files <- getFromNamespace("cell2location_result_files", "scop")(result_dir)
       dir.create(dirname(files$abundance), recursive = TRUE, showWarnings = FALSE)
       dir.create(dirname(files$signatures), recursive = TRUE, showWarnings = FALSE)
@@ -196,13 +196,13 @@ test_that("RunCell2location does not mutate Seurat when Python fails", {
   testthat::local_mocked_bindings(
     .package = "scop",
     cell2location_check_python = function(...) "python",
-    cell2location_runner_path = function() "cell2location_runner.py",
-    cell2location_write_json = function(...) invisible(NULL),
+    runner_script_path = function(...) "cell2location_runner.py",
+    runner_write_json = function(...) invisible(NULL),
     srt_to_h5ad = function(srt, path, ...) {
       file.create(path)
       invisible(path)
     },
-    cell2location_run_system2 = function(command, args, env, stdout, stderr) {
+    runner_system2 = function(command, args, env, stdout, stderr) {
       writeLines("synthetic backend failure", stderr)
       file.create(stdout)
       2L
@@ -216,47 +216,10 @@ test_that("RunCell2location does not mutate Seurat when Python fails", {
       assay = "RNA",
       verbose = FALSE
     ),
-    "synthetic backend\\s+failure"
+    "synthetic\\s+backend\\s+failure"
   )
   expect_false(any(startsWith(colnames(pair$spatial@meta.data), "Cell2location_")))
   expect_false("Cell2location" %in% names(pair$spatial@tools))
-})
-
-test_that("Cell2locationPlot exposes all result views", {
-  pair <- make_cell2location_pair()
-  abundance <- matrix(
-    c(8, 2, 2, 6, 1, 9),
-    nrow = 3,
-    byrow = TRUE,
-    dimnames = list(paste0("Spot", 1:3), c("Alpha", "Beta"))
-  )
-  proportions <- abundance / rowSums(abundance)
-  pair$spatial@tools$Cell2location <- list(
-    abundance = abundance,
-    proportions = proportions
-  )
-  pair$spatial$Cell2location_dominant_type <- c("Alpha", "Beta", "Beta")
-
-  expect_s3_class(Cell2locationPlot(pair$spatial, "proportion", overlay_image = FALSE), "ggplot")
-  expect_s3_class(Cell2locationPlot(pair$spatial, "abundance", overlay_image = FALSE), "ggplot")
-  expect_s3_class(Cell2locationPlot(pair$spatial, "dominant", overlay_image = FALSE), "ggplot")
-  if (requireNamespace("scatterpie", quietly = TRUE)) {
-    expect_s3_class(Cell2locationPlot(pair$spatial, "pie", overlay_image = FALSE), "ggplot")
-  }
-})
-
-test_that("Cell2locationPlot requires explicit selection for multi-image objects", {
-  data("visium_mouse_brain_slices_sub", package = "scop")
-  srt <- visium_mouse_brain_slices_sub
-  srt$Cell2location_dominant_type <- rep(c("Alpha", "Beta"), length.out = ncol(srt))
-
-  expect_error(
-    Cell2locationPlot(srt, "dominant"),
-    "Multiple spatial images"
-  )
-  plotted <- Cell2locationPlot(srt, "dominant", image = "anterior1")
-  expect_s3_class(plotted, "ggplot")
-  expect_identical(nrow(plotted$data), 1000L)
 })
 
 test_that("standard spatial workflow dispatches cell2location signatures", {

--- a/tests/testthat/test-choir.R
+++ b/tests/testthat/test-choir.R
@@ -100,6 +100,10 @@ test_that("RunCHOIR validates inputs before checking the backend", {
     RunCHOIR(srt, batch.by = "missing", verbose = FALSE),
     "cell metadata"
   )
+  expect_error(
+    RunCHOIR(srt, max_clusters = 2L, verbose = FALSE),
+    "may not terminate"
+  )
 })
 
 test_that("RunCHOIR calls the optional backend and standardizes results", {

--- a/tests/testthat/test-choir.R
+++ b/tests/testthat/test-choir.R
@@ -77,6 +77,12 @@ with_mock_choir <- function(code, backend = NULL) {
   list(received = received, checked = checked)
 }
 
+test_that("CHOIR rejects unsafe numeric cluster limits", {
+  validate <- getFromNamespace("choir_validate_max_clusters", "scop")
+  expect_identical(validate("auto"), "auto")
+  expect_error(validate(2L), "may not terminate")
+})
+
 test_that("RunCHOIR validates inputs before checking the backend", {
   expect_error(
     RunCHOIR(matrix(1, nrow = 2, ncol = 2), verbose = FALSE),
@@ -99,10 +105,6 @@ test_that("RunCHOIR validates inputs before checking the backend", {
   expect_error(
     RunCHOIR(srt, batch.by = "missing", verbose = FALSE),
     "cell metadata"
-  )
-  expect_error(
-    RunCHOIR(srt, max_clusters = 2L, verbose = FALSE),
-    "may not terminate"
   )
 })
 

--- a/tests/testthat/test-run-benchmark.R
+++ b/tests/testthat/test-run-benchmark.R
@@ -578,7 +578,7 @@ test_that("real child error handling resolves internal helpers from the namespac
   result <- benchmark_run_isolated(
     input_path, run_dir, adapter,
     params = list(), seed = 1, keep_object = FALSE,
-    timeout = 30, poll_interval = 0.05,
+    timeout = 120, poll_interval = 0.05,
     package_context = benchmark_package_context()
   )
   expect_identical(result$status, "failed")


### PR DESCRIPTION
## Summary

Follow-up hardening after merged PRs #335 and #336, rebased onto current `main` after #341.

- reject numeric `max_clusters` before CHOIR backend execution because the pinned upstream full-tree loop can fail to terminate when cluster counts plateau; keep the tested `auto` path unchanged
- reserve Python 3.9 for the standalone Cell2fate environment
- treat malformed Cell2fate resume manifests as cache misses, allowing safe recovery with `overwrite = TRUE`
- preserve character IDs such as `001`, `010`, and literal `NA` when reading runner CSV output
- retain Python stderr independently even when stdout is long
- reuse one internal runner implementation across Cell2fate and Cell2location for script discovery, JSON I/O, scoped environment variables, CSV parsing, numeric validation, and failure diagnostics
- remove Cell2location plotting tests; no test plots or image artifacts are generated or uploaded
- keep both backends optional: no DESCRIPTION, NAMESPACE, hard-dependency, global-option, or persistent environment-variable changes

## Simplification

The unification commit changes 6 files by `+255/-324` (net -69 lines). Across the complete PR, 11 files are `+423/-260`; most additions are real behavior tests rather than duplicated runtime code.

## Validation

After the rebase and unification:

- all 8 changed R/test files parse successfully
- `git diff --check origin/main...HEAD` passes
- `test-cell2fate.R`: 50 passed, 0 failed; one Python-version probe skipped on this Windows host
- `test-cell2location.R`: 45 passed, 0 failed
- standalone CHOIR `auto`/numeric validation contract passed
- full local CHOIR execution could not be repeated with `compile = FALSE` because the package's native DLL is intentionally unavailable in that mode; GitHub R-CMD-check and coverage perform the authoritative full build

Original real `pancreas_sub` smoke validation from this PR remains applicable:

- CHOIR: 60 real cells, `max_clusters = auto`, CPU, completed twice; no missing final labels; provenance records upstream commit `e9ebfbc9089beeaf4ca088c7b81b18f39758b0bc`
- Cell2fate: 80 real cells, 50 input genes / 46 retained genes, CPU, one training epoch, 80/80 posterior rows mapped back; provenance records upstream commit `c03d1ca0bb963f550001c6070d4986a61ec8456a`
- repeated Cell2fate run reused the matching result
- a deliberately corrupted manifest with `resume = TRUE, overwrite = TRUE` caused a real retrain and produced a new complete manifest

## Scope boundary

These runs validate wrapper integration, error handling, cache recovery, and small CPU execution. They do not claim GPU, production-scale, long-training, or biological-performance validation.
## Final CI

- R-CMD-check passed on macOS, Ubuntu, and Windows
- pkgdown passed
- coverage passed with `FAIL 0 | WARN 21 | SKIP 26 | PASS 3052`
- the real isolated benchmark error path passed locally in 23.38 seconds and under covr after raising its startup allowance from 30 to 120 seconds
- no plotting tests or image artifacts were added by this PR