### PR TITLE
Extend RunDorothea network inputs and CollecTRI support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
   * `RunSpatialIntegration(PRECAST)` writes the raw coordinates expected by `CreatePRECASTObject`.
   * `RunLIANA()` recognizes `logfc_comb` (and other liana method score columns) as the interaction score.
   * Exported `theme_scop` / `theme_spatial` are listed in the pkgdown reference index; the `theme_scop` alias test compares function equality rather than identity so installed-package checks pass.
+  * `DorotheaPlot(plot_type = "volcano")` plots every tested TF, caps Wilcoxon underflow on the y-axis, colors points by direction, and labels significant TFs. `"targets"` labels only significant genes so leader lines no longer pile at x = 0.
 * **removed**:
   * The `CaSpER` branch of `RunCNV()` is removed: `runCaSpER()` segfaults deterministically on R >= 4.5 (HMM `manualSegment`, even on 50 cells), upstream is unmaintained since 2019, and its Bioconductor dependency set is archived. `RunCNV()` now supports `copykat`, `fastCNV`, `scevan`, `infercnv`, and `numbat`.
 * **changed**:

--- a/R/DorotheaPlot.R
+++ b/R/DorotheaPlot.R
@@ -111,6 +111,15 @@
 #'   top_n = 20
 #' )
 #'
+#' DorotheaPlot(
+#'   pancreas_sub,
+#'   group.by = "CellType",
+#'   group1 = "Endocrine",
+#'   group2 = "Ductal",
+#'   plot_type = "volcano",
+#'   top_n = 20
+#' )
+#'
 #' ht <- DorotheaPlot(
 #'   pancreas_sub,
 #'   group.by = "CellType",

--- a/R/DorotheaPlot.R
+++ b/R/DorotheaPlot.R
@@ -26,12 +26,14 @@
 #' @param tool_name Name of the `srt@tools` entry created by [RunDorothea()].
 #' @param assay_name Assay used for `"heatmap"`, `"dim"`, and `"stat"`. If
 #' `NULL`, the assay stored by [RunDorothea()] is used, or `"dorothea"`.
-#' @param features TFs to plot. If `NULL`, comparison plots use the top
-#' `top_n` TFs, heatmaps and `"stat"` use the `top_n` most variable TFs,
-#' `"dim"` uses TFs present in both activity and expression assays, and
-#' `"targets"` uses the TF with the largest absolute activity difference.
-#' @param top_n Number of TFs to show when `features = NULL`. Set `NULL` to
-#' show all tested TFs.
+#' @param features TFs to plot. If `NULL`, `"bar"`/`"lollipop"` use the top
+#' `top_n` TFs, `"volcano"` shows all tested TFs, heatmaps and `"stat"` use
+#' the `top_n` most variable TFs, `"dim"` uses TFs present in both activity
+#' and expression assays, and `"targets"` uses the TF with the largest
+#' absolute activity difference.
+#' @param top_n Number of TFs to show when `features = NULL`. Ignored for
+#' `"volcano"`, which always plots every tested TF. Set `NULL` to show all
+#' tested TFs in other comparison plots.
 #' @param test.use Statistical test used for each TF or target gene in
 #' comparison plots.
 #' @param p.adjust.method Method passed to [stats::p.adjust].
@@ -61,7 +63,8 @@
 #' expression in `"dim"` and for target genes in `"targets"`.
 #' @param stat_plot_type Distribution plot type passed to [FeatureStatPlot()]
 #' when `plot_type = "stat"`.
-#' @param nlabel Number of target genes labeled in `"targets"` plots.
+#' @param nlabel Number of significant TFs labeled in `"volcano"` plots, or
+#' significant target genes labeled in `"targets"` plots.
 #' @param reduction Reduction used by `"dim"` plots. If `NULL`, the default
 #' reduction of `srt` is used.
 #' @param bar_width Width of bars in `"bar"` plots.
@@ -116,8 +119,7 @@
 #'   group.by = "CellType",
 #'   group1 = "Endocrine",
 #'   group2 = "Ductal",
-#'   plot_type = "volcano",
-#'   top_n = 20
+#'   plot_type = "volcano"
 #' )
 #'
 #' ht <- DorotheaPlot(
