### PR TITLE
feat: unify python backend result storage into srt@tools

### DIFF
--- a/R/RunPAGA.R
+++ b/R/RunPAGA.R
@@ -267,21 +267,30 @@ RunPAGA <- function(
   if (isTRUE(return_seurat)) {
     srt_out <- adata_to_srt(adata)
     if (is.null(srt)) {
-      return(srt_out)
+      srt_final <- srt_out
     } else {
       srt_out1 <- srt_append(
         srt_raw = srt,
         srt_append = srt_out
       )
-      srt_out2 <- srt_append(
+      srt_final <- srt_append(
         srt_raw = srt_out1,
         srt_append = srt_out,
         pattern = "(paga)|(distances)|(connectivities)|(draw_graph)",
         overwrite = TRUE,
         verbose = FALSE
       )
-      return(srt_out2)
     }
+    paga_res <- srt_final@misc[["paga"]]
+    if (!is.null(paga_res)) {
+      if (is.null(paga_res[["groups"]])) {
+        paga_res[["groups"]] <- group.by
+      }
+      paga_res[["backend"]] <- "python"
+      srt_final@tools[["PAGA"]] <- paga_res
+      srt_final@misc[["paga"]] <- NULL
+    }
+    return(srt_final)
   } else {
     return(adata)
   }

--- a/R/RunPalantir.R
+++ b/R/RunPalantir.R
@@ -348,18 +348,58 @@ RunPalantir <- function(
   if (isTRUE(return_seurat)) {
     srt_out <- adata_to_srt(adata)
     if (is.null(srt)) {
-      return(srt_out)
+      srt_final <- srt_out
     } else {
       srt_out1 <- srt_append(srt_raw = srt, srt_append = srt_out)
-      srt_out2 <- srt_append(
+      srt_final <- srt_append(
         srt_raw = srt_out1,
         srt_append = srt_out,
         pattern = "(palantir)|(dm_kernel)|(_diff_potential)",
         overwrite = TRUE,
         verbose = FALSE
       )
-      return(srt_out2)
     }
+    meta_names <- colnames(srt_final@meta.data)
+    reduction_names <- names(srt_final@reductions)
+    branch_cols <- setdiff(
+      grep("_diff_potential$", meta_names, value = TRUE),
+      "palantir_diff_potential"
+    )
+    dm_reduction <- reduction_names[
+      grepl("palantir.*dm", reduction_names, ignore.case = TRUE)
+    ]
+    srt_final@tools[["Palantir"]] <- list(
+      backend = "python",
+      group.by = group.by,
+      pseudotime = if ("palantir_pseudotime" %in% meta_names) {
+        srt_final@meta.data[["palantir_pseudotime"]]
+      } else {
+        NULL
+      },
+      diff_potential = if ("palantir_diff_potential" %in% meta_names) {
+        srt_final@meta.data[["palantir_diff_potential"]]
+      } else {
+        NULL
+      },
+      branch_probs = if (length(branch_cols) > 0L) {
+        as.matrix(srt_final@meta.data[, branch_cols, drop = FALSE])
+      } else {
+        NULL
+      },
+      diffusion_map_reduction = if (length(dm_reduction) > 0L) {
+        dm_reduction[[1L]]
+      } else {
+        NULL
+      },
+      dm_kernel = srt_final@misc[["dm_kernel"]],
+      parameters = list(
+        linear_reduction = linear_reduction,
+        nonlinear_reduction = nonlinear_reduction,
+        n_pcs = n_pcs,
+        n_neighbors = n_neighbors
+      )
+    )
+    return(srt_final)
   } else {
     return(adata)
   }

--- a/R/RunSCVELO.R
+++ b/R/RunSCVELO.R
@@ -322,10 +322,10 @@ RunSCVELO <- function(
   if (isTRUE(return_seurat)) {
     srt_out <- adata_to_srt(adata)
     if (is.null(srt)) {
-      return(srt_out)
+      srt_final <- srt_out
     } else {
       srt_out1 <- srt_append(srt_raw = srt, srt_append = srt_out)
-      srt_out2 <- srt_append(
+      srt_final <- srt_append(
         srt_raw = srt_out1,
         srt_append = srt_out,
         pattern = paste0(
@@ -336,8 +336,56 @@ RunSCVELO <- function(
         overwrite = TRUE,
         verbose = FALSE
       )
-      return(srt_out2)
     }
+    reduction_names <- names(srt_final@reductions)
+    meta_names <- colnames(srt_final@meta.data)
+    misc_names <- names(srt_final@misc)
+    scvelo_tools <- list(
+      backend = "python",
+      group.by = group.by,
+      parameters = list(
+        linear_reduction = linear_reduction,
+        nonlinear_reduction = nonlinear_reduction,
+        n_pcs = n_pcs,
+        n_neighbors = n_neighbors
+      ),
+      mode = mode
+    )
+    for (m in mode) {
+      velocity_reduction <- reduction_names[
+        grepl(paste0("^", m, "_"), reduction_names, ignore.case = TRUE) |
+          grepl("^velocity_", reduction_names, ignore.case = TRUE)
+      ]
+      conf_key <- intersect(
+        c(paste0(m, "_confidence"), "velocity_confidence"), meta_names
+      )
+      len_key <- intersect(
+        c(paste0(m, "_length"), "velocity_length"), meta_names
+      )
+      pt_key <- intersect(
+        c(paste0(m, "_pseudotime"), "velocity_pseudotime"), meta_names
+      )
+      graph_key <- intersect(
+        c(paste0(m, "_graph"), "velocity_graph"), misc_names
+      )
+      scvelo_tools[[m]] <- list(
+        velocity_reduction = if (length(velocity_reduction) > 0L) {
+          velocity_reduction[[1L]]
+        } else {
+          NULL
+        },
+        confidence_key = if (length(conf_key) > 0L) conf_key[[1L]] else NULL,
+        length_key = if (length(len_key) > 0L) len_key[[1L]] else NULL,
+        pseudotime_key = if (length(pt_key) > 0L) pt_key[[1L]] else NULL,
+        velocity_graph = if (length(graph_key) > 0L) {
+          srt_final@misc[[graph_key[[1L]]]]
+        } else {
+          NULL
+        }
+      )
+    }
+    srt_final@tools[["SCVELO"]] <- scvelo_tools
+    return(srt_final)
   } else {
     return(adata)
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background

Several `Run*` functions offer `backend = c("python", "cpp")`, but the python backends surfaced results differently from the cpp backends:

- `RunPAGA` cpp → `srt@tools[["PAGA"]]`; python → `srt@misc[["paga"]]` (scanpy stores PAGA in `adata.uns`, and `adata_to_srt()` maps `uns` keys to `@misc`).
- `RunSCVELO` / `RunPalantir` cpp populate `srt@tools[["SCVELO"]]` / `srt@tools[["Palantir"]]`; the python backends left `@tools` empty.

This made `Tool(srt, "PAGA")` (etc.) return `NULL` for python results.

## Change

The python backends now expose results through `srt@tools[[...]]` with `backend = "python"`, matching the cpp backend and the existing `RunCellRank` convention:

- `RunPAGA`: promotes the scanpy `uns` result to `srt@tools[["PAGA"]]` and drops the `@misc[["paga"]]` duplicate.
- `RunSCVELO` / `RunPalantir`: record where the converted results live (reduction / meta.data column names, graph/kernel), probed defensively from the already-converted object so a missing result is stored as `NULL` rather than failing.

The `@reductions` / `@meta.data` outputs consumed by `VelocityPlot` / `PalantirTrajectoryPlot` are unchanged, and `PAGAPlot` keeps its `srt@tools[["PAGA"]] %||% srt@misc[["paga"]]` fallback so previously saved objects still render.

Scope: `RunCellRank` already wrote `@tools[["CellRank"]]`; `RuntAge` / `RunPHATE` / `RunSCENIC` / `RunSCENICPlus` already share one storage contract across backends; `RunWOT` is python-only. No changes were needed there.

## Validation (R 4.6.1, cloud VM)

- `RunPAGA(backend = "python")` on `pancreas_sub` → `@tools[["PAGA"]]` has `connectivities, connectivities_tree, groups, pos, backend="python"`, `@misc[["paga"]]` is `NULL`, `Tool(srt, "PAGA")` works, and `PAGAPlot` renders. The cpp backend is unchanged and still populates the same slot.
- `test-cpp-backend-safety.R`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 55` (cpp paths untouched).
- The SCVELO/Palantir probing logic was unit-tested against a mocked Seurat object (correctly resolves the velocity reduction / confidence / length / pseudotime / graph keys and the Palantir pseudotime / branch-probability / diffusion-map / kernel entries; missing results yield `NULL`). Their python backends were not run end-to-end here because `scvelo` / `palantir` are not installed in this environment.
- `R CMD check` (no examples/tests/vignettes, `_R_CHECK_FORCE_SUGGESTS_=false`): `Status: OK`.

[PAGA python backend (unified @tools)](https://cursor.com/agents/bc-1b36fcc2-164b-487b-9c4c-25a3b0192a65/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscop_paga_unified_python.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b36fcc2-164b-487b-9c4c-25a3b0192a65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b36fcc2-164b-487b-9c4c-25a3b0192a65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

