### PR TITLE
fix: correct GSEA negative correlation label

### DIFF
--- a/R/GSEAPlot.R
+++ b/R/GSEAPlot.R
@@ -715,7 +715,7 @@ GSEAPlot <- function(
             hjust = 1,
             color = "#3C298C",
             size = 4,
-            label = "Negtively correlated "
+            label = "Negatively correlated "
           )
       }
       if (max(df2$y) > 0 && min(df2$y) < 0) {

--- a/tests/testthat/test-gsea-plot-labels.R
+++ b/tests/testthat/test-gsea-plot-labels.R
@@ -1,0 +1,6 @@
+test_that("GSEAPlot uses the correctly spelled negative correlation label", {
+  gsea_plot_body <- paste(deparse(body(GSEAPlot)), collapse = "\n")
+
+  expect_match(gsea_plot_body, "Negatively correlated", fixed = TRUE)
+  expect_false(grepl("Negtively correlated", gsea_plot_body, fixed = TRUE))
+})


### PR DESCRIPTION
Corrects the misspelled "Negtively correlated" annotation in GSEAPlot to "Negatively correlated" and adds a regression test for the label. Validation: targeted testthat test passed; package load passed; local R CMD check completed with 0 errors, with only pre-existing CellRank/Rd warnings and note. The required dependency and unstated-example-dependency checks both reported OK.