### PR TITLE
fix: reuse RCTD weights in SpaTalk

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
   * `RunMERINGUE()` gains a `backend = c("cpp", "r")` option; the C++ kernels replicate `MERINGUE::moranTest()`/`moranPermutationTest()` to machine precision (including the `sample.kind` RNG stream). `backend = "r"` retains the original calls and honors `moran_params`.
   * Real-data consistency tests verify the wrappers against the original pipelines (CellChat, SpatialCellChat, LIANA, BayesSpace, MERINGUE, SPOTlight, SpaNorm, SpatialDWLS, RCTD, BANKSY, CARD, SpotSweeper, PRECAST).
 * **fixed**:
+  * `RunSpaTalk()` now reuses stored `RunRCTD()` weights through SpaTalk method 2, records the deconvolution source, and accepts a working installed SpaTalk package even when its DESCRIPTION lacks GitHub remote metadata.
   * `RunLIANA()` now preserves the field set returned by LIANA's official consensus mode: rank consensus no longer gains all-`NA` aggregate/significance placeholders, aggregate consensus no longer gains all-`NA` magnitude/specificity placeholders, and deterministic ligand-receptor display identifiers are completed during SCOP/LIANA export.
   * `RunCNV()` attaches backend packages to the search path during execution so lazy data objects (copykat `full.anno`, fastCNV `geneMetadata`, numbat `gtf_hg38`) are resolvable from backend namespace code; `copykat` is installed from its GitHub source (`navinlabcode/copykat`) because it was removed from CRAN.
   * `RunCNV(numbat)` prefers the plain `seg` column over `seg_label` when reading `joint_post` output, so segment identifiers are not polluted with the `(loh)` suffix.

