### PR TITLE
fix: discover LIANA resources across R libraries

### DIFF
--- a/R/RunLIANA.R
+++ b/R/RunLIANA.R
@@ -244,13 +244,10 @@ ccc_resources_liana <- function() {
     description = "Install saezlab/liana to inspect LIANA resources",
     stringsAsFactors = FALSE
   )
-  available <- tryCatch(
+  tryCatch(
     check_r(c("saezlab/liana", "SingleCellExperiment"), verbose = FALSE),
-    error = function(e) FALSE
+    error = function(e) NULL
   )
-  if (!isTRUE(unname(unlist(available))[1])) {
-    return(empty)
-  }
   resources <- tryCatch(
     unique(as.character(liana_get_fun("show_resources")())),
     error = function(e) character(0)

--- a/tests/testthat/test-ccc-platform-v2.R
+++ b/tests/testthat/test-ccc-platform-v2.R
@@ -53,6 +53,28 @@ test_that("LIANA resources are discovered from the optional backend", {
   expect_equal(resources$Status[resources$Resource == "OmniPath"], "available")
 })
 
+test_that("LIANA resource discovery follows the resolvable backend across libraries", {
+  check_called <- FALSE
+  testthat::local_mocked_bindings(
+    check_r = function(...) {
+      check_called <<- TRUE
+      invisible(list(liana = FALSE, SingleCellExperiment = FALSE))
+    },
+    liana_get_fun = function(fun, package = "liana") {
+      expect_equal(package, "liana")
+      expect_equal(fun, "show_resources")
+      function() c("Consensus", "MouseConsensus")
+    },
+    .package = "scop"
+  )
+
+  resources <- scop::ListCCCDB(db = "LIANA")
+  expect_true(check_called)
+  expect_equal(resources$Resource, c("Consensus", "MouseConsensus"))
+  expect_equal(resources$Species, c("human", "mouse"))
+  expect_true(all(resources$Status == "available"))
+})
+
 test_that("RunLIANA stores official consensus and keeps legacy tables", {
   skip_if_not_installed("Seurat")
   skip_if_not_installed("Matrix")


### PR DESCRIPTION
﻿## Summary

- keep the required optional-backend `check_r()` probe
- use successful resolution of LIANA's official `show_resources()` as the authoritative availability check
- add a regression test for installations where LIANA is resolvable from a non-primary R library

## Root cause

`check_r()` checks its default library path and can report `FALSE` when LIANA and SingleCellExperiment are installed in another entry of `.libPaths()`. `get_namespace_fun()` can still resolve and call the official backend, but `ListCCCDB()` returned early and incorrectly reported LIANA as unavailable. This also rejected `MouseConsensus` before analysis.

## Validation

- `testthat::test_file("tests/testthat/test-ccc-platform-v2.R")`
- real backend smoke test: 19 LIANA resources discovered, including one `MouseConsensus`
- `pkgload::load_all(".", quiet = TRUE, compile = FALSE)`
- local R CMD check without CRAN incoming network probe reached `checking for unstated dependencies in examples ... OK`; existing CellChat/nichenetr dependency warning is unrelated to this diff
