### PR TITLE
docs: replace external file paths in examples with built-in data

### DIFF
--- a/R/DataConvert.R
+++ b/R/DataConvert.R
@@ -33,13 +33,10 @@
 #' adata
 #'
 #' # Or save as a h5ad/loom file
-#' adata$write_h5ad(
-#'   "pancreas_sub.h5ad"
-#' )
-#' adata$write_loom(
-#'   "pancreas_sub.loom",
-#'   write_obsm_varm = TRUE
-#' )
+#' h5ad_path <- tempfile(fileext = ".h5ad")
+#' loom_path <- tempfile(fileext = ".loom")
+#' adata$write_h5ad(h5ad_path)
+#' adata$write_loom(loom_path, write_obsm_varm = TRUE)
 #' }
 srt_to_adata <- function(
   srt,
@@ -343,7 +340,8 @@ get_adata_sparse_assay_layer <- function(
 #' @examples
 #' \dontrun{
 #' data(pancreas_sub)
-#' srt_to_h5ad(pancreas_sub, "pancreas_sub.h5ad")
+#' h5ad_path <- tempfile(fileext = ".h5ad")
+#' srt_to_h5ad(pancreas_sub, h5ad_path)
 #' }
 srt_to_h5ad <- function(
   srt,
@@ -437,8 +435,10 @@ srt_to_h5ad <- function(
 #' srt
 #'
 #' # Or convert a h5ad file to Seurat object
+#' h5ad_path <- tempfile(fileext = ".h5ad")
+#' srt_to_h5ad(pancreas_sub, h5ad_path)
 #' sc <- reticulate::import("scanpy")
-#' adata <- sc$read_h5ad("pancreas.h5ad")
+#' adata <- sc$read_h5ad(h5ad_path)
 #' srt <- adata_to_srt(adata)
 #' srt
 #' }
@@ -713,7 +713,10 @@ adata_to_srt <- function(
 #'
 #' @examples
 #' \dontrun{
-#' srt <- h5ad_to_srt("path/to/data.h5ad")
+#' data(pancreas_sub)
+#' h5ad_path <- tempfile(fileext = ".h5ad")
+#' srt_to_h5ad(pancreas_sub, h5ad_path)
+#' srt <- h5ad_to_srt(h5ad_path)
 #' srt
 #' }
 h5ad_to_srt <- function(
@@ -810,7 +813,11 @@ __main__.adata = adata
 #'
 #' @examples
 #' \dontrun{
-#' adata <- loom_to_adata("path/to/data.loom")
+#' data(pancreas_sub)
+#' adata <- srt_to_adata(pancreas_sub)
+#' loom_path <- tempfile(fileext = ".loom")
+#' adata$write_loom(loom_path, write_obsm_varm = TRUE)
+#' adata <- loom_to_adata(loom_path)
 #' adata
 #' }
 loom_to_adata <- function(
@@ -880,7 +887,11 @@ loom_to_adata <- function(
 #'
 #' @examples
 #' \dontrun{
-#' srt <- loom_to_srt("path/to/data.loom")
+#' data(pancreas_sub)
+#' adata <- srt_to_adata(pancreas_sub)
+#' loom_path <- tempfile(fileext = ".loom")
+#' adata$write_loom(loom_path, write_obsm_varm = TRUE)
+#' srt <- loom_to_srt(loom_path)
 #' srt
 #' }
 loom_to_srt <- function(

--- a/R/ExternalDatasets.R
+++ b/R/ExternalDatasets.R
@@ -54,6 +54,9 @@ ListExternalDatasets <- function(
 #'
 #' @examples
 #' \dontrun{
+#' data(visium_human_pancreas_sub)
+#' SpatialSpotPlot(visium_human_pancreas_sub, group.by = "coda_label")
+#' # Optional remote datasets from mengxu98/datasets:
 #' xenium <- LoadExternalDataset("xenium_human_pancreas_sub", collection = "Xenium")
 #' SpatialSpotPlot(xenium, group.by = "nCount_Xenium")
 #' }

--- a/R/RunCell2location.R
+++ b/R/RunCell2location.R
@@ -59,24 +59,28 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Official cell2location Human Lymph Node tutorial data:
-#' # https://cell2location.readthedocs.io/en/latest/notebooks/cell2location_tutorial.html
-#' reference <- h5ad_to_srt("reference_subset.h5ad")
-#' spatial <- h5ad_to_srt("spatial_subset.h5ad")
+#' data(visium_human_pancreas_sub)
+#' data(panc8_sub)
+#' spatial <- visium_human_pancreas_sub[, seq_len(120)]
+#' reference <- panc8_sub[, panc8_sub$celltype %in% c("ductal", "alpha", "beta")]
 #' spatial <- RunCell2location(
 #'   srt = spatial,
-#'   result_dir = "human_lymph_node_cell2location",
+#'   result_dir = tempfile("cell2location"),
 #'   reference = reference,
-#'   reference_label = "Subset",
-#'   reference_batch = "Sample",
-#'   spatial_batch = "sample",
+#'   reference_label = "celltype",
+#'   assay = "Spatial",
+#'   reference_assay = "RNA",
+#'   layer = "counts",
+#'   reference_layer = "counts",
 #'   N_cells_per_location = 30,
-#'   detection_alpha = 20
+#'   detection_alpha = 20,
+#'   reference_train_params = list(max_epochs = 2),
+#'   spatial_train_params = list(max_epochs = 2)
 #' )
 #' Cell2locationPlot(
 #'   spatial,
 #'   plot_type = "proportion",
-#'   cell_types = c("B_naive", "T_CD4+_naive", "FDC"),
+#'   cell_types = c("ductal", "alpha", "beta"),
 #'   overlay_image = FALSE,
 #'   coord.cols = c("x", "y")
 #' )
@@ -422,13 +426,23 @@ RunCell2location <- function(
 #' @export
 #'
 #' @examples
-#' \dontrun{
-#' # Result from the official Human Lymph Node example in RunCell2location().
-#' spatial <- readRDS("human_lymph_node_cell2location/official_human_lymph_node.rds")
-#' selected <- names(sort(
-#'   colMeans(spatial@tools$Cell2location$proportions),
-#'   decreasing = TRUE
-#' ))[1:6]
+#' data(visium_human_pancreas_sub)
+#' spatial <- visium_human_pancreas_sub[, seq_len(120)]
+#' cell2location_props <- data.frame(
+#'   Cell2location_prop_Ductal = seq(0.70, 0.20, length.out = ncol(spatial)),
+#'   Cell2location_prop_Endocrine = seq(0.20, 0.70, length.out = ncol(spatial)),
+#'   Cell2location_prop_Stromal = 0.10,
+#'   row.names = colnames(spatial)
+#' )
+#' cell2location_props <- cell2location_props / rowSums(cell2location_props)
+#' spatial <- Seurat::AddMetaData(spatial, cell2location_props)
+#' spatial@tools$Cell2location <- list(proportions = cell2location_props)
+#' spatial$Cell2location_dominant_type <- sub(
+#'   "^Cell2location_prop_",
+#'   "",
+#'   colnames(cell2location_props)[max.col(cell2location_props)]
+#' )
+#' selected <- names(sort(colMeans(cell2location_props), decreasing = TRUE))
 #' Cell2locationPlot(
 #'   spatial,
 #'   plot_type = "proportion",
@@ -443,7 +457,6 @@ RunCell2location <- function(
 #'   overlay_image = FALSE,
 #'   coord.cols = c("x", "y")
 #' )
-#' }
 Cell2locationPlot <- function(
   srt,
   plot_type = c("proportion", "abundance", "dominant", "pie"),

--- a/R/RunSCENICPlus.R
+++ b/R/RunSCENICPlus.R
@@ -121,7 +121,7 @@
 #' pancreas_sub <- RunSCENICPlus(
 #'   pancreas_sub,
 #'   backend = "python",
-#'   python_result_dir = "test/scenicplus"
+#'   python_result_dir = tempfile("scenicplus")
 #' )
 #' scenicplus_dot <- SCENICPlusPlot(
 #'   pancreas_sub,

--- a/R/RunscMalignantFinder.R
+++ b/R/RunscMalignantFinder.R
@@ -47,11 +47,12 @@
 #'
 #' @examplesIf FALSE
 #' data(pancreas_sub)
+#' # Requires scMalignantFinder pretrained model files (see ?RunscMalignantFinder).
 #' pancreas_sub <- RunscMalignantFinder(
 #'   pancreas_sub,
 #'   assay = "RNA",
 #'   layer = "counts",
-#'   pretrain_dir = "path/to/pretrained_model"
+#'   pretrain_dir = pretrain_dir
 #' )
 #' CellDimPlot(pancreas_sub, group.by = "malignancy_probability")
 RunscMalignantFinder <- function(
@@ -216,9 +217,11 @@ RunscMalignantFinder <- function(
 #' @export
 #'
 #' @examplesIf FALSE
-#' srt <- RunscMalignantRegion(
-#'   srt,
-#'   signature_gmt = "path/to/sc_malignant_deg.gmt",
+#' data(visium_human_pancreas_sub)
+#' # Requires scMalignantFinder resource file signature_gmt (see ?RunscMalignantRegion).
+#' spatial <- RunscMalignantRegion(
+#'   visium_human_pancreas_sub,
+#'   signature_gmt = signature_gmt,
 #'   spatial.cols = c("x", "y")
 #' )
 RunscMalignantRegion <- function(
@@ -420,9 +423,11 @@ RunscMalignantRegion <- function(
 #' @export
 #'
 #' @examplesIf FALSE
-#' srt <- RunscMalignantStates(
-#'   srt,
-#'   gene_sets = "path/to/Malignant_MPs.Gavish_2023.gmt"
+#' data(pancreas_sub)
+#' # Requires scMalignantFinder resource gene-set GMT (see ?RunscMalignantStates).
+#' pancreas_sub <- RunscMalignantStates(
+#'   pancreas_sub,
+#'   gene_sets = gene_sets
 #' )
 RunscMalignantStates <- function(
   srt = NULL,

--- a/R/SCENICPlot.R
+++ b/R/SCENICPlot.R
@@ -86,7 +86,7 @@
 #'   pancreas_sub,
 #'   species = "Mus_musculus",
 #'   backend = "cpp",
-#'   work_dir = "test/scenic"
+#'   work_dir = tempfile("scenic")
 #' )
 #' scenic_rss <- SCENICPlot(pancreas_sub, group.by = "CellType", plot_type = "rss_rank")
 #' example_tfs <- unique(scenic_rss$top_table$TF)[1:3]

--- a/R/SCENICPlusPlot.R
+++ b/R/SCENICPlusPlot.R
@@ -25,7 +25,7 @@
 #' pancreas_sub <- RunSCENICPlus(
 #'   pancreas_sub,
 #'   backend = "python",
-#'   python_result_dir = "test/scenicplus"
+#'   python_result_dir = tempfile("scenicplus")
 #' )
 #' scenicplus_dot <- SCENICPlusPlot(pancreas_sub, group.by = "CellType")
 #' example_tfs <- unique(scenicplus_dot$top_table$TF)[1:3]

--- a/man/Cell2locationPlot.Rd
+++ b/man/Cell2locationPlot.Rd
@@ -43,13 +43,23 @@ A \code{ggplot}, \code{patchwork}, or list of plots.
 Plot cell2location spatial results
 }
 \examples{
-\dontrun{
-# Result from the official Human Lymph Node example in RunCell2location().
-spatial <- readRDS("human_lymph_node_cell2location/official_human_lymph_node.rds")
-selected <- names(sort(
-  colMeans(spatial@tools$Cell2location$proportions),
-  decreasing = TRUE
-))[1:6]
+data(visium_human_pancreas_sub)
+spatial <- visium_human_pancreas_sub[, seq_len(120)]
+cell2location_props <- data.frame(
+  Cell2location_prop_Ductal = seq(0.70, 0.20, length.out = ncol(spatial)),
+  Cell2location_prop_Endocrine = seq(0.20, 0.70, length.out = ncol(spatial)),
+  Cell2location_prop_Stromal = 0.10,
+  row.names = colnames(spatial)
+)
+cell2location_props <- cell2location_props / rowSums(cell2location_props)
+spatial <- Seurat::AddMetaData(spatial, cell2location_props)
+spatial@tools$Cell2location <- list(proportions = cell2location_props)
+spatial$Cell2location_dominant_type <- sub(
+  "^Cell2location_prop_",
+  "",
+  colnames(cell2location_props)[max.col(cell2location_props)]
+)
+selected <- names(sort(colMeans(cell2location_props), decreasing = TRUE))
 Cell2locationPlot(
   spatial,
   plot_type = "proportion",
@@ -64,5 +74,4 @@ Cell2locationPlot(
   overlay_image = FALSE,
   coord.cols = c("x", "y")
 )
-}
 }

--- a/man/LoadExternalDataset.Rd
+++ b/man/LoadExternalDataset.Rd
@@ -43,6 +43,9 @@ sha256 checksum when the manifest provides them, cache it under
 }
 \examples{
 \dontrun{
+data(visium_human_pancreas_sub)
+SpatialSpotPlot(visium_human_pancreas_sub, group.by = "coda_label")
+# Optional remote datasets from mengxu98/datasets:
 xenium <- LoadExternalDataset("xenium_human_pancreas_sub", collection = "Xenium")
 SpatialSpotPlot(xenium, group.by = "nCount_Xenium")
 }

--- a/man/RunCell2location.Rd
+++ b/man/RunCell2location.Rd
@@ -122,24 +122,28 @@ model implemented by this function.
 
 \examples{
 \dontrun{
-# Official cell2location Human Lymph Node tutorial data:
-# https://cell2location.readthedocs.io/en/latest/notebooks/cell2location_tutorial.html
-reference <- h5ad_to_srt("reference_subset.h5ad")
-spatial <- h5ad_to_srt("spatial_subset.h5ad")
+data(visium_human_pancreas_sub)
+data(panc8_sub)
+spatial <- visium_human_pancreas_sub[, seq_len(120)]
+reference <- panc8_sub[, panc8_sub$celltype %in% c("ductal", "alpha", "beta")]
 spatial <- RunCell2location(
   srt = spatial,
-  result_dir = "human_lymph_node_cell2location",
+  result_dir = tempfile("cell2location"),
   reference = reference,
-  reference_label = "Subset",
-  reference_batch = "Sample",
-  spatial_batch = "sample",
+  reference_label = "celltype",
+  assay = "Spatial",
+  reference_assay = "RNA",
+  layer = "counts",
+  reference_layer = "counts",
   N_cells_per_location = 30,
-  detection_alpha = 20
+  detection_alpha = 20,
+  reference_train_params = list(max_epochs = 2),
+  spatial_train_params = list(max_epochs = 2)
 )
 Cell2locationPlot(
   spatial,
   plot_type = "proportion",
-  cell_types = c("B_naive", "T_CD4+_naive", "FDC"),
+  cell_types = c("ductal", "alpha", "beta"),
   overlay_image = FALSE,
   coord.cols = c("x", "y")
 )

--- a/man/RunSCENICPlus.Rd
+++ b/man/RunSCENICPlus.Rd
@@ -223,7 +223,7 @@ pancreas_sub <- RunStandardWorkflow(pancreas_sub)
 pancreas_sub <- RunSCENICPlus(
   pancreas_sub,
   backend = "python",
-  python_result_dir = "test/scenicplus"
+  python_result_dir = tempfile("scenicplus")
 )
 scenicplus_dot <- SCENICPlusPlot(
   pancreas_sub,

--- a/man/RunscMalignantFinder.Rd
+++ b/man/RunscMalignantFinder.Rd
@@ -79,11 +79,12 @@ files are not bundled with \code{scop}; provide a directory containing
 \examples{
 \dontshow{if (FALSE) withAutoprint(\{ # examplesIf}
 data(pancreas_sub)
+# Requires scMalignantFinder pretrained model files (see ?RunscMalignantFinder).
 pancreas_sub <- RunscMalignantFinder(
   pancreas_sub,
   assay = "RNA",
   layer = "counts",
-  pretrain_dir = "path/to/pretrained_model"
+  pretrain_dir = pretrain_dir
 )
 CellDimPlot(pancreas_sub, group.by = "malignancy_probability")
 \dontshow{\}) # examplesIf}

--- a/man/RunscMalignantRegion.Rd
+++ b/man/RunscMalignantRegion.Rd
@@ -93,9 +93,11 @@ object does not already contain spatial coordinates.
 }
 \examples{
 \dontshow{if (FALSE) withAutoprint(\{ # examplesIf}
-srt <- RunscMalignantRegion(
-  srt,
-  signature_gmt = "path/to/sc_malignant_deg.gmt",
+data(visium_human_pancreas_sub)
+# Requires scMalignantFinder resource file signature_gmt (see ?RunscMalignantRegion).
+spatial <- RunscMalignantRegion(
+  visium_human_pancreas_sub,
+  signature_gmt = signature_gmt,
   spatial.cols = c("x", "y")
 )
 \dontshow{\}) # examplesIf}

--- a/man/RunscMalignantStates.Rd
+++ b/man/RunscMalignantStates.Rd
@@ -64,9 +64,11 @@ and append the resulting activity scores to Seurat metadata.
 }
 \examples{
 \dontshow{if (FALSE) withAutoprint(\{ # examplesIf}
-srt <- RunscMalignantStates(
-  srt,
-  gene_sets = "path/to/Malignant_MPs.Gavish_2023.gmt"
+data(pancreas_sub)
+# Requires scMalignantFinder resource gene-set GMT (see ?RunscMalignantStates).
+pancreas_sub <- RunscMalignantStates(
+  pancreas_sub,
+  gene_sets = gene_sets
 )
 \dontshow{\}) # examplesIf}
 }

--- a/man/SCENICPlot.Rd
+++ b/man/SCENICPlot.Rd
@@ -220,7 +220,7 @@ pancreas_sub <- RunSCENIC(
   pancreas_sub,
   species = "Mus_musculus",
   backend = "cpp",
-  work_dir = "test/scenic"
+  work_dir = tempfile("scenic")
 )
 scenic_rss <- SCENICPlot(pancreas_sub, group.by = "CellType", plot_type = "rss_rank")
 example_tfs <- unique(scenic_rss$top_table$TF)[1:3]

--- a/man/SCENICPlusPlot.Rd
+++ b/man/SCENICPlusPlot.Rd
@@ -43,7 +43,7 @@ pancreas_sub <- RunStandardWorkflow(pancreas_sub)
 pancreas_sub <- RunSCENICPlus(
   pancreas_sub,
   backend = "python",
-  python_result_dir = "test/scenicplus"
+  python_result_dir = tempfile("scenicplus")
 )
 scenicplus_dot <- SCENICPlusPlot(pancreas_sub, group.by = "CellType")
 example_tfs <- unique(scenicplus_dot$top_table$TF)[1:3]

--- a/man/adata_to_srt.Rd
+++ b/man/adata_to_srt.Rd
@@ -31,8 +31,10 @@ srt <- adata_to_srt(adata)
 srt
 
 # Or convert a h5ad file to Seurat object
+h5ad_path <- tempfile(fileext = ".h5ad")
+srt_to_h5ad(pancreas_sub, h5ad_path)
 sc <- reticulate::import("scanpy")
-adata <- sc$read_h5ad("pancreas.h5ad")
+adata <- sc$read_h5ad(h5ad_path)
 srt <- adata_to_srt(adata)
 srt
 }

--- a/man/h5ad_to_srt.Rd
+++ b/man/h5ad_to_srt.Rd
@@ -25,7 +25,10 @@ Read an \code{.h5ad} file and convert to a \code{Seurat}
 }
 \examples{
 \dontrun{
-srt <- h5ad_to_srt("path/to/data.h5ad")
+data(pancreas_sub)
+h5ad_path <- tempfile(fileext = ".h5ad")
+srt_to_h5ad(pancreas_sub, h5ad_path)
+srt <- h5ad_to_srt(h5ad_path)
 srt
 }
 }

--- a/man/loom_to_adata.Rd
+++ b/man/loom_to_adata.Rd
@@ -28,7 +28,11 @@ Python.
 }
 \examples{
 \dontrun{
-adata <- loom_to_adata("path/to/data.loom")
+data(pancreas_sub)
+adata <- srt_to_adata(pancreas_sub)
+loom_path <- tempfile(fileext = ".loom")
+adata$write_loom(loom_path, write_obsm_varm = TRUE)
+adata <- loom_to_adata(loom_path)
 adata
 }
 }

--- a/man/loom_to_srt.Rd
+++ b/man/loom_to_srt.Rd
@@ -39,7 +39,11 @@ as additional assays, which is useful for velocity-style loom files with
 }
 \examples{
 \dontrun{
-srt <- loom_to_srt("path/to/data.loom")
+data(pancreas_sub)
+adata <- srt_to_adata(pancreas_sub)
+loom_path <- tempfile(fileext = ".loom")
+adata$write_loom(loom_path, write_obsm_varm = TRUE)
+srt <- loom_to_srt(loom_path)
 srt
 }
 }

--- a/man/srt_to_adata.Rd
+++ b/man/srt_to_adata.Rd
@@ -64,13 +64,10 @@ adata <- srt_to_adata(pancreas_sub)
 adata
 
 # Or save as a h5ad/loom file
-adata$write_h5ad(
-  "pancreas_sub.h5ad"
-)
-adata$write_loom(
-  "pancreas_sub.loom",
-  write_obsm_varm = TRUE
-)
+h5ad_path <- tempfile(fileext = ".h5ad")
+loom_path <- tempfile(fileext = ".loom")
+adata$write_h5ad(h5ad_path)
+adata$write_loom(loom_path, write_obsm_varm = TRUE)
 }
 }
 \seealso{

--- a/man/srt_to_h5ad.Rd
+++ b/man/srt_to_h5ad.Rd
@@ -66,7 +66,8 @@ Convert a Seurat object to an \code{.h5ad} file
 \examples{
 \dontrun{
 data(pancreas_sub)
-srt_to_h5ad(pancreas_sub, "pancreas_sub.h5ad")
+h5ad_path <- tempfile(fileext = ".h5ad")
+srt_to_h5ad(pancreas_sub, h5ad_path)
 }
 }
 \seealso{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces documentation examples that referenced external files (local `.rds`/`.h5ad` paths, `path/to/...` placeholders, repo `test/` directories) with bundled package datasets and reproducible patterns.

## Changes

- **`RunCell2location` / `Cell2locationPlot`**: use `visium_human_pancreas_sub` + `panc8_sub`; plot example uses mock stored proportions (same pattern as `RunRCTD`/`RunSPOTlight`).
- **`DataConvert` (`h5ad_to_srt`, `loom_to_*`, `srt_to_h5ad`, etc.)**: round-trip examples via `data(pancreas_sub)` + `tempfile()`.
- **`RunSCENIC` / `RunSCENICPlus` / `SCENICPlusPlot`**: `tempfile()` for output directories instead of `test/scenic*`.
- **`RunscMalignantFinder*`**: remove fake `path/to/...` paths; show built-in data and document required external resource variables.
- **`LoadExternalDataset`**: show bundled `visium_human_pancreas_sub` first; keep remote download as optional `\dontrun{}` follow-up.

## Notes

- Left deployment/config placeholders (e.g. `path/to/conda`, `path/to/scop_env`) and dataset-creation `\dontrun{}` blocks in `data.R` unchanged.
- Synced corresponding `man/*.Rd` files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a017ac-be4e-7fe2-8bf0-26aaf0da72ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a017ac-be4e-7fe2-8bf0-26aaf0da72ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