--- a/R/RunSpaTalk.R
+++ b/R/RunSpaTalk.R
@@ -9,10 +9,17 @@ spatalk_required_symbols <- function() {
 }
 
 spatalk_check_r <- function() {
-  available <- check_r(
-    c(.spatalk_nnlm_repository, .spatalk_repository),
+  package_status <- check_r(
+    c("NNLM", .spatalk_package),
+    install = FALSE,
     verbose = FALSE
   )
+  package_status <- unname(unlist(package_status, use.names = FALSE))
+  package_status <- suppressWarnings(as.logical(package_status))
+  if (length(package_status) == 2L && !anyNA(package_status) && all(package_status)) {
+    return(invisible(TRUE))
+  }
+  available <- check_r(c(.spatalk_nnlm_repository, .spatalk_repository), verbose = FALSE)
   available <- unname(unlist(available, use.names = FALSE))
   available <- suppressWarnings(as.logical(available))
   if (length(available) != 2L || anyNA(available) || !all(available)) {
@@ -157,6 +164,110 @@ spatalk_reference_input <- function(reference, reference.group.by, assay, layer)
   list(expression = expression, labels = labels, assay = assay)
 }
 
+spatalk_normalize_ids <- function(x) {
+  gsub("[ -]", "_", as.character(x))
+}
+
+spatalk_prepare_dec_result <- function(dec_result, spot_ids, reference_labels, source) {
+  if (!is.matrix(dec_result) && !methods::is(dec_result, "Matrix")) {
+    log_message(
+      "SpaTalk {.arg dec_result} from {.val {source}} must be a numeric matrix",
+      message_type = "error"
+    )
+  }
+  dec_result <- as.matrix(dec_result)
+  if (!is.numeric(dec_result) || nrow(dec_result) == 0L || ncol(dec_result) == 0L ||
+      is.null(rownames(dec_result)) || is.null(colnames(dec_result)) ||
+      anyNA(rownames(dec_result)) || anyNA(colnames(dec_result)) ||
+      any(!nzchar(rownames(dec_result))) || any(!nzchar(colnames(dec_result))) ||
+      anyDuplicated(rownames(dec_result)) || anyDuplicated(colnames(dec_result))) {
+    log_message(
+      "SpaTalk {.arg dec_result} from {.val {source}} must have unique spot and cell-type names",
+      message_type = "error"
+    )
+  }
+  if (any(!is.finite(dec_result)) || any(dec_result < 0)) {
+    log_message(
+      "SpaTalk {.arg dec_result} from {.val {source}} must contain finite non-negative weights",
+      message_type = "error"
+    )
+  }
+  missing_spots <- setdiff(spot_ids, rownames(dec_result))
+  if (length(missing_spots) > 0L) {
+    log_message(
+      "SpaTalk {.arg dec_result} from {.val {source}} is missing {.val {length(missing_spots)}} selected spot{?s}",
+      message_type = "error"
+    )
+  }
+  dec_result <- dec_result[spot_ids, , drop = FALSE]
+  if (any(rowSums(dec_result) <= 0)) {
+    log_message(
+      "SpaTalk {.arg dec_result} from {.val {source}} has selected spots with zero total weight",
+      message_type = "error"
+    )
+  }
+  normalized_types <- spatalk_normalize_ids(colnames(dec_result))
+  normalized_reference <- spatalk_normalize_ids(unique(reference_labels))
+  if (anyDuplicated(normalized_types) || anyDuplicated(normalized_reference)) {
+    log_message(
+      "SpaTalk cell-type names become duplicated after replacing spaces or hyphens with underscores",
+      message_type = "error"
+    )
+  }
+  unknown_types <- setdiff(normalized_types, normalized_reference)
+  if (length(unknown_types) > 0L) {
+    log_message(
+      "SpaTalk {.arg dec_result} cell types are absent from {.arg reference.group.by}: {.val {paste(unknown_types, collapse = ', ')}}",
+      message_type = "error"
+    )
+  }
+  dec_result
+}
+
+spatalk_deconvolution_spec <- function(
+  srt, input, reference_input, deconvolution, rctd.tool, dots
+) {
+  dec_result <- dots$dec_result %||% NULL
+  dots$dec_result <- NULL
+  if (identical(deconvolution, "NNLM")) {
+    if (!is.null(dec_result)) {
+      log_message(
+        "Do not supply {.arg dec_result} with {.arg deconvolution = 'NNLM'}; use {.val RCTD} or {.val none}",
+        message_type = "error"
+      )
+    }
+    return(list(method = 1L, dec_result = NULL, source = "SpaTalk NNLM", dots = dots))
+  }
+  source <- "dec_result argument"
+  if (identical(deconvolution, "RCTD") && is.null(dec_result)) {
+    if (!is.character(rctd.tool) || length(rctd.tool) != 1L || is.na(rctd.tool) || !nzchar(rctd.tool)) {
+      log_message("{.arg rctd.tool} must be one non-empty tool name", message_type = "error")
+    }
+    stored <- srt@tools[[rctd.tool]]
+    dec_result <- stored$weights %||% NULL
+    source <- paste0("srt@tools$", rctd.tool, "$weights")
+    if (is.null(dec_result)) {
+      log_message(
+        "Stored RCTD weights are absent at {.code {source}}; run {.fn RunRCTD} first or provide {.arg dec_result}",
+        message_type = "error"
+      )
+    }
+  }
+  if (is.null(dec_result)) {
+    log_message(
+      "{.arg deconvolution = 'none'} requires a named {.arg dec_result} matrix in {.arg ...}",
+      message_type = "error"
+    )
+  }
+  dec_result <- spatalk_prepare_dec_result(
+    dec_result = dec_result,
+    spot_ids = input$cells,
+    reference_labels = reference_input$labels,
+    source = source
+  )
+  list(method = 2L, dec_result = dec_result, source = source, dots = dots)
+}
+
 spatalk_pick_col <- function(df, candidates) {
   hit <- intersect(candidates, colnames(df))
   if (length(hit) == 0L) NULL else hit[[1L]]
@@ -240,7 +351,11 @@ spatalk_validate_bundle <- function(bundle) {
 #' @param image Explicit spatial image. Required for multi-image objects.
 #' @param coord.cols Metadata coordinate columns used when no image is present.
 #' @param deconvolution Spot deconvolution mode. `"NNLM"` runs SpaTalk method 1;
-#'   `"none"` requires a named `dec_result` matrix in `...`.
+#'   `"RCTD"` reuses `srt@tools[[rctd.tool]]$weights` from [RunRCTD()] (or an
+#'   explicitly supplied `dec_result`); `"none"` requires a named external
+#'   `dec_result` matrix in `...`. Imported matrices use SpaTalk method 2.
+#' @param rctd.tool Tool key containing stored RCTD weights when
+#'   `deconvolution = "RCTD"`.
 #' @param result.name Stored result name.
 #' @param store.object Whether to store the full upstream SpaTalk object.
 #' @param overwrite Whether to replace an existing named result.
@@ -281,7 +396,8 @@ RunSpaTalk <- function(
   reference.layer = "counts",
   image = NULL,
   coord.cols = c("col", "row"),
-  deconvolution = c("NNLM", "none"),
+  deconvolution = c("NNLM", "RCTD", "none"),
+  rctd.tool = "RCTD",
   result.name = "default",
   store.object = c("minimal", "full"),
   overwrite = FALSE,
@@ -312,10 +428,15 @@ RunSpaTalk <- function(
     }
   }
   dots <- list(...)
-  if (identical(mode, "spot") && identical(deconvolution, "none") && is.null(dots$dec_result)) {
-    log_message("{.arg deconvolution = 'none'} requires {.arg dec_result} in {.arg ...}", message_type = "error")
-  }
   spot_max_cell <- dots$spot_max_cell %||% if (identical(mode, "single_cell")) 1L else 30L
+  deconvolution_spec <- NULL
+  if (identical(mode, "spot")) {
+    deconvolution_spec <- spatalk_deconvolution_spec(
+      srt = srt, input = input, reference_input = reference_input,
+      deconvolution = deconvolution, rctd.tool = rctd.tool, dots = dots
+    )
+    dots <- deconvolution_spec$dots
+  }
 
   spatalk_check_r()
   create_fun <- spatalk_get_fun("createSpaTalk")
@@ -351,7 +472,8 @@ RunSpaTalk <- function(
         object = native,
         sc_data = reference_input$expression,
         sc_celltype = reference_input$labels,
-        method = 1
+        method = deconvolution_spec$method,
+        dec_result = deconvolution_spec$dec_result
       ),
       dots
     )
@@ -380,6 +502,9 @@ RunSpaTalk <- function(
     reference.layer = reference.layer, image = input$source$image %||% image,
     coord.cols = coord.cols, coordinate_space = "raw",
     deconvolution = deconvolution, result.name = result.name,
+    deconvolution_source = deconvolution_spec$source %||% "single-cell labels",
+    rctd.tool = if (identical(deconvolution, "RCTD")) rctd.tool else NULL,
+    dec_result_dimensions = if (is.null(deconvolution_spec$dec_result)) NULL else dim(deconvolution_spec$dec_result),
     store.object = store.object, spot_max_cell = spot_max_cell,
     backend = backend, backend_scope = "unified CCC result aggregation",
     backend_args = dots

--- a/man/RunSpaTalk.Rd
+++ b/man/RunSpaTalk.Rd
@@ -17,7 +17,8 @@ RunSpaTalk(
   reference.layer = "counts",
   image = NULL,
   coord.cols = c("col", "row"),
-  deconvolution = c("NNLM", "none"),
+  deconvolution = c("NNLM", "RCTD", "none"),
+  rctd.tool = "RCTD",
   result.name = "default",
   store.object = c("minimal", "full"),
   overwrite = FALSE,
@@ -49,7 +50,12 @@ supplied and single-cell mode otherwise.}
 \item{coord.cols}{Metadata coordinate columns used when no image is present.}
 
 \item{deconvolution}{Spot deconvolution mode. `"NNLM"` runs SpaTalk method 1;
-`"none"` requires a named `dec_result` matrix in `...`.}
+`"RCTD"` reuses `srt@tools[[rctd.tool]]$weights` from [RunRCTD()] (or an
+explicitly supplied `dec_result`); `"none"` requires a named external
+`dec_result` matrix in `...`. Imported matrices use SpaTalk method 2.}
+
+\item{rctd.tool}{Tool key containing stored RCTD weights when
+`deconvolution = "RCTD"`.}
 
 \item{result.name}{Stored result name.}
 

--- a/tests/testthat/test-run-spatalk.R
+++ b/tests/testthat/test-run-spatalk.R
@@ -13,11 +13,9 @@ make_spatalk_test_object <- function() {
 
 mock_spatalk_bindings <- function(dec_seen = NULL, fail_cci = FALSE) {
   testthat::local_mocked_bindings(
-    check_r = function(repos, verbose = FALSE, ...) {
-      expect_identical(
-        repos,
-        c("linxihui/NNLM", "ZJUFanLab/SpaTalk")
-      )
+    check_r = function(repos, verbose = FALSE, install = TRUE, ...) {
+      expect_identical(repos, c("NNLM", "SpaTalk"))
+      expect_false(install)
       list(NNLM = TRUE, SpaTalk = TRUE)
     },
     get_namespace_fun = function(package, fun) {
@@ -32,10 +30,15 @@ mock_spatalk_bindings <- function(dec_seen = NULL, fail_cci = FALSE) {
           )
         },
         dec_celltype = function(object, sc_data, sc_celltype, method = 1, dec_result = NULL, ...) {
-          if (!is.null(dec_seen)) dec_seen$value <- TRUE
-          object$coef <- matrix(
-            c(0.7, 0.3, 0.2, 0.8), nrow = 2,
-            dimnames = list(colnames(object$data$rawdata)[1:2], c("A", "B"))
+          if (!is.null(dec_seen)) {
+            dec_seen$value <- TRUE
+            dec_seen$method <- method
+            dec_seen$dec_result <- dec_result
+          }
+          object$coef <- dec_result %||% matrix(
+            rep(c(0.7, 0.3), ncol(object$data$rawdata)), ncol = 2,
+            byrow = TRUE,
+            dimnames = list(colnames(object$data$rawdata), c("A", "B"))
           )
           object
         },
@@ -78,6 +81,43 @@ mock_spatalk_bindings <- function(dec_seen = NULL, fail_cci = FALSE) {
   )
 }
 
+test_that("SpaTalk preflight accepts installed packages without remote metadata", {
+  seen <- new.env(parent = emptyenv())
+  seen$calls <- list()
+  testthat::local_mocked_bindings(
+    check_r = function(repos, verbose = FALSE, install = TRUE, ...) {
+      seen$calls[[length(seen$calls) + 1L]] <- list(repos = repos, install = install)
+      list(NNLM = TRUE, SpaTalk = TRUE)
+    },
+    .package = "scop"
+  )
+  expect_invisible(spatalk_check_r())
+  expect_length(seen$calls, 1L)
+  expect_identical(seen$calls[[1L]]$repos, c("NNLM", "SpaTalk"))
+  expect_false(seen$calls[[1L]]$install)
+})
+
+test_that("SpaTalk preflight falls back to official repositories when absent", {
+  seen <- new.env(parent = emptyenv())
+  seen$calls <- list()
+  testthat::local_mocked_bindings(
+    check_r = function(repos, verbose = FALSE, install = TRUE, ...) {
+      seen$calls[[length(seen$calls) + 1L]] <- list(repos = repos, install = install)
+      if (identical(repos, c("NNLM", "SpaTalk"))) {
+        return(list(NNLM = FALSE, SpaTalk = FALSE))
+      }
+      list(NNLM = TRUE, SpaTalk = TRUE)
+    },
+    .package = "scop"
+  )
+  expect_invisible(spatalk_check_r())
+  expect_length(seen$calls, 2L)
+  expect_identical(
+    seen$calls[[2L]]$repos,
+    c("linxihui/NNLM", "ZJUFanLab/SpaTalk")
+  )
+})
+
 test_that("RunSpaTalk stores official single-cell results and unified CCC rows", {
   srt <- make_spatalk_test_object()
   mock_spatalk_bindings()
@@ -111,8 +151,69 @@ test_that("RunSpaTalk spot mode runs NNLM deconvolution and can retain native ou
     backend = "r", verbose = FALSE
   )
   expect_true(seen$value)
+  expect_identical(seen$method, 1L)
+  expect_null(seen$dec_result)
   expect_true(is.list(out@tools$SpaTalk$results$default$native_object))
   expect_true(is.matrix(out@tools$SpaTalk$results$default$deconvolution))
+})
+
+test_that("RunSpaTalk reuses stored RCTD weights with SpaTalk method 2", {
+  spatial <- make_spatalk_test_object()
+  reference <- make_spatalk_test_object()
+  reference$ref_type <- c("A", "A", "B", "B")
+  weights <- matrix(
+    c(0.1, 0.9, 0.2, 0.8, 0.3, 0.7, 0.4, 0.6),
+    ncol = 2, byrow = TRUE,
+    dimnames = list(rev(colnames(spatial)), c("A", "B"))
+  )
+  spatial@tools$RCTD <- list(weights = weights)
+  seen <- new.env(parent = emptyenv())
+  seen$value <- FALSE
+  mock_spatalk_bindings(dec_seen = seen)
+
+  out <- RunSpaTalk(
+    spatial, group.by = "celltype", mode = "spot",
+    reference = reference, reference.group.by = "ref_type",
+    deconvolution = "RCTD", coord.cols = c("col", "row"),
+    backend = "r", verbose = FALSE
+  )
+
+  expected <- weights[colnames(spatial), , drop = FALSE]
+  expect_true(seen$value)
+  expect_identical(seen$method, 2L)
+  expect_identical(seen$dec_result, expected)
+  expect_identical(
+    out@tools$SpaTalk$parameters$deconvolution_source,
+    "srt@tools$RCTD$weights"
+  )
+  expect_identical(out@tools$SpaTalk$results$default$deconvolution, expected)
+  expect_null(out@tools$SpaTalk$parameters$backend_args$dec_result)
+})
+
+test_that("RunSpaTalk accepts an explicit external deconvolution matrix", {
+  spatial <- make_spatalk_test_object()
+  reference <- make_spatalk_test_object()
+  reference$ref_type <- c("A", "A", "B", "B")
+  dec_result <- matrix(
+    rep(c(0.6, 0.4), ncol(spatial)), ncol = 2, byrow = TRUE,
+    dimnames = list(colnames(spatial), c("A", "B"))
+  )
+  seen <- new.env(parent = emptyenv())
+  mock_spatalk_bindings(dec_seen = seen)
+
+  out <- RunSpaTalk(
+    spatial, group.by = "celltype", mode = "spot",
+    reference = reference, reference.group.by = "ref_type",
+    deconvolution = "none", dec_result = dec_result,
+    coord.cols = c("col", "row"), backend = "r", verbose = FALSE
+  )
+
+  expect_identical(seen$method, 2L)
+  expect_identical(seen$dec_result, dec_result)
+  expect_identical(
+    out@tools$SpaTalk$parameters$deconvolution_source,
+    "dec_result argument"
+  )
 })
 
 test_that("RunSpaTalk validates spot inputs before backend execution", {
@@ -133,6 +234,27 @@ test_that("RunSpaTalk validates spot inputs before backend execution", {
       deconvolution = "none", coord.cols = c("col", "row"), verbose = FALSE
     ),
     "dec_result"
+  )
+  expect_error(
+    RunSpaTalk(
+      spatial, group.by = "celltype", mode = "spot",
+      reference = reference, reference.group.by = "ref_type",
+      deconvolution = "RCTD", coord.cols = c("col", "row"), verbose = FALSE
+    ),
+    "Stored RCTD weights are absent"
+  )
+  invalid <- matrix(
+    c(1, 0, 0, 1, 1, 0), ncol = 2, byrow = TRUE,
+    dimnames = list(colnames(spatial)[1:3], c("A", "B"))
+  )
+  spatial@tools$RCTD <- list(weights = invalid)
+  expect_error(
+    RunSpaTalk(
+      spatial, group.by = "celltype", mode = "spot",
+      reference = reference, reference.group.by = "ref_type",
+      deconvolution = "RCTD", coord.cols = c("col", "row"), verbose = FALSE
+    ),
+    "is missing 1 selected"
   )
 })
 


### PR DESCRIPTION
﻿## Summary
- make SpaTalk preflight accept working installed `SpaTalk`/`NNLM` packages even when GitHub remote metadata is absent, while retaining the official-repository fallback
- add `deconvolution = "RCTD"` to reuse `srt@tools[[rctd.tool]]$weights` and pass imported weights to official SpaTalk method 2
- validate/reorder spot weights, validate cell-type compatibility, and record deconvolution provenance without storing the matrix in backend arguments
- update Rd/NEWS and add focused regression tests

## Validation
- `Rscript -e "pkgload::load_all('.', quiet=TRUE, compile=FALSE)"`
- focused `tests/testthat/test-run-spatalk.R`: 108 expectations passed
- `tools::Rd2ex('man/RunSpaTalk.Rd')` + `parse()`: passed
- live official SpaTalk 1.0 STARmap spot/reference run using stored RCTD-like weights: 132 spots, 14 cell types, 3 LR rows, 3 TF rows; stored coefficients identical to supplied weights
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --as-cran --no-manual --no-examples --no-tests`: 0 errors; `checking dependencies in R code ... OK`; `checking for unstated dependencies in examples ... OK`

The remaining check warning is pre-existing and comes from direct `infercnv`/`numbat` references in unrelated tests. No optional backend was added to Imports/Depends/Suggests.