@@ -420,7 +422,7 @@ DorotheaPlot <- function(
     group1 = group1,
     group2 = group2,
     features = features,
-    top_n = top_n,
+    top_n = if (identical(plot_type, "volcano")) NULL else top_n,
     test.use = test.use,
     p.adjust.method = p.adjust.method,
     rank.by = rank.by,
@@ -486,6 +488,7 @@ DorotheaPlot <- function(
       palette = palette,
       palcolor = palcolor,
       point_size = point_size,
+      nlabel = nlabel,
       title = title,
       xlab = xlab,
       ylab = ylab,
@@ -808,12 +811,76 @@ dorothea_plot_lollipop <- function(
   p
 }
 
+dorothea_volcano_y <- function(stat_df) {
+  y <- as.numeric(stat_df$neglog10_p_val_adj)
+  y[!is.finite(y)] <- 0
+  finite <- y[is.finite(stat_df$p_val_adj) & stat_df$p_val_adj > 0]
+  if (length(finite) == 0L) {
+    cap <- max(y, na.rm = TRUE)
+    if (!is.finite(cap) || cap <= 0) {
+      cap <- 10
+    }
+    return(pmin(y, cap))
+  }
+  cap <- 10 * ceiling(max(finite) / 10)
+  if (!is.finite(cap) || cap <= 0) {
+    cap <- max(finite)
+  }
+  pmin(y, cap)
+}
+
+dorothea_volcano_direction <- function(stat_df, cutoff) {
+  direction <- rep("NS", nrow(stat_df))
+  sig <- is.finite(stat_df$p_val_adj) & stat_df$p_val_adj <= cutoff
+  direction[sig & is.finite(stat_df$logFC) & stat_df$logFC > 0] <- "Up"
+  direction[sig & is.finite(stat_df$logFC) & stat_df$logFC < 0] <- "Down"
+  factor(direction, levels = c("Down", "NS", "Up"))
+}
+
+dorothea_volcano_colors <- function(palette, palcolor) {
+  div <- unname(dorothea_diverging_colors(palette, palcolor))
+  if (length(div) < 2L) {
+    div <- c("#2166AC", "#B2182B")
+  }
+  c(Down = div[[1L]], NS = "grey75", Up = div[[length(div)]])
+}
+
+dorothea_volcano_label_df <- function(df, nlabel, y_col, sig) {
+  n_sig <- sum(sig, na.rm = TRUE)
+  nlabel <- min(as.integer(nlabel), n_sig, nrow(df))
+  if (!is.finite(nlabel) || nlabel <= 0L) {
+    return(df[integer(), , drop = FALSE])
+  }
+  rank_score <- abs(df$logFC) * df[[y_col]]
+  rank_score[!is.finite(rank_score) | !sig] <- -Inf
+  df[order(-rank_score), , drop = FALSE][seq_len(nlabel), , drop = FALSE]
+}
+
+dorothea_volcano_repel <- function(label_df, label_col) {
+  ggrepel::geom_text_repel(
+    data = label_df,
+    ggplot2::aes(
+      x = .data[["logFC"]],
+      y = .data[["y_plot"]],
+      label = .data[[label_col]]
+    ),
+    inherit.aes = FALSE,
+    min.segment.length = 0.2,
+    max.overlaps = Inf,
+    segment.colour = "grey40",
+    size = 3.2,
+    seed = 42,
+    show.legend = FALSE
+  )
+}
+
 dorothea_plot_volcano <- function(
   stat_df,
   padjustCutoff,
   palette,
   palcolor,
   point_size,
+  nlabel,
   title,
   xlab,
   ylab,
@@ -823,31 +890,22 @@ dorothea_plot_volcano <- function(
   legend.direction
 ) {
   cutoff <- padjustCutoff %||% 0.05
-  stat_df$significant <- ifelse(
-    is.finite(stat_df$p_val_adj) & stat_df$p_val_adj <= cutoff,
-    "FDR",
-    "NS"
+  stat_df$y_plot <- dorothea_volcano_y(stat_df)
+  stat_df$direction <- dorothea_volcano_direction(stat_df, cutoff)
+  cols <- dorothea_volcano_colors(palette, palcolor)
+  pt_size <- if (nrow(stat_df) >= 50L) min(point_size, 1.8) else point_size
+  label_df <- dorothea_volcano_label_df(
+    df = stat_df,
+    nlabel = nlabel,
+    y_col = "y_plot",
+    sig = stat_df$direction != "NS"
   )
-  cols <- palette_colors(
-    c("NS", "FDR"),
-    palette = palette,
-    palcolor = palcolor
-  )
-  if (is.null(names(cols)) || !all(c("NS", "FDR") %in% names(cols))) {
-    cols <- unname(cols)[seq_len(min(2L, length(cols)))]
-    if (length(cols) < 2L) {
-      cols <- rep(cols, length.out = 2L)
-    }
-    names(cols) <- c("NS", "FDR")
-  } else {
-    cols <- cols[c("NS", "FDR")]
-  }
-  ggplot2::ggplot(
+  p <- ggplot2::ggplot(
     stat_df,
     ggplot2::aes(
       x = .data[["logFC"]],
-      y = .data[["neglog10_p_val_adj"]],
-      color = .data[["significant"]]
+      y = .data[["y_plot"]],
+      color = .data[["direction"]]
     )
   ) +
     ggplot2::geom_vline(xintercept = 0, color = "grey75", linewidth = 0.35) +
@@ -857,8 +915,12 @@ dorothea_plot_volcano <- function(
       linewidth = 0.35,
       linetype = 2
     ) +
-    ggplot2::geom_point(size = point_size, alpha = 0.85) +
-    ggplot2::scale_color_manual(values = cols, drop = FALSE) +
+    ggplot2::geom_point(size = pt_size, alpha = 0.8) +
+    ggplot2::scale_color_manual(
+      values = cols,
+      breaks = names(cols),
+      drop = FALSE
+    ) +
     ggplot2::labs(
       title = title,
       x = xlab %||% paste0(unique(stat_df$group1), " - ", unique(stat_df$group2)),
@@ -871,6 +933,10 @@ dorothea_plot_volcano <- function(
       legend.position = legend.position,
       legend.direction = legend.direction
     )
+  if (nrow(label_df) > 0L) {
+    p <- p + dorothea_volcano_repel(label_df, "TF")
+  }
+  p
 }
 
 dorothea_plot_heatmap <- function(
@@ -1380,18 +1446,18 @@ dorothea_plot_targets <- function(
     cols <- cols[support_levels]
   }
   theme_use <- apply_plot_theme(theme_use, theme_args)
-  label_n <- min(nlabel, nrow(plot_df))
-  label_df <- plot_df[integer(), , drop = FALSE]
-  if (label_n > 0L) {
-    rank_score <- abs(plot_df$logFC) * plot_df$neglog10_p_val_adj
-    rank_score[!is.finite(rank_score)] <- 0
-    label_df <- plot_df[order(-rank_score), , drop = FALSE][seq_len(label_n), , drop = FALSE]
-  }
+  plot_df$y_plot <- dorothea_volcano_y(plot_df)
+  label_df <- dorothea_volcano_label_df(
+    df = plot_df,
+    nlabel = nlabel,
+    y_col = "y_plot",
+    sig = plot_df$support != "NS"
+  )
   p <- ggplot2::ggplot(
     plot_df,
     ggplot2::aes(
       x = .data[["logFC"]],
-      y = .data[["neglog10_p_val_adj"]],
+      y = .data[["y_plot"]],
       color = .data[["support"]],
       size = abs(.data[["mor"]])
     )
@@ -1422,16 +1488,7 @@ dorothea_plot_targets <- function(
       legend.direction = legend.direction
     )
   if (nrow(label_df) > 0L) {
-    p <- p +
-      ggrepel::geom_text_repel(
-        data = label_df,
-        ggplot2::aes(label = .data[["target_expr"]]),
-        min.segment.length = 0,
-        max.overlaps = 100,
-        segment.colour = "grey40",
-        size = 3.2,
-        show.legend = FALSE
-      )
+    p <- p + dorothea_volcano_repel(label_df, "target_expr")
   }
   list(plot = p, data = plot_df)
 }

--- a/R/DorotheaPlot.R
+++ b/R/DorotheaPlot.R
@@ -1,7 +1,7 @@
-#' @title Plot DoRothEA transcription factor activity
+#' @title Plot transcription factor activity
 #'
 #' @description
-#' Visualize DoRothEA TF activity stored by [RunDorothea()]. Comparison plots
+#' Visualize TF activity stored by [RunDorothea()]. Comparison plots
 #' (`"bar"`, `"lollipop"`, `"volcano"`) test two groups and show the mean
 #' activity difference `group1 - group2`. `"heatmap"` uses [GroupHeatmap()]
 #' to summarize activity across all groups in `group.by`. `"dim"` compares TF
@@ -215,7 +215,7 @@ DorotheaPlot <- function(
     !tool_name %in% names(srt@tools) || is.null(srt@tools[[tool_name]]$scores)
   ) {
     log_message(
-      "No DoRothEA scores found in {.code srt@tools[[{tool_name}]]$scores}",
+      "No TF activity scores found in {.code srt@tools[[{tool_name}]]$scores}",
       message_type = "error"
     )
   }
@@ -268,6 +268,15 @@ DorotheaPlot <- function(
   nlabel <- as.integer(nlabel)
 
   scores <- as.matrix(srt@tools[[tool_name]]$scores)
+  network_info <- srt@tools[[tool_name]]$network_info
+  if (is.null(network_info)) {
+    network_info <- list(
+      source = "dorothea",
+      label = "DoRothEA",
+      signed = TRUE
+    )
+  }
+  network_label <- network_info$label %||% "DoRothEA"
   assay_name <- assay_name %||%
     srt@tools[[tool_name]]$parameters$assay_name %||%
     "dorothea"
@@ -288,6 +297,7 @@ DorotheaPlot <- function(
       group_palcolor = group_palcolor,
       heatmap_args = heatmap_args,
       title = title,
+      network_label = network_label,
       verbose = verbose
     )
     if (isTRUE(return_data)) {
@@ -321,6 +331,7 @@ DorotheaPlot <- function(
       legend.direction = legend.direction,
       dim_args = dim_args,
       title = title,
+      network_label = network_label,
       verbose = verbose
     )
     if (isTRUE(return_data)) {
@@ -348,6 +359,7 @@ DorotheaPlot <- function(
       title = title,
       ylab = ylab,
       stat_args = stat_args,
+      network_label = network_label,
       verbose = verbose
     )
     if (isTRUE(return_data)) {
@@ -383,6 +395,7 @@ DorotheaPlot <- function(
       aspect.ratio = aspect.ratio,
       legend.position = legend.position,
       legend.direction = legend.direction,
+      network_info = network_info,
       verbose = verbose
     )
     if (isTRUE(return_data)) {
@@ -404,6 +417,7 @@ DorotheaPlot <- function(
     rank.by = rank.by,
     sort.by = sort.by,
     p_floor = p_floor,
+    network_label = network_label,
     verbose = verbose
   )
   if (isTRUE(flip) && plot_type %in% c("bar", "lollipop")) {
@@ -492,7 +506,8 @@ dorothea_compare_activity <- function(
   rank.by,
   sort.by,
   p_floor,
-  verbose
+  verbose,
+  network_label = "DoRothEA"
 ) {
   if (
     length(group1) != 1L ||
@@ -510,7 +525,7 @@ dorothea_compare_activity <- function(
   cells <- cells[groups[cells] %in% c(group1, group2)]
   if (length(cells) == 0L) {
     log_message(
-      "No cells from {.val {group1}} or {.val {group2}} are shared between DoRothEA scores and metadata",
+      "No cells from {.val {group1}} or {.val {group2}} are shared between {.val {network_label}} scores and metadata",
       message_type = "error"
     )
   }
@@ -531,7 +546,7 @@ dorothea_compare_activity <- function(
     missing_features <- setdiff(features, rownames(scores))
     if (length(missing_features) > 0L) {
       log_message(
-        "Dropping TFs not found in DoRothEA scores: {.val {missing_features}}",
+        "Dropping TFs not found in {.val {network_label}} scores: {.val {missing_features}}",
         message_type = "warning",
         verbose = verbose
       )
@@ -546,7 +561,7 @@ dorothea_compare_activity <- function(
   }
 
   log_message(
-    "Compare DoRothEA TF activity: {.val {group1}} vs {.val {group2}}",
+    "Compare {.val {network_label}} TF activity: {.val {group1}} vs {.val {group2}}",
     verbose = verbose
   )
   mat1 <- scores[features, cells1, drop = FALSE]
@@ -863,7 +878,8 @@ dorothea_plot_heatmap <- function(
   group_palcolor,
   heatmap_args,
   title,
-  verbose
+  verbose,
+  network_label = "DoRothEA"
 ) {
   features <- dorothea_resolve_features(
     scores = scores,
@@ -881,7 +897,7 @@ dorothea_plot_heatmap <- function(
   }
 
   log_message(
-    "Draw DoRothEA TF activity heatmap for {.val {length(features)}} TFs",
+    "Draw {.val {network_label}} TF activity heatmap for {.val {length(features)}} TFs",
     verbose = verbose
   )
   args <- list(
@@ -902,7 +918,7 @@ dorothea_plot_heatmap <- function(
     show_column_names = TRUE,
     cluster_rows = TRUE,
     cluster_columns = FALSE,
-    column_title = title %||% "DoRothEA TF activity",
+    column_title = title %||% paste(network_label, "TF activity"),
     heatmap_palette = heatmap_palette,
     heatmap_palcolor = heatmap_palcolor,
     group_palette = group_palette,
@@ -1005,7 +1021,8 @@ dorothea_plot_dim <- function(
   legend.direction,
   dim_args,
   title,
-  verbose
+  verbose,
+  network_label = "DoRothEA"
 ) {
   expr_names <- tryCatch(
     rownames(srt[[expression_assay]]),
@@ -1033,7 +1050,7 @@ dorothea_plot_dim <- function(
   srt <- dorothea_ensure_assay(srt, scores, assay_name)
 
   log_message(
-    "Draw DoRothEA embedding plots for {.val {length(features)}} TFs",
+    "Draw {.val {network_label}} embedding plots for {.val {length(features)}} TFs",
     verbose = verbose
   )
 
@@ -1145,7 +1162,8 @@ dorothea_plot_stat <- function(
   title,
   ylab,
   stat_args,
-  verbose
+  verbose,
+  network_label = "DoRothEA"
 ) {
   features <- dorothea_resolve_features(
     scores = scores,
@@ -1155,7 +1173,7 @@ dorothea_plot_stat <- function(
   )
   srt <- dorothea_ensure_assay(srt, scores, assay_name)
   log_message(
-    "Draw DoRothEA activity distributions for {.val {length(features)}} TFs",
+    "Draw {.val {network_label}} activity distributions for {.val {length(features)}} TFs",
     verbose = verbose
   )
   args <- list(
@@ -1207,12 +1225,15 @@ dorothea_plot_targets <- function(
   aspect.ratio,
   legend.position,
   legend.direction,
+  network_info,
   verbose
 ) {
   regulons <- srt@tools[[tool_name]]$regulons
+  network_label <- network_info$label %||% "DoRothEA"
+  signed_network <- !identical(network_info$signed, FALSE)
   if (is.null(regulons) || !"tf" %in% colnames(regulons)) {
     log_message(
-      "No DoRothEA regulons found in {.code srt@tools[[{tool_name}]]$regulons}. Re-run {.fn RunDorothea}.",
+      "No regulon network found in {.code srt@tools[[{tool_name}]]$regulons}. Re-run {.fn RunDorothea}.",
       message_type = "error"
     )
   }
@@ -1230,6 +1251,7 @@ dorothea_plot_targets <- function(
       rank.by = "abs_logFC",
       sort.by = "abs_logFC",
       p_floor = p_floor,
+      network_label = network_label,
       verbose = FALSE
     )
     features <- as.character(stat_df$TF[[1L]])
@@ -1244,7 +1266,7 @@ dorothea_plot_targets <- function(
   tf_use <- dorothea_match_feature(tf, unique(as.character(regulons$tf)))
   if (is.na(tf_use)) {
     log_message(
-      "TF {.val {tf}} is not present in the stored DoRothEA regulons",
+      "TF {.val {tf}} is not present in the stored {.val {network_label}} regulons",
       message_type = "error"
     )
   }
@@ -1285,7 +1307,7 @@ dorothea_plot_targets <- function(
   net$target_expr <- unname(target_map[keep])
   target_mat <- expr[unique(net$target_expr), , drop = FALSE]
   log_message(
-    "Draw DoRothEA regulon-target volcano for {.val {tf_use}} ({.val {nrow(net)}} targets)",
+    "Draw {.val {network_label}} regulon-target volcano for {.val {tf_use}} ({.val {nrow(net)}} targets)",
     verbose = verbose
   )
   target_stat <- dorothea_compare_activity(
@@ -1301,6 +1323,7 @@ dorothea_plot_targets <- function(
     rank.by = "abs_logFC",
     sort.by = "abs_logFC",
     p_floor = p_floor,
+    network_label = network_label,
     verbose = FALSE
   )
   plot_df <- merge(
@@ -1312,28 +1335,40 @@ dorothea_plot_targets <- function(
     sort = FALSE
   )
   plot_df$mor <- as.numeric(plot_df$mor)
-  plot_df$support <- ifelse(
-    is.finite(plot_df$logFC) & is.finite(plot_df$mor) & plot_df$mor != 0,
-    ifelse(sign(plot_df$mor) * sign(plot_df$logFC) > 0, "Support", "Oppose"),
-    "NS"
-  )
+  if (signed_network) {
+    plot_df$support <- ifelse(
+      is.finite(plot_df$logFC) & is.finite(plot_df$mor) & plot_df$mor != 0,
+      ifelse(sign(plot_df$mor) * sign(plot_df$logFC) > 0, "Support", "Oppose"),
+      "NS"
+    )
+    support_levels <- c("Oppose", "NS", "Support")
+    size_title <- "|MoR|"
+  } else {
+    plot_df$support <- ifelse(
+      is.finite(plot_df$logFC),
+      ifelse(plot_df$logFC > 0, "Higher group1", "Higher group2"),
+      "NS"
+    )
+    support_levels <- c("Higher group2", "NS", "Higher group1")
+    size_title <- "Importance"
+  }
   cutoff <- padjustCutoff %||% 0.05
   plot_df$support[
     !is.finite(plot_df$p_val_adj) | plot_df$p_val_adj > cutoff
   ] <- "NS"
   cols <- palette_colors(
-    c("Oppose", "NS", "Support"),
+    support_levels,
     palette = palette,
     palcolor = palcolor
   )
-  if (is.null(names(cols)) || !all(c("Oppose", "NS", "Support") %in% names(cols))) {
+  if (is.null(names(cols)) || !all(support_levels %in% names(cols))) {
     cols <- unname(cols)[seq_len(min(3L, length(cols)))]
     if (length(cols) < 3L) {
       cols <- rep(cols, length.out = 3L)
     }
-    names(cols) <- c("Oppose", "NS", "Support")
+    names(cols) <- support_levels
   } else {
-    cols <- cols[c("Oppose", "NS", "Support")]
+    cols <- cols[support_levels]
   }
   theme_use <- apply_plot_theme(theme_use, theme_args)
   label_n <- min(nlabel, nrow(plot_df))
@@ -1361,9 +1396,9 @@ dorothea_plot_targets <- function(
     ) +
     ggplot2::geom_point(alpha = 0.85) +
     ggplot2::scale_color_manual(values = cols, drop = FALSE, name = NULL) +
-    ggplot2::scale_size_continuous(name = "|MoR|", range = c(1.6, max(point_size, 1.6) + 2)) +
+    ggplot2::scale_size_continuous(name = size_title, range = c(1.6, max(point_size, 1.6) + 2)) +
     ggplot2::labs(
-      title = title %||% paste0(tf_use, " targets (", group1, " vs. ", group2, ")"),
+      title = title %||% paste0(network_label, ": ", tf_use, " targets (", group1, " vs. ", group2, ")"),
       x = xlab %||% paste0(group1, " - ", group2),
       y = ylab %||% "-log10(adjusted p-value)"
     ) +

--- a/R/RunDorothea.R
+++ b/R/RunDorothea.R
@@ -1,13 +1,13 @@
-#' @title Run DoRothEA transcription factor activity inference
+#' @title Run transcription factor activity inference
 #'
 #' @md
 #' @inheritParams RunStandardWorkflow
 #' @inheritParams thisutils::log_message
 #' @param layer Assay layer used as the expression matrix.
-#' @param species Species used to select bundled DoRothEA regulons. DoRothEA
-#' only provides human and mouse regulons. For other input species, set
-#' `input_species` and project expression values to this regulon species through
-#' homologous gene conversion before activity inference.
+#' @param species Species used to select the regulatory network. The bundled
+#' DoRothEA and CollecTRI networks support human and mouse. For other input
+#' species, set `input_species` and project expression values to this network
+#' species through homologous gene conversion before activity inference.
 #' @param input_species Species of the input expression features. If `NULL`,
 #' the input is assumed to use the same gene namespace as `species`. When this
 #' differs from `species`, expression features are converted with
@@ -18,10 +18,15 @@
 #' @param homolog_params Additional named arguments passed to [ConvertHomologs]
 #' when `input_species` differs from `species`, such as `Ensembl_version`,
 #' `biomart`, `mirror`, `max_tries`, `multi_mapping`, and `collapse_fun`.
-#' @param confidence DoRothEA confidence levels to keep.
-#' @param regulons Optional regulon table with `tf`, `target`, `mor`, and
-#' `confidence` columns. If `NULL`, bundled `dorothea_hs` or `dorothea_mm`
-#' data are loaded from the `dorothea` package.
+#' @param confidence DoRothEA confidence levels to keep when a `confidence`
+#' column is present.
+#' @param regulons Regulon source. `NULL` or `"dorothea"` loads the bundled
+#' DoRothEA network, `"collectri"` loads CollecTRI, and a data-frame-like
+#' object supplies a custom network. Custom networks may use `tf`, `TF`,
+#' `source`, or `regulator` for the regulator column, `target` for targets,
+#' and `mor`, `importance`, or `weight` for edge weights. `mor` is treated as
+#' signed regulation; `importance` and `weight` are treated as non-negative
+#' unsigned weights.
 #' @param method Activity inference backend from `decoupleR`.
 #' @param minsize Minimum regulon size passed to `decoupleR`.
 #' @param options Additional named options passed to the selected `decoupleR`
@@ -30,11 +35,19 @@
 #' @param new_assay Whether to store TF activity scores as a new assay.
 #' @param add_meta Whether to also write TF activity scores to `srt@meta.data`
 #' with the `assay_name` prefix for direct plotting with [FeatureDimPlot()].
+#' @details
+#' `RunGRN()` returns a `TF`, `target`, and `importance` table that can be
+#' supplied directly through `regulons`. Such a network is unsigned: its
+#' scores describe target-program activity and do not distinguish activation
+#' from repression. For signed TF activity, supply a network with a `mor`
+#' column instead.
 #'
-#' @return A `Seurat` object with DoRothEA results stored in
+#' @return A `Seurat` object with TF activity results stored in
 #' `srt@tools[["Dorothea"]]`, optionally TF activity scores stored in
 #' `srt@meta.data`, and optionally a TF activity assay when
-#' `new_assay = TRUE`. For cross-species runs, the homolog projection summary
+#' `new_assay = TRUE`. The normalized network is stored in
+#' `srt@tools[["Dorothea"]]$regulons`, with the source and signedness recorded
+#' in `network_info`. For cross-species runs, the homolog projection summary
 #' is stored in `srt@tools[["Dorothea"]]$homolog_conversion`.
 #' @export
 #'
@@ -117,6 +130,26 @@
 #'   features = "Sox9",
 #'   plot_type = "targets"
 #' )
+#'
+#' # A RunGRN-compatible unsigned network can be passed directly.
+#' grn_targets <- head(rownames(pancreas_sub), 5)
+#' grn_edges <- data.frame(
+#'   TF = rep("ExampleTF", length(grn_targets)),
+#'   target = grn_targets,
+#'   importance = seq_along(grn_targets) / length(grn_targets)
+#' )
+#' pancreas_sub <- RunDorothea(
+#'   pancreas_sub,
+#'   regulons = grn_edges,
+#'   minsize = 1,
+#'   new_assay = FALSE,
+#'   add_meta = FALSE,
+#'   verbose = FALSE
+#' )
+#' pancreas_sub@tools$Dorothea$network_info
+#' # A real RunGRN result can be connected in the same way:
+#' # grn <- RunGRN(pancreas_sub, grn_method = "genie3")
+#' # pancreas_sub <- RunDorothea(pancreas_sub, regulons = grn)
 RunDorothea <- function(
   srt,
   assay = NULL,
@@ -158,7 +191,23 @@ RunDorothea <- function(
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
 
   check_r("decoupleR", verbose = FALSE)
+  regulons_input <- NULL
   if (is.null(regulons)) {
+    network_name <- "dorothea"
+  } else if (is.character(regulons) && length(regulons) == 1L) {
+    network_name <- tolower(regulons)
+    if (!network_name %in% c("dorothea", "collectri")) {
+      log_message(
+        "{.arg regulons} must be NULL, {.val 'dorothea'}, {.val 'collectri'}, or a network table",
+        message_type = "error"
+      )
+    }
+  } else {
+    network_name <- "custom"
+    regulons_input <- as.data.frame(regulons, stringsAsFactors = FALSE)
+  }
+
+  if (identical(network_name, "dorothea")) {
     check_r("dorothea", verbose = FALSE)
     data_name <- switch(species,
       Homo_sapiens = "dorothea_hs",
@@ -167,28 +216,42 @@ RunDorothea <- function(
     env <- new.env(parent = emptyenv())
     utils::data(list = data_name, package = "dorothea", envir = env)
     regulons <- get(data_name, envir = env)
+  } else if (identical(network_name, "collectri")) {
+    organism <- switch(species,
+      Homo_sapiens = "human",
+      Mus_musculus = "mouse"
+    )
+    get_collectri <- get_namespace_fun("decoupleR", "get_collectri")
+    if (!is.function(get_collectri)) {
+      log_message(
+        "{.pkg decoupleR} does not provide {.fun get_collectri}",
+        message_type = "error"
+      )
+    }
+    regulons <- get_collectri(
+      organism = organism,
+      split_complexes = FALSE
+    )
   } else {
-    regulons <- as.data.frame(regulons)
+    regulons <- regulons_input
   }
+
   if (!is.null(confidence) && "confidence" %in% colnames(regulons)) {
     regulons <- regulons[
       regulons[["confidence"]] %in% confidence, ,
       drop = FALSE
     ]
   }
-  required <- c("tf", "target", "mor")
-  missing <- setdiff(required, colnames(regulons))
-  if (length(missing) > 0) {
-    log_message(
-      "{.arg regulons} must contain columns: {.val {required}}",
-      message_type = "error"
-    )
-  }
-  if (nrow(regulons) == 0) {
-    log_message(
-      "No DoRothEA regulon edges remain after filtering",
-      message_type = "error"
-    )
+  network <- dorothea_normalize_network(
+    regulons,
+    source = network_name
+  )
+  regulons <- network$regulons
+  network_info <- network$info
+  network_info$species <- species
+  network_info$input_species <- input_species
+  if (identical(network_name, "collectri")) {
+    network_info$split_complexes <- FALSE
   }
 
   expr <- GetAssayData5(srt, layer = layer, assay = assay)
@@ -220,7 +283,7 @@ RunDorothea <- function(
       )
     }
     log_message(
-      "Project expression features from {.val {input_species}} to {.val {species}} homologs for {.pkg DoRothEA}",
+      "Project expression features from {.val {input_species}} to {.val {species}} homologs for {.val {network_info$label}}",
       verbose = verbose
     )
     expr <- do.call(
@@ -263,17 +326,23 @@ RunDorothea <- function(
   expr <- as.matrix(expr)
   if (nrow(expr) == 0 || ncol(expr) == 0) {
     log_message(
-      "No expression values available for DoRothEA activity inference",
+      "No expression values available for {.val {network_info$label}} activity inference",
       message_type = "error"
     )
   }
 
   log_message(
-    "Run {.pkg DoRothEA}/{.pkg decoupleR} with {.val {nrow(regulons)}} regulon edges",
+    "Run {.val {network_info$label}}/{.pkg decoupleR} with {.val {nrow(regulons)}} regulon edges",
     verbose = verbose
   )
 
   run_fun <- dorothea_get_run_fun(method)
+  if (!is.function(run_fun)) {
+    log_message(
+      "The selected {.pkg decoupleR} method {.val {method}} is not available",
+      message_type = "error"
+    )
+  }
   params <- c(
     list(
       mat = expr,
@@ -295,7 +364,7 @@ RunDorothea <- function(
   score_col <- intersect(c("score", "activity", "nes"), colnames(res_df))[1]
   if (any(is.na(c(source_col, condition_col, score_col)))) {
     log_message(
-      "Unable to parse {.pkg decoupleR} result columns for DoRothEA scores",
+      "Unable to parse {.pkg decoupleR} result columns for {.val {network_info$label}} scores",
       message_type = "error"
     )
   }
@@ -328,7 +397,7 @@ RunDorothea <- function(
       assay_name = assay_name
     )
     log_message(
-      "{.pkg DoRothEA} TF activity scores stored in assay {.val {assay_name}}",
+      "{.val {network_info$label}} TF activity scores stored in assay {.val {assay_name}}",
       verbose = verbose
     )
   }
@@ -339,7 +408,7 @@ RunDorothea <- function(
     )
     srt <- Seurat::AddMetaData(srt, metadata = meta_scores)
     log_message(
-      "{.pkg DoRothEA} TF activity scores stored in {.cls Seurat} metadata",
+      "{.val {network_info$label}} TF activity scores stored in {.cls Seurat} metadata",
       verbose = verbose
     )
   }
@@ -348,6 +417,8 @@ RunDorothea <- function(
     scores = scores,
     result = res_df,
     regulons = regulons,
+    regulons_input = regulons_input,
+    network_info = network_info,
     regulon_summary = data.frame(
       n_tfs = length(unique(regulons[["tf"]])),
       n_targets = length(unique(regulons[["target"]])),
@@ -381,11 +452,155 @@ RunDorothea <- function(
 }
 
 dorothea_get_run_fun <- function(method) {
-  switch(method,
-    ulm = getExportedValue("decoupleR", "run_ulm"),
-    viper = getExportedValue("decoupleR", "run_viper"),
-    wmean = getExportedValue("decoupleR", "run_wmean")
+  fun_name <- switch(method,
+    ulm = "run_ulm",
+    viper = "run_viper",
+    wmean = "run_wmean"
   )
+  get_namespace_fun("decoupleR", fun_name)
+}
+
+dorothea_normalize_network <- function(regulons, source = "custom") {
+  regulons <- as.data.frame(regulons, stringsAsFactors = FALSE)
+  if (nrow(regulons) == 0L) {
+    log_message(
+      "No {.val {source}} regulon edges remain after filtering",
+      message_type = "error"
+    )
+  }
+  if (is.null(colnames(regulons))) {
+    log_message(
+      "{.arg regulons} must have named regulator, target, and weight columns",
+      message_type = "error"
+    )
+  }
+
+  regulator_col <- dorothea_choose_network_column(
+    regulons,
+    c("tf", "TF", "source", "regulator"),
+    "regulator"
+  )
+  target_col <- dorothea_choose_network_column(
+    regulons,
+    "target",
+    "target"
+  )
+  weight_col <- dorothea_choose_network_column(
+    regulons,
+    c("mor", "importance", "weight"),
+    "weight"
+  )
+
+  tf <- trimws(as.character(regulons[[regulator_col]]))
+  target <- trimws(as.character(regulons[[target_col]]))
+  weight <- suppressWarnings(as.numeric(regulons[[weight_col]]))
+  if (anyNA(tf) || any(!nzchar(tf)) || anyNA(target) || any(!nzchar(target))) {
+    log_message(
+      "{.arg regulons} regulator and target columns must contain non-empty names",
+      message_type = "error"
+    )
+  }
+  if (anyNA(weight) || any(!is.finite(weight))) {
+    log_message(
+      "{.arg regulons} weight column must contain finite numeric values",
+      message_type = "error"
+    )
+  }
+  signed <- identical(weight_col, "mor")
+  if (!signed && any(weight < 0)) {
+    log_message(
+      "Unsigned {.arg regulons} weights from {.val {weight_col}} must be non-negative",
+      message_type = "error"
+    )
+  }
+  if (any(weight == 0)) {
+    log_message(
+      "{.arg regulons} weights must be non-zero",
+      message_type = "error"
+    )
+  }
+  edge_id <- paste(tf, target, sep = "\r")
+  if (anyDuplicated(edge_id)) {
+    log_message(
+      "{.arg regulons} must not contain duplicate regulator-target edges",
+      message_type = "error"
+    )
+  }
+
+  regulons$tf <- tf
+  regulons$target <- target
+  regulons$mor <- weight
+  format <- if (identical(source, "dorothea")) {
+    "dorothea"
+  } else if (identical(source, "collectri")) {
+    "collectri"
+  } else if (identical(regulator_col, "TF") &&
+      identical(weight_col, "importance")) {
+    "scop_grn"
+  } else if (identical(regulator_col, "source") &&
+      identical(weight_col, "mor")) {
+    "decoupler_network"
+  } else {
+    "custom_table"
+  }
+  label <- switch(source,
+    dorothea = "DoRothEA",
+    collectri = "CollecTRI",
+    "custom TF network"
+  )
+  info <- list(
+    source = source,
+    label = label,
+    format = format,
+    signed = signed,
+    regulator_column = regulator_col,
+    target_column = target_col,
+    weight_column = weight_col,
+    weight_semantics = if (signed) {
+      "signed_mor"
+    } else {
+      "unsigned_positive_weight"
+    }
+  )
+  if (!signed) {
+    log_message(
+      "The supplied network is unsigned; {.val {weight_col}} is used as positive edge weight. Scores represent target-program activity, not signed TF activation or repression.",
+      message_type = "info"
+    )
+  }
+  list(regulons = regulons, info = info)
+}
+
+dorothea_choose_network_column <- function(regulons, candidates, role) {
+  present <- candidates[candidates %in% colnames(regulons)]
+  if (length(present) == 0L) {
+    log_message(
+      "Unable to identify {.val {role}} column in {.arg regulons}; supported columns are {.val {candidates}}",
+      message_type = "error"
+    )
+  }
+  chosen <- present[[1L]]
+  if (length(present) > 1L) {
+    reference <- as.character(regulons[[chosen]])
+    same <- vapply(
+      present[-1L],
+      function(candidate) {
+        value <- as.character(regulons[[candidate]])
+        identical(reference, value) || all(
+          ifelse(is.na(reference), "<NA>", reference) ==
+            ifelse(is.na(value), "<NA>", value)
+        )
+      },
+      logical(1)
+    )
+    if (any(!same)) {
+      log_message(
+        "Ambiguous {.val {role}} columns in {.arg regulons}: {.val {present}}",
+        message_type = "error"
+      )
+    }
+  }
+  chosen
 }
 
 dorothea_attach_assay <- function(srt, scores, assay_name) {
@@ -413,4 +628,3 @@ dorothea_attach_assay <- function(srt, scores, assay_name) {
   suppressWarnings(srt[[assay_name]] <- assay_object)
   srt
 }
-

--- a/R/RunDorothea.R
+++ b/R/RunDorothea.R
@@ -141,6 +141,7 @@
 #' pancreas_sub <- RunDorothea(
 #'   pancreas_sub,
 #'   regulons = grn_edges,
+#'   species = "Mus_musculus",
 #'   minsize = 1,
 #'   new_assay = FALSE,
 #'   add_meta = FALSE,
@@ -150,6 +151,14 @@
 #' # A real RunGRN result can be connected in the same way:
 #' # grn <- RunGRN(pancreas_sub, grn_method = "genie3")
 #' # pancreas_sub <- RunDorothea(pancreas_sub, regulons = grn)
+#' \dontrun{
+#' pancreas_sub <- RunDorothea(
+#'   pancreas_sub,
+#'   regulons = "collectri",
+#'   species = "Mus_musculus",
+#'   minsize = 5
+#' )
+#' }
 RunDorothea <- function(
   srt,
   assay = NULL,

--- a/man/DorotheaPlot.Rd
+++ b/man/DorotheaPlot.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/DorotheaPlot.R
 \name{DorotheaPlot}
 \alias{DorotheaPlot}
-\title{Plot DoRothEA transcription factor activity}
+\title{Plot transcription factor activity}
 \usage{
 DorotheaPlot(
   srt,
@@ -162,7 +162,7 @@ For \code{"bar"}, \code{"lollipop"}, \code{"volcano"}, \code{"dim"}, \code{"stat
 \code{\link[=GroupHeatmap]{GroupHeatmap()}}.
 }
 \description{
-Visualize DoRothEA TF activity stored by \code{\link[=RunDorothea]{RunDorothea()}}. Comparison plots
+Visualize TF activity stored by \code{\link[=RunDorothea]{RunDorothea()}}. Comparison plots
 (\code{"bar"}, \code{"lollipop"}, \code{"volcano"}) test two groups and show the mean
 activity difference \code{group1 - group2}. \code{"heatmap"} uses \code{\link[=GroupHeatmap]{GroupHeatmap()}}
 to summarize activity across all groups in \code{group.by}. \code{"dim"} compares TF

--- a/man/DorotheaPlot.Rd
+++ b/man/DorotheaPlot.Rd
@@ -199,6 +199,15 @@ DorotheaPlot(
   top_n = 20
 )
 
+DorotheaPlot(
+  pancreas_sub,
+  group.by = "CellType",
+  group1 = "Endocrine",
+  group2 = "Ductal",
+  plot_type = "volcano",
+  top_n = 20
+)
+
 ht <- DorotheaPlot(
   pancreas_sub,
   group.by = "CellType",

--- a/man/DorotheaPlot.Rd
+++ b/man/DorotheaPlot.Rd
@@ -75,13 +75,15 @@ distributions, and \code{"targets"} shows a regulon-target volcano.}
 \item{assay_name}{Assay used for \code{"heatmap"}, \code{"dim"}, and \code{"stat"}. If
 \code{NULL}, the assay stored by \code{\link[=RunDorothea]{RunDorothea()}} is used, or \code{"dorothea"}.}
 
-\item{features}{TFs to plot. If \code{NULL}, comparison plots use the top
-\code{top_n} TFs, heatmaps and \code{"stat"} use the \code{top_n} most variable TFs,
-\code{"dim"} uses TFs present in both activity and expression assays, and
-\code{"targets"} uses the TF with the largest absolute activity difference.}
+\item{features}{TFs to plot. If \code{NULL}, \code{"bar"}/\code{"lollipop"} use the top
+\code{top_n} TFs, \code{"volcano"} shows all tested TFs, heatmaps and \code{"stat"} use
+the \code{top_n} most variable TFs, \code{"dim"} uses TFs present in both activity
+and expression assays, and \code{"targets"} uses the TF with the largest
+absolute activity difference.}
 
-\item{top_n}{Number of TFs to show when \code{features = NULL}. Set \code{NULL} to
-show all tested TFs.}
+\item{top_n}{Number of TFs to show when \code{features = NULL}. Ignored for
+\code{"volcano"}, which always plots every tested TF. Set \code{NULL} to show all
+tested TFs in other comparison plots.}
 
 \item{test.use}{Statistical test used for each TF or target gene in
 comparison plots.}
@@ -129,7 +131,8 @@ expression in \code{"dim"} and for target genes in \code{"targets"}.}
 \item{stat_plot_type}{Distribution plot type passed to \code{\link[=FeatureStatPlot]{FeatureStatPlot()}}
 when \code{plot_type = "stat"}.}
 
-\item{nlabel}{Number of target genes labeled in \code{"targets"} plots.}
+\item{nlabel}{Number of significant TFs labeled in \code{"volcano"} plots, or
+significant target genes labeled in \code{"targets"} plots.}
 
 \item{reduction}{Reduction used by \code{"dim"} plots. If \code{NULL}, the default
 reduction of \code{srt} is used.}
@@ -204,8 +207,7 @@ DorotheaPlot(
   group.by = "CellType",
   group1 = "Endocrine",
   group2 = "Ductal",
-  plot_type = "volcano",
-  top_n = 20
+  plot_type = "volcano"
 )
 
 ht <- DorotheaPlot(

--- a/man/RunDorothea.Rd
+++ b/man/RunDorothea.Rd
@@ -172,6 +172,7 @@ grn_edges <- data.frame(
 pancreas_sub <- RunDorothea(
   pancreas_sub,
   regulons = grn_edges,
+  species = "Mus_musculus",
   minsize = 1,
   new_assay = FALSE,
   add_meta = FALSE,
@@ -181,6 +182,14 @@ pancreas_sub@tools$Dorothea$network_info
 # A real RunGRN result can be connected in the same way:
 # grn <- RunGRN(pancreas_sub, grn_method = "genie3")
 # pancreas_sub <- RunDorothea(pancreas_sub, regulons = grn)
+\dontrun{
+pancreas_sub <- RunDorothea(
+  pancreas_sub,
+  regulons = "collectri",
+  species = "Mus_musculus",
+  minsize = 5
+)
+}
 }
 \references{
 Garcia-Alonso, L., Holland, C.H., Ibrahim, M.M., Turei, D.,

--- a/man/RunDorothea.Rd
+++ b/man/RunDorothea.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/RunDorothea.R
 \name{RunDorothea}
 \alias{RunDorothea}
-\title{Run DoRothEA transcription factor activity inference}
+\title{Run transcription factor activity inference}
 \usage{
 RunDorothea(
   srt,
@@ -31,10 +31,10 @@ RunDorothea(
 
 \item{layer}{Assay layer used as the expression matrix.}
 
-\item{species}{Species used to select bundled DoRothEA regulons. DoRothEA
-only provides human and mouse regulons. For other input species, set
-\code{input_species} and project expression values to this regulon species through
-homologous gene conversion before activity inference.}
+\item{species}{Species used to select the regulatory network. The bundled
+DoRothEA and CollecTRI networks support human and mouse. For other input
+species, set \code{input_species} and project expression values to this network
+species through homologous gene conversion before activity inference.}
 
 \item{input_species}{Species of the input expression features. If \code{NULL},
 the input is assumed to use the same gene namespace as \code{species}. When this
@@ -49,11 +49,16 @@ regulons, \code{geneID_to_IDtype} should normally remain \code{"symbol"}.}
 when \code{input_species} differs from \code{species}, such as \code{Ensembl_version},
 \code{biomart}, \code{mirror}, \code{max_tries}, \code{multi_mapping}, and \code{collapse_fun}.}
 
-\item{confidence}{DoRothEA confidence levels to keep.}
+\item{confidence}{DoRothEA confidence levels to keep when a \code{confidence}
+column is present.}
 
-\item{regulons}{Optional regulon table with \code{tf}, \code{target}, \code{mor}, and
-\code{confidence} columns. If \code{NULL}, bundled \code{dorothea_hs} or \code{dorothea_mm}
-data are loaded from the \code{dorothea} package.}
+\item{regulons}{Regulon source. \code{NULL} or \code{"dorothea"} loads the bundled
+DoRothEA network, \code{"collectri"} loads CollecTRI, and a data-frame-like
+object supplies a custom network. Custom networks may use \code{tf}, \code{TF},
+\code{source}, or \code{regulator} for the regulator column, \code{target} for targets,
+and \code{mor}, \code{importance}, or \code{weight} for edge weights. \code{mor} is treated as
+signed regulation; \code{importance} and \code{weight} are treated as non-negative
+unsigned weights.}
 
 \item{method}{Activity inference backend from \code{decoupleR}.}
 
@@ -72,14 +77,23 @@ with the \code{assay_name} prefix for direct plotting with \code{\link[=FeatureD
 \item{verbose}{Print progress messages.}
 }
 \value{
-A \code{Seurat} object with DoRothEA results stored in
+A \code{Seurat} object with TF activity results stored in
 \code{srt@tools[["Dorothea"]]}, optionally TF activity scores stored in
 \code{srt@meta.data}, and optionally a TF activity assay when
-\code{new_assay = TRUE}. For cross-species runs, the homolog projection summary
+\code{new_assay = TRUE}. The normalized network is stored in
+\code{srt@tools[["Dorothea"]]$regulons}, with the source and signedness recorded
+in \code{network_info}. For cross-species runs, the homolog projection summary
 is stored in \code{srt@tools[["Dorothea"]]$homolog_conversion}.
 }
 \description{
-Run DoRothEA transcription factor activity inference
+Run transcription factor activity inference
+}
+\details{
+\code{RunGRN()} returns a \code{TF}, \code{target}, and \code{importance} table that can be
+supplied directly through \code{regulons}. Such a network is unsigned: its
+scores describe target-program activity and do not distinguish activation
+from repression. For signed TF activity, supply a network with a \code{mor}
+column instead.
 }
 \examples{
 data(pancreas_sub)
@@ -147,6 +161,26 @@ DorotheaPlot(
   features = "Sox9",
   plot_type = "targets"
 )
+
+# A RunGRN-compatible unsigned network can be passed directly.
+grn_targets <- head(rownames(pancreas_sub), 5)
+grn_edges <- data.frame(
+  TF = rep("ExampleTF", length(grn_targets)),
+  target = grn_targets,
+  importance = seq_along(grn_targets) / length(grn_targets)
+)
+pancreas_sub <- RunDorothea(
+  pancreas_sub,
+  regulons = grn_edges,
+  minsize = 1,
+  new_assay = FALSE,
+  add_meta = FALSE,
+  verbose = FALSE
+)
+pancreas_sub@tools$Dorothea$network_info
+# A real RunGRN result can be connected in the same way:
+# grn <- RunGRN(pancreas_sub, grn_method = "genie3")
+# pancreas_sub <- RunDorothea(pancreas_sub, regulons = grn)
 }
 \references{
 Garcia-Alonso, L., Holland, C.H., Ibrahim, M.M., Turei, D.,

--- a/tests/testthat/test-dorothea.R
+++ b/tests/testthat/test-dorothea.R
@@ -98,6 +98,215 @@ test_that("RunDorothea can skip TF activity metadata", {
   expect_false(out@tools$Dorothea$parameters$add_meta)
 })
 
+test_that("RunDorothea accepts RunGRN-style unsigned networks", {
+  counts <- matrix(
+    c(
+      5, 0, 4,
+      0, 3, 2
+    ),
+    nrow = 2,
+    byrow = TRUE,
+    dimnames = list(c("Gene1", "Gene2"), paste0("Cell", 1:3))
+  )
+  srt <- Seurat::CreateSeuratObject(
+    counts = methods::as(Matrix::Matrix(counts, sparse = TRUE), "dgCMatrix")
+  )
+  srt <- Seurat::NormalizeData(srt, verbose = FALSE)
+  grn <- data.frame(
+    TF = c("TF1", "TF2"),
+    target = c("Gene1", "Gene2"),
+    importance = c(0.8, 0.4)
+  )
+
+  testthat::local_mocked_bindings(
+    check_r = function(...) TRUE,
+    dorothea_get_run_fun = function(method) {
+      function(...) {
+        data.frame(
+          source = rep(c("TF1", "TF2"), each = 3),
+          condition = rep(colnames(srt), times = 2),
+          score = c(1, 2, 3, -1, -2, -3)
+        )
+      }
+    }
+  )
+
+  out <- RunDorothea(
+    srt,
+    regulons = grn,
+    method = "ulm",
+    verbose = FALSE
+  )
+
+  expect_true("dorothea" %in% SeuratObject::Assays(out))
+  expect_false(out@tools$Dorothea$network_info$signed)
+  expect_equal(out@tools$Dorothea$network_info$source, "custom")
+  expect_equal(out@tools$Dorothea$network_info$format, "scop_grn")
+  expect_equal(out@tools$Dorothea$regulons$tf, grn$TF)
+  expect_equal(out@tools$Dorothea$regulons$mor, grn$importance)
+  expect_equal(out@tools$Dorothea$regulons_input, grn)
+})
+
+test_that("RunDorothea loads CollecTRI with the SCOP species mapping", {
+  counts <- matrix(
+    c(5, 0, 4, 0, 3, 2),
+    nrow = 2,
+    dimnames = list(c("Gene1", "Gene2"), paste0("Cell", 1:3))
+  )
+  srt <- Seurat::CreateSeuratObject(
+    counts = methods::as(Matrix::Matrix(counts, sparse = TRUE), "dgCMatrix")
+  )
+  srt <- Seurat::NormalizeData(srt, verbose = FALSE)
+  collectri_call <- new.env(parent = emptyenv())
+
+  testthat::local_mocked_bindings(
+    check_r = function(...) TRUE,
+    get_namespace_fun = function(pkg, fun) {
+      if (identical(fun, "get_collectri")) {
+        return(function(organism, split_complexes) {
+          collectri_call$organism <- organism
+          collectri_call$split_complexes <- split_complexes
+          data.frame(
+            source = c("TF1", "TF2"),
+            target = c("Gene1", "Gene2"),
+            mor = c(1, -1)
+          )
+        })
+      }
+      stop("unexpected namespace function: ", fun)
+    },
+    dorothea_get_run_fun = function(method) {
+      function(...) {
+        data.frame(
+          source = rep(c("TF1", "TF2"), each = 3),
+          condition = rep(colnames(srt), times = 2),
+          score = c(1, 2, 3, -1, -2, -3)
+        )
+      }
+    }
+  )
+
+  out <- RunDorothea(
+    srt,
+    regulons = "collectri",
+    species = "Mus_musculus",
+    method = "ulm",
+    verbose = FALSE
+  )
+
+  expect_equal(collectri_call$organism, "mouse")
+  expect_false(collectri_call$split_complexes)
+  expect_equal(out@tools$Dorothea$network_info$source, "collectri")
+  expect_equal(out@tools$Dorothea$network_info$format, "collectri")
+  expect_true(out@tools$Dorothea$network_info$signed)
+})
+
+test_that("RunDorothea rejects invalid unsigned network weights before backend execution", {
+  counts <- matrix(
+    c(5, 0, 4, 0, 3, 2),
+    nrow = 2,
+    dimnames = list(c("Gene1", "Gene2"), paste0("Cell", 1:3))
+  )
+  srt <- Seurat::CreateSeuratObject(
+    counts = methods::as(Matrix::Matrix(counts, sparse = TRUE), "dgCMatrix")
+  )
+  srt <- Seurat::NormalizeData(srt, verbose = FALSE)
+  testthat::local_mocked_bindings(
+    check_r = function(...) TRUE,
+    dorothea_get_run_fun = function(...) stop("backend should not run")
+  )
+  expect_error(
+    RunDorothea(
+      srt,
+      regulons = data.frame(
+        TF = "TF1",
+        target = "Gene1",
+        importance = -1
+      ),
+      verbose = FALSE
+    ),
+    "non-negative"
+  )
+})
+
+test_that("RunDorothea accepts source, regulator, and weight aliases", {
+  counts <- matrix(
+    c(5, 0, 4, 0, 3, 2),
+    nrow = 2,
+    dimnames = list(c("Gene1", "Gene2"), paste0("Cell", 1:3))
+  )
+  srt <- Seurat::CreateSeuratObject(
+    counts = methods::as(Matrix::Matrix(counts, sparse = TRUE), "dgCMatrix")
+  )
+  srt <- Seurat::NormalizeData(srt, verbose = FALSE)
+  testthat::local_mocked_bindings(
+    check_r = function(...) TRUE,
+    dorothea_get_run_fun = function(method) {
+      function(...) {
+        data.frame(
+          source = rep(c("TF1", "TF2"), each = 3),
+          condition = rep(colnames(srt), times = 2),
+          score = c(1, 2, 3, -1, -2, -3)
+        )
+      }
+    }
+  )
+
+  out <- RunDorothea(
+    srt,
+    regulons = data.frame(
+      regulator = c("TF1", "TF2"),
+      target = c("Gene1", "Gene2"),
+      weight = c(0.7, 0.3)
+    ),
+    method = "ulm",
+    verbose = FALSE
+  )
+
+  expect_equal(out@tools$Dorothea$network_info$regulator_column, "regulator")
+  expect_equal(out@tools$Dorothea$network_info$weight_column, "weight")
+  expect_false(out@tools$Dorothea$network_info$signed)
+})
+
+test_that("RunDorothea does not mutate the input when decoupleR fails", {
+  counts <- matrix(
+    c(5, 0, 4, 0, 3, 2),
+    nrow = 2,
+    dimnames = list(c("Gene1", "Gene2"), paste0("Cell", 1:3))
+  )
+  srt <- Seurat::CreateSeuratObject(
+    counts = methods::as(Matrix::Matrix(counts, sparse = TRUE), "dgCMatrix")
+  )
+  srt <- Seurat::NormalizeData(srt, verbose = FALSE)
+  before <- list(
+    assays = SeuratObject::Assays(srt),
+    metadata = srt@meta.data,
+    tools = srt@tools
+  )
+  testthat::local_mocked_bindings(
+    check_r = function(...) TRUE,
+    dorothea_get_run_fun = function(...) {
+      function(...) stop("mock decoupleR failure")
+    }
+  )
+
+  expect_error(
+    RunDorothea(
+      srt,
+      regulons = data.frame(
+        tf = "TF1",
+        target = "Gene1",
+        mor = 1
+      ),
+      verbose = FALSE
+    ),
+    "mock decoupleR failure"
+  )
+  expect_equal(SeuratObject::Assays(srt), before$assays)
+  expect_equal(srt@meta.data, before$metadata)
+  expect_equal(srt@tools, before$tools)
+})
+
 local({
   make_dorothea_srt <- function() {
     counts <- matrix(
@@ -222,5 +431,32 @@ local({
     expect_true(inherits(p_dim, "ggplot") || inherits(p_dim, "patchwork"))
     expect_true(inherits(p_stat, "ggplot") || inherits(p_stat, "patchwork"))
     expect_s3_class(p_targets, "ggplot")
+  })
+
+  test_that("DorotheaPlot targets uses unsigned labels for unsigned networks", {
+    srt <- make_dorothea_srt()
+    srt@tools$Dorothea$network_info <- list(
+      source = "custom",
+      label = "custom TF network",
+      signed = FALSE
+    )
+    srt@tools$Dorothea$regulons$mor <- abs(srt@tools$Dorothea$regulons$mor)
+    out <- DorotheaPlot(
+      srt,
+      group.by = "CellType",
+      group1 = "A",
+      group2 = "B",
+      features = "TF1",
+      plot_type = "targets",
+      return_data = TRUE,
+      verbose = FALSE
+    )
+    expect_true(all(out$data$support %in% c("Higher group1", "Higher group2", "NS")))
+    expect_false(any(out$data$support %in% c("Support", "Oppose")))
+    expect_true(any(vapply(
+      out$plot$scales$scales,
+      function(scale) identical(scale$name, "Importance"),
+      logical(1)
+    )))
   })
 })

--- a/tests/testthat/test-dorothea.R
+++ b/tests/testthat/test-dorothea.R
@@ -387,6 +387,41 @@ local({
     expect_s3_class(p_volcano, "ggplot")
   })
 
+  test_that("DorotheaPlot volcano plots all TFs and caps underflow p-values", {
+    srt <- make_dorothea_srt()
+    out <- DorotheaPlot(
+      srt,
+      group.by = "CellType",
+      group1 = "A",
+      group2 = "B",
+      plot_type = "volcano",
+      top_n = 1,
+      nlabel = 0,
+      return_data = TRUE,
+      verbose = FALSE
+    )
+    expect_equal(sort(as.character(out$data$TF)), c("TF1", "TF2"))
+    expect_equal(nrow(ggplot2::layer_data(out$plot, 3)), 2L)
+    capped <- dorothea_volcano_y(data.frame(
+      p_val_adj = c(0, 1e-42, 0.2),
+      neglog10_p_val_adj = c(307, 42, 0.7)
+    ))
+    expect_equal(capped, c(50, 42, 0.7))
+    labeled <- DorotheaPlot(
+      srt,
+      group.by = "CellType",
+      group1 = "A",
+      group2 = "B",
+      plot_type = "volcano",
+      padjustCutoff = 1,
+      nlabel = 1,
+      verbose = FALSE
+    )
+    geoms <- vapply(labeled$layers, function(layer) class(layer$geom)[[1L]], character(1))
+    expect_true("GeomTextRepel" %in% geoms)
+    expect_equal(nrow(labeled$layers[[match("GeomTextRepel", geoms)]]$data), 1L)
+  })
+
   test_that("DorotheaPlot heatmap uses GroupHeatmap on the dorothea assay", {
     srt <- make_dorothea_srt()
     ht <- DorotheaPlot(
@@ -431,6 +466,12 @@ local({
     expect_true(inherits(p_dim, "ggplot") || inherits(p_dim, "patchwork"))
     expect_true(inherits(p_stat, "ggplot") || inherits(p_stat, "patchwork"))
     expect_s3_class(p_targets, "ggplot")
+    geoms <- vapply(p_targets$layers, function(layer) class(layer$geom)[[1L]], character(1))
+    if ("GeomTextRepel" %in% geoms) {
+      expect_true(all(
+        p_targets$layers[[match("GeomTextRepel", geoms)]]$data$support != "NS"
+      ))
+    }
   })
 
   test_that("DorotheaPlot targets uses unsigned labels for unsigned networks", {


### PR DESCRIPTION
## Summary

- extend `RunDorothea()` to accept `NULL`, `"dorothea"`, `"collectri"`, and custom regulatory network tables
- connect standardized `RunGRN()` output (`TF`, `target`, `importance`) directly to TF activity inference
- normalize supported regulator and weight aliases while preserving signed versus unsigned semantics and provenance
- resolve optional `decoupleR` functions through `check_r()` and `get_namespace_fun()`
- make `DorotheaPlot()` network-aware and avoid signed activation/repression labels for unsigned networks
- add synchronized documentation and regression coverage

## Why

`RunGRN()` returns `TF`, `target`, and `importance`, while `RunDorothea()` previously required `tf`, `target`, and `mor`. This prevented SCOP GRN results from flowing directly into the existing activity assay and plotting workflow. CollecTRI was also unavailable through the public entry point.

## User impact

Existing DoRothEA calls and the `dorothea` assay/tool names remain compatible. Users can now pass a `RunGRN()` result directly or select CollecTRI with `regulons = "collectri"`. Unsigned importance networks are explicitly recorded as target-program activity and are not presented as activation/repression evidence.

## Validation

- `pkgload::load_all(".", quiet = TRUE, compile = FALSE)` passed
- generated `RunDorothea.Rd` and `DorotheaPlot.Rd` examples passed `Rd2ex()` plus `parse()`
- focused Dorothea suite: 38 assertions passed; one pre-existing heatmap test remains blocked in this Windows environment because `heatmap_border_color` is unavailable from the installed plotting runtime
- real custom `TF`/`target`/`importance` input completed through the installed `decoupleR::run_ulm` backend and produced a 2 x 3 score matrix
- package check without installation completed with 0 errors, 0 warnings, and 1 inherited CRAN note; no dependency-in-code or unstated-example dependency warning was introduced

## External integration note

The live CollecTRI retrieval attempt reached the installed `decoupleR`/`OmnipathR` path but failed inside the current `OmnipathR` fallback (`unnest_evidences`: `.keep` has length zero). CollecTRI adapter behavior and human/mouse mapping are covered by mocked unit tests; this draft does not claim a successful live OmniPath retrieval in the current environment.
