### PR TITLE
docs: expand RunCell2fate examples with workflow and plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 * **removed**:
   * The `CaSpER` branch of `RunCNV()` is removed: `runCaSpER()` segfaults deterministically on R >= 4.5 (HMM `manualSegment`, even on 50 cells), upstream is unmaintained since 2019, and its Bioconductor dependency set is archived. `RunCNV()` now supports `copykat`, `fastCNV`, `scevan`, `infercnv`, and `numbat`.
 * **changed**:
+  * `RunCell2fate()` examples call `RunStandardWorkflow()` and plot time, uncertainty, module activation, and module state. `env_requirements()` also shows the standalone Cell2fate Python 3.9 stack.
   * `ListLIANAResources()` is replaced by `ListCCCDB()`, which enumerates ligand-receptor databases and prior models across all CCC backends with a unified `db`/`species`/`status` schema.
   * New `PrepareCCCDB()` prepares the CellTalk and CellChat databases (`TERM2GENE`/`TERM2NAME`, `R.cache`-backed); the CellTalk/CellChat branches were removed from `PrepareDB()`.
   * Database listing outputs are unified (`ListDB()` and `ListCCCDB()` return plain data frames; colored console rendering is available via `thisplot::print_colored_table()`).

--- a/R/PrepareEnv.R
+++ b/R/PrepareEnv.R
@@ -1735,6 +1735,7 @@ env_info <- function(conda, envname, verbose = TRUE) {
 #' @export
 #' @examples
 #' env_requirements("3.10-1")
+#' env_requirements(version = "3.9-1", modules = "cell2fate")
 env_requirements <- function(
   version = "3.10-1",
   include_optional = FALSE,

--- a/R/RunCell2fate.R
+++ b/R/RunCell2fate.R
@@ -62,16 +62,31 @@
 #'
 #' @export
 #'
+#' @seealso [RunStandardWorkflow], [FeatureDimPlot], [CellDimPlot]
+#'
 #' @examples
 #' \dontrun{
 #' data(pancreas_sub)
+#' pancreas_sub <- RunStandardWorkflow(pancreas_sub)
 #' pancreas_sub <- RunCell2fate(
 #'   pancreas_sub,
 #'   result_dir = "pancreas_cell2fate",
 #'   cluster.by = "SubCellType",
 #'   n_modules = 10
 #' )
-#' FeatureDimPlot(pancreas_sub, "Cell2fate_time")
+#' FeatureDimPlot(
+#'   pancreas_sub,
+#'   c("Cell2fate_time", "Cell2fate_time_uncertainty")
+#' )
+#' FeatureDimPlot(
+#'   pancreas_sub,
+#'   grep(
+#'     "^Cell2fate_module_.*_activation$",
+#'     colnames(pancreas_sub@meta.data),
+#'     value = TRUE
+#'   )
+#' )
+#' CellDimPlot(pancreas_sub, group.by = "Cell2fate_module_0_state")
 #' }
 RunCell2fate <- function(
   srt,

--- a/man/RunCell2fate.Rd
+++ b/man/RunCell2fate.Rd
@@ -119,12 +119,28 @@ overwritten.
 \examples{
 \dontrun{
 data(pancreas_sub)
+pancreas_sub <- RunStandardWorkflow(pancreas_sub)
 pancreas_sub <- RunCell2fate(
   pancreas_sub,
   result_dir = "pancreas_cell2fate",
   cluster.by = "SubCellType",
   n_modules = 10
 )
-FeatureDimPlot(pancreas_sub, "Cell2fate_time")
+FeatureDimPlot(
+  pancreas_sub,
+  c("Cell2fate_time", "Cell2fate_time_uncertainty")
+)
+FeatureDimPlot(
+  pancreas_sub,
+  grep(
+    "^Cell2fate_module_.*_activation$",
+    colnames(pancreas_sub@meta.data),
+    value = TRUE
+  )
+)
+CellDimPlot(pancreas_sub, group.by = "Cell2fate_module_0_state")
 }
+}
+\seealso{
+\link{RunStandardWorkflow}, \link{FeatureDimPlot}, \link{CellDimPlot}
 }

--- a/man/env_requirements.Rd
+++ b/man/env_requirements.Rd
@@ -49,4 +49,5 @@ All packages will be installed using uv as the primary tool.
 }
 \examples{
 env_requirements("3.10-1")
+env_requirements(version = "3.9-1", modules = "cell2fate")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`RunCell2fate()` documentation examples now match the actual workflow:

- call `RunStandardWorkflow()` first so `FeatureDimPlot()` has a reduction (`pancreas_sub` has none)
- plot time, time uncertainty, module activation, and module state
- `env_requirements()` shows the standalone Cell2fate Python 3.9 stack

No function behavior changes. `test-cell2fate.R`: 77 passed. Examples still `\dontrun` because they need the isolated Python environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00f3d-19cd-7d32-b63e-ce70fd657503?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00f3d-19cd-7d32-b63e-ce70fd657503&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

