### PR TITLE
feat: support grouped fits in DynamicPlot

### DIFF
--- a/R/DynamicPlot.R
+++ b/R/DynamicPlot.R
@@ -724,6 +724,9 @@ DynamicPlot <- function(
           )
         }
       }
+      libsize_use[
+        !is.finite(libsize_use) | libsize_use <= 0
+      ] <- NA_real_
       raw_matrix[, gene] <- raw_matrix[, gene, drop = FALSE] /
         libsize_use *
         normalization_center
@@ -979,8 +982,9 @@ DynamicPlot <- function(
     fit_series_labels <- as.vector(outer(
       lineages,
       features,
-      paste,
-      sep = " - "
+      function(lineage, feature) {
+        paste0("Lineage: ", lineage, "; feature: ", feature)
+      }
     ))
   } else if (isTRUE(compare_features)) {
     fit_series_index <- feature_code
@@ -1044,6 +1048,8 @@ DynamicPlot <- function(
   hide_point_guide <- identical(group.by, fit.by) &&
     isTRUE(add_line) &&
     all(point_group_levels %in% fitted_group_levels)
+  show_rug_guide <- isTRUE(compare_features) ||
+    (!isTRUE(add_point) && !isTRUE(hide_point_guide))
 
   if (!is.null(cells)) {
     df_all <- df_all[df_all[["Cell"]] %in% cells, , drop = FALSE]
@@ -1183,7 +1189,7 @@ DynamicPlot <- function(
               ),
               alpha = 1,
               length = grid::unit(0.05, "npc"),
-              show.legend = isTRUE(compare_features)
+              show.legend = show_rug_guide
             ),
             scale_color_manual(
               values = point_palette_values,

--- a/R/DynamicPlot.R
+++ b/R/DynamicPlot.R
@@ -11,6 +11,10 @@
 #' @param group_use Groups from `group.by` to
 #' keep. If both `group_use` and `cells` are provided, their intersection will
 #' be used.
+#' @param fit.by Optional metadata column used to fit an independent trajectory
+#' for each group over that group's observed pseudotime range. The fit is not
+#' extrapolated beyond observed cells. This does not change the existing
+#' point-coloring behavior of `group.by`.
 #' @param cells Cell names to use.
 #' @param family GLM family. `NULL` chooses automatically.
 #' @param exp_method Expression transform: `"log1p"`, `"raw"`, `"zscore"`, `"fc"`,
@@ -56,6 +60,23 @@
 #'   compare_features = TRUE
 #' )
 #'
+#' # Demonstration only: create two conditions spanning the same pseudotime.
+#' lineage1_cells <- rownames(pancreas_sub@meta.data)[
+#'   order(pancreas_sub$Lineage1, na.last = NA)
+#' ]
+#' pancreas_sub$condition <- NA_character_
+#' pancreas_sub$condition[lineage1_cells] <- rep(
+#'   c("control", "HUA"),
+#'   length.out = length(lineage1_cells)
+#' )
+#' DynamicPlot(
+#'   pancreas_sub,
+#'   lineages = "Lineage1",
+#'   features = "Vim",
+#'   group.by = "condition",
+#'   fit.by = "condition"
+#' )
+#'
 #' DynamicPlot(
 #'   pancreas_sub,
 #'   lineages = c("Lineage1", "Lineage2"),
@@ -79,6 +100,7 @@ DynamicPlot <- function(
   features,
   group.by = NULL,
   group_use = NULL,
+  fit.by = NULL,
   cells = NULL,
   layer = "counts",
   assay = NULL,
@@ -129,6 +151,20 @@ DynamicPlot <- function(
     if (length(group_missing) > 0) {
       log_message(
         "{.val {group_missing}} is not in the meta.data of srt object",
+        message_type = "error"
+      )
+    }
+  }
+  if (!is.null(fit.by)) {
+    if (length(fit.by) != 1) {
+      log_message(
+        "{.arg fit.by} must be one metadata column.",
+        message_type = "error"
+      )
+    }
+    if (!fit.by %in% colnames(srt@meta.data)) {
+      log_message(
+        "{.val {fit.by}} is not in the meta.data of srt object",
         message_type = "error"
       )
     }
@@ -200,24 +236,108 @@ DynamicPlot <- function(
   fitted_matrix_list <- list()
   upr_matrix_list <- list()
   lwr_matrix_list <- list()
+  fit_lineage_list <- list()
+  fit_group_list <- list()
+  if (is.null(fit.by)) {
+    fit_groups <- NA_character_
+  } else {
+    fit_cells <- rownames(srt@meta.data)
+    if (!is.null(cells)) {
+      fit_cells <- intersect(fit_cells, cells)
+    }
+    fit_values <- srt@meta.data[fit_cells, fit.by, drop = TRUE]
+    fit_groups <- unique(as.character(fit_values[!is.na(fit_values)]))
+    fit_groups <- fit_groups[nzchar(fit_groups)]
+    if (length(fit_groups) == 0) {
+      log_message(
+        "No non-missing groups found for {.arg fit.by} in the selected cells.",
+        message_type = "error"
+      )
+    }
+  }
   for (l in lineages) {
+    if (!is.null(fit.by)) {
+      n_fit_before <- length(raw_matrix_list)
+      for (g in fit_groups) {
+        group_cells <- fit_cells[
+          !is.na(fit_values) & as.character(fit_values) == g
+        ]
+        lineage_values <- srt@meta.data[group_cells, l, drop = TRUE]
+        valid_cells <- group_cells[is.finite(lineage_values)]
+        valid_pseudotime <- lineage_values[is.finite(lineage_values)]
+        if (length(valid_cells) < 4 || length(unique(valid_pseudotime)) < 3) {
+          log_message(
+            "Skip {.val {g}} in {.val {l}}: at least four cells and three unique pseudotime values are required.",
+            message_type = "warning",
+            verbose = verbose
+          )
+          next
+        }
+
+        srt_tmp <- srt
+        exclude_cells <- setdiff(rownames(srt_tmp@meta.data), valid_cells)
+        srt_tmp@meta.data[exclude_cells, l] <- NA_real_
+        srt_tmp <- RunDynamicFeatures(
+          srt_tmp,
+          lineages = l,
+          features = features,
+          assay = assay,
+          layer = layer,
+          family = family,
+          libsize = libsize,
+          cores = cores,
+          verbose = verbose
+        )
+        fit_result <- srt_tmp@tools[[paste0("DynamicFeatures_", l)]]
+        fit_id <- paste0("fit", length(raw_matrix_list) + 1L)
+        raw_matrix_list[[fit_id]] <- as_matrix(
+          fit_result[["raw_matrix"]][, features, drop = FALSE]
+        )
+        fitted_matrix_list[[fit_id]] <- as_matrix(
+          fit_result[["fitted_matrix"]][, features, drop = FALSE]
+        )
+        upr_matrix_list[[fit_id]] <- as_matrix(
+          fit_result[["upr_matrix"]][, features, drop = FALSE]
+        )
+        lwr_matrix_list[[fit_id]] <- as_matrix(
+          fit_result[["lwr_matrix"]][, features, drop = FALSE]
+        )
+        fit_lineage_list[[fit_id]] <- l
+        fit_group_list[[fit_id]] <- g
+        cell_union <- unique(c(
+          cell_union,
+          rownames(fit_result[["raw_matrix"]])
+        ))
+      }
+      if (length(raw_matrix_list) == n_fit_before) {
+        log_message(
+          "No group in {.val {fit.by}} has enough observations for {.val {l}}.",
+          message_type = "error"
+        )
+      }
+      next
+    }
+
     features_exist <- c()
     raw_matrix <- NULL
     if (paste0("DynamicFeatures_", l) %in% names(srt@tools)) {
       raw_matrix <- srt@tools[[paste0("DynamicFeatures_", l)]][["raw_matrix"]][
         ,
-        -1
+        -1,
+        drop = FALSE
       ]
       fitted_matrix <- srt@tools[[paste0("DynamicFeatures_", l)]][[
         "fitted_matrix"
-      ]][, -1]
+      ]][, -1, drop = FALSE]
       upr_matrix <- srt@tools[[paste0("DynamicFeatures_", l)]][["upr_matrix"]][
         ,
-        -1
+        -1,
+        drop = FALSE
       ]
       lwr_matrix <- srt@tools[[paste0("DynamicFeatures_", l)]][["lwr_matrix"]][
         ,
-        -1
+        -1,
+        drop = FALSE
       ]
       features_exist <- colnames(raw_matrix)
     }
@@ -284,6 +404,8 @@ DynamicPlot <- function(
     lwr_matrix_list[[l]] <- as_matrix(
       lwr_matrix[, features, drop = FALSE]
     )
+    fit_lineage_list[[l]] <- l
+    fit_group_list[[l]] <- NA_character_
     cell_union <- unique(c(cell_union, rownames(raw_matrix)))
   }
 
@@ -313,6 +435,7 @@ DynamicPlot <- function(
   }
 
   df_list <- list()
+  fit_groups_fitted <- unique(unlist(fit_group_list, use.names = FALSE))
   y_libsize <- Matrix::colSums(
     GetAssayData5(
       srt,
@@ -320,11 +443,13 @@ DynamicPlot <- function(
       layer = "counts"
     )
   )
-  for (l in lineages) {
-    raw_matrix <- raw_matrix_list[[l]]
-    fitted_matrix <- fitted_matrix_list[[l]]
-    upr_matrix <- upr_matrix_list[[l]]
-    lwr_matrix <- lwr_matrix_list[[l]]
+  for (fit_id in names(raw_matrix_list)) {
+    l <- fit_lineage_list[[fit_id]]
+    fit_group <- fit_group_list[[fit_id]]
+    raw_matrix <- raw_matrix_list[[fit_id]]
+    fitted_matrix <- fitted_matrix_list[[fit_id]]
+    upr_matrix <- upr_matrix_list[[fit_id]]
+    lwr_matrix <- lwr_matrix_list[[fit_id]]
     if (isTRUE(lib_normalize) && min(raw_matrix[, gene], na.rm = TRUE) >= 0) {
       if (!is.null(libsize)) {
         libsize_use <- libsize
@@ -464,7 +589,12 @@ DynamicPlot <- function(
 
     df_tmp <- rbind(raw, fitted)
     df_tmp[["Lineages"]] <- factor(l, levels = lineages)
-    df_list[[l]] <- df_tmp
+    df_tmp[["FitGroup"]] <- if (is.null(fit.by)) {
+      factor("all")
+    } else {
+      factor(fit_group, levels = fit_groups_fitted)
+    }
+    df_list[[fit_id]] <- df_tmp
   }
   df_all <- do.call(rbind, df_list)
   rownames(df_all) <- NULL
@@ -482,6 +612,11 @@ DynamicPlot <- function(
   df_all[["LineagesFeatures"]] <- paste(
     df_all[["Lineages"]],
     df_all[["Features"]],
+    sep = "-"
+  )
+  df_all[["LineagesFeaturesFitGroups"]] <- paste(
+    df_all[["LineagesFeatures"]],
+    df_all[["FitGroup"]],
     sep = "-"
   )
 
@@ -520,6 +655,9 @@ DynamicPlot <- function(
     features_guide <- TRUE
   } else {
     features_guide <- FALSE
+  }
+  if (!is.null(fit.by)) {
+    fill_by <- "FitGroup"
   }
 
   for (l in lineages_use) {
@@ -564,7 +702,15 @@ DynamicPlot <- function(
                   df[[group.by]],
                   palette = point_palette,
                   palcolor = point_palcolor
-                )
+                ),
+                guide = if (identical(group.by, fit.by)) {
+                  "none"
+                } else {
+                  guide_legend(
+                    override.aes = list(alpha = 1, size = 3),
+                    order = 1
+                  )
+                }
               ),
               scale_fill_manual(
                 values = palette_colors(
@@ -572,10 +718,14 @@ DynamicPlot <- function(
                   palette = point_palette,
                   palcolor = point_palcolor
                 ),
-                guide = guide_legend(
-                  override.aes = list(alpha = 1, size = 3),
-                  order = 1
-                )
+                guide = if (identical(group.by, fit.by)) {
+                  "none"
+                } else {
+                  guide_legend(
+                    override.aes = list(alpha = 1, size = 3),
+                    order = 1
+                  )
+                }
               ),
               ggnewscale::new_scale_color(),
               ggnewscale::new_scale_fill()
@@ -630,7 +780,7 @@ DynamicPlot <- function(
               ymin = .data[["lwr"]],
               ymax = .data[["upr"]],
               fill = .data[[fill_by]],
-              group = .data[["LineagesFeatures"]]
+              group = .data[["LineagesFeaturesFitGroups"]]
             ),
             alpha = 0.4,
             color = "grey90"
@@ -638,10 +788,21 @@ DynamicPlot <- function(
           scale_fill_manual(
             values = palette_colors(
               df[[fill_by]],
-              palette = line_palette,
-              palcolor = line_palcolor
+              palette = if (!is.null(fit.by) && identical(group.by, fit.by)) {
+                point_palette
+              } else {
+                line_palette
+              },
+              palcolor = if (!is.null(fit.by) && identical(group.by, fit.by)) {
+                point_palcolor
+              } else {
+                line_palcolor
+              }
             ),
-            guide = if (
+            name = if (is.null(fit.by)) NULL else fit.by,
+            guide = if (!is.null(fit.by)) {
+              "none"
+            } else if (
               fill_by == "Features" || lineages_guide || length(l) == 1
             ) {
               "none"
@@ -654,7 +815,46 @@ DynamicPlot <- function(
       } else {
         interval <- NULL
       }
-      if (isTRUE(compare_features)) {
+      if (!is.null(fit.by)) {
+        if (isTRUE(add_line)) {
+          line <- list(
+            geom_line(
+              data = subset(df, df[["Value"]] == "fitted"),
+              mapping = aes(
+                x = .data[["Pseudotime"]],
+                y = .data[["exp"]],
+                color = .data[["FitGroup"]],
+                group = .data[["LineagesFeaturesFitGroups"]]
+              ),
+              linewidth = line.size,
+              alpha = 0.8
+            ),
+            scale_color_manual(
+              name = fit.by,
+              values = palette_colors(
+                df[["FitGroup"]],
+                palette = if (identical(group.by, fit.by)) {
+                  point_palette
+                } else {
+                  line_palette
+                },
+                palcolor = if (identical(group.by, fit.by)) {
+                  point_palcolor
+                } else {
+                  line_palcolor
+                }
+              ),
+              guide = guide_legend(
+                override.aes = list(alpha = 1, linewidth = 2),
+                order = 2
+              )
+            ),
+            ggnewscale::new_scale_color()
+          )
+        } else {
+          line <- NULL
+        }
+      } else if (isTRUE(compare_features)) {
         line <- list(
           geom_line(
             data = subset(df, df[["Value"]] == "fitted"),

--- a/R/DynamicPlot.R
+++ b/R/DynamicPlot.R
@@ -225,9 +225,18 @@ DynamicPlot <- function(
   }
 
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
-  fit_group_col <- make.unique(
-    c(colnames(srt@meta.data), ".scop_fit_group")
-  )[[ncol(srt@meta.data) + 1L]]
+  internal_cols <- make.unique(c(
+    colnames(srt@meta.data),
+    ".scop_fit_group",
+    ".scop_fit_series",
+    ".scop_fit_path"
+  ))
+  internal_cols <- internal_cols[
+    ncol(srt@meta.data) + seq_len(3L)
+  ]
+  fit_group_col <- internal_cols[[1]]
+  fit_series_col <- internal_cols[[2]]
+  fit_path_col <- internal_cols[[3]]
   gene <- features[features %in% rownames(srt@assays[[assay]])]
   meta <- features[features %in% colnames(srt@meta.data)]
   features <- c(gene, meta)
@@ -324,6 +333,58 @@ DynamicPlot <- function(
     }
     family_all[features_fit]
   }
+  fit_libsize_all <- NULL
+  feature_uses_libsize <- stats::setNames(
+    rep(FALSE, length(features)),
+    features
+  )
+  if (!is.null(fit.by) && layer == "counts" && length(gene) > 0) {
+    counts_status <- CheckDataType(
+      srt,
+      assay = assay,
+      layer = "counts",
+      verbose = FALSE
+    )
+    family_all <- subset_family(features)
+    if (is.null(family_all)) {
+      family_all <- stats::setNames(
+        rep("gaussian", length(features)),
+        features
+      )
+      if (counts_status == "raw_counts") {
+        family_all[gene] <- "nb"
+      }
+    } else if (length(family_all) == 1) {
+      family_all <- stats::setNames(
+        rep(family_all, length(features)),
+        features
+      )
+    }
+    feature_uses_libsize[gene] <- family_all[gene] != "gaussian"
+    if (any(feature_uses_libsize)) {
+      if (is.null(libsize)) {
+        fit_libsize_all <- if (counts_status == "raw_counts") {
+          Matrix::colSums(
+            GetAssayData5(srt, assay = assay, layer = "counts")
+          )
+        } else {
+          stats::setNames(rep(1, ncol(srt)), colnames(srt))
+        }
+      } else {
+        if (!length(libsize) %in% c(1, ncol(srt))) {
+          log_message(
+            "{.arg libsize} must be length of 1 or the number of cells",
+            message_type = "error"
+          )
+        }
+        fit_libsize_all <- if (length(libsize) == 1) {
+          stats::setNames(rep(libsize, ncol(srt)), colnames(srt))
+        } else {
+          stats::setNames(as.numeric(libsize), colnames(srt))
+        }
+      }
+    }
+  }
   for (l in lineages) {
     if (!is.null(fit.by)) {
       for (g in fit_groups) {
@@ -370,6 +431,11 @@ DynamicPlot <- function(
           seq_along(features),
           function(i) {
             valid_feature <- is.finite(feature_values[i, ])
+            if (feature_uses_libsize[[i]]) {
+              libsize_group <- fit_libsize_all[valid_cells]
+              valid_feature <- valid_feature &
+                is.finite(libsize_group) & libsize_group > 0
+            }
             sum(valid_feature) >= 10 &&
               length(unique(valid_pseudotime[valid_feature])) >= 10
           },
@@ -379,7 +445,7 @@ DynamicPlot <- function(
         features_raw_only <- features[!feature_supported]
         if (length(features_raw_only) > 0) {
           log_message(
-            "Skip the fitted trajectory for {.val {features_raw_only}} in {.val {g}} / {.val {l}}: each feature requires at least ten finite observations and ten unique pseudotime values. Raw points and rugs are retained.",
+            "Skip the fitted trajectory for {.val {features_raw_only}} in {.val {g}} / {.val {l}}: each feature requires at least ten finite usable observations and ten unique pseudotime values. Raw points and rugs are retained.",
             message_type = "warning",
             verbose = verbose
           )
@@ -873,16 +939,41 @@ DynamicPlot <- function(
     }
     df_all <- cbind(df_all, cell_group)
   }
-  df_all[["LineagesFeatures"]] <- paste(
-    df_all[["Lineages"]],
-    df_all[["Features"]],
-    sep = "-"
+  lineage_code <- match(as.character(df_all[["Lineages"]]), lineages)
+  feature_code <- match(as.character(df_all[["Features"]]), features)
+  fit_group_code <- match(
+    as.character(df_all[[fit_group_col]]),
+    fit_group_levels
   )
-  df_all[["LineagesFeaturesFitGroups"]] <- paste(
-    df_all[["LineagesFeatures"]],
-    df_all[[fit_group_col]],
-    sep = "-"
+  if (isTRUE(compare_lineages) && isTRUE(compare_features)) {
+    fit_series_index <- lineage_code +
+      (feature_code - 1L) * length(lineages)
+    fit_series_labels <- as.vector(outer(
+      lineages,
+      features,
+      paste,
+      sep = " - "
+    ))
+  } else if (isTRUE(compare_features)) {
+    fit_series_index <- feature_code
+    fit_series_labels <- features
+  } else if (isTRUE(compare_lineages)) {
+    fit_series_index <- lineage_code
+    fit_series_labels <- lineages
+  } else {
+    fit_series_index <- rep(1L, nrow(df_all))
+    fit_series_labels <- "Series"
+  }
+  fit_series_levels <- paste0("series", seq_along(fit_series_labels))
+  names(fit_series_labels) <- fit_series_levels
+  df_all[[fit_series_col]] <- factor(
+    paste0("series", fit_series_index),
+    levels = fit_series_levels
   )
+  fit_path_index <- lineage_code +
+    (feature_code - 1L) * length(lineages) +
+    (fit_group_code - 1L) * length(lineages) * length(features)
+  df_all[[fit_path_col]] <- factor(paste0("path", fit_path_index))
 
   fitted_group_levels <- if (is.null(fit.by)) {
     character()
@@ -965,8 +1056,10 @@ DynamicPlot <- function(
       hide_point_guide <- identical(group.by, fit.by) &&
         isTRUE(add_line) &&
         all(point_groups %in% fitted_groups)
-      fit_series <- unique(as.character(df[["LineagesFeatures"]]))
-      fit_series <- fit_series[nzchar(fit_series)]
+      fitted_series <- unique(as.character(df[[fit_series_col]][
+        df[["Value"]] == "fitted" & is.finite(df[["exp"]])
+      ]))
+      fit_series <- fit_series_levels[fit_series_levels %in% fitted_series]
       distinguish_fit_series <- !is.null(fit.by) && length(fit_series) > 1
       if (
         (isTRUE(add_line) || isTRUE(add_interval)) &&
@@ -1076,8 +1169,8 @@ DynamicPlot <- function(
             ymin = .data[["lwr"]],
             ymax = .data[["upr"]],
             fill = .data[[fill_by]],
-            linetype = .data[["LineagesFeatures"]],
-            group = .data[["LineagesFeaturesFitGroups"]]
+            linetype = .data[[fit_series_col]],
+            group = .data[[fit_path_col]]
           )
         } else {
           aes(
@@ -1086,7 +1179,7 @@ DynamicPlot <- function(
             ymin = .data[["lwr"]],
             ymax = .data[["upr"]],
             fill = .data[[fill_by]],
-            group = .data[["LineagesFeaturesFitGroups"]]
+            group = .data[[fit_path_col]]
           )
         }
         interval_geom <- if (isTRUE(distinguish_interval_series)) {
@@ -1114,6 +1207,7 @@ DynamicPlot <- function(
             name = "Lineage - feature",
             values = linetype_values,
             limits = fit_series,
+            labels = fit_series_labels[fit_series],
             drop = FALSE,
             guide = guide_legend(order = 3)
           )
@@ -1164,15 +1258,15 @@ DynamicPlot <- function(
               x = .data[["Pseudotime"]],
               y = .data[["exp"]],
               color = .data[[fit_group_col]],
-              linetype = .data[["LineagesFeatures"]],
-              group = .data[["LineagesFeaturesFitGroups"]]
+              linetype = .data[[fit_series_col]],
+              group = .data[[fit_path_col]]
             )
           } else {
             aes(
               x = .data[["Pseudotime"]],
               y = .data[["exp"]],
               color = .data[[fit_group_col]],
-              group = .data[["LineagesFeaturesFitGroups"]]
+              group = .data[[fit_path_col]]
             )
           }
           linetype_scale <- if (isTRUE(distinguish_fit_series)) {
@@ -1183,6 +1277,8 @@ DynamicPlot <- function(
             scale_linetype_manual(
               name = "Lineage - feature",
               values = linetype_values,
+              limits = fit_series,
+              labels = fit_series_labels[fit_series],
               guide = guide_legend(order = 3)
             )
           } else {
@@ -1234,7 +1330,7 @@ DynamicPlot <- function(
               x = .data[["Pseudotime"]],
               y = .data[["exp"]],
               color = .data[["Features"]],
-              group = .data[["LineagesFeatures"]]
+              group = .data[[fit_path_col]]
             ),
             linewidth = line.size,
             alpha = 0.8
@@ -1265,7 +1361,7 @@ DynamicPlot <- function(
                 x = .data[["Pseudotime"]],
                 y = .data[["exp"]],
                 color = .data[["Lineages"]],
-                group = .data[["LineagesFeatures"]]
+                group = .data[[fit_path_col]]
               ),
               linewidth = line.size,
               alpha = 0.8

--- a/R/DynamicPlot.R
+++ b/R/DynamicPlot.R
@@ -104,7 +104,6 @@ DynamicPlot <- function(
   features,
   group.by = NULL,
   group_use = NULL,
-  fit.by = NULL,
   cells = NULL,
   layer = "counts",
   assay = NULL,
@@ -144,7 +143,8 @@ DynamicPlot <- function(
   byrow = TRUE,
   cores = 1,
   verbose = TRUE,
-  seed = 11
+  seed = 11,
+  fit.by = NULL
 ) {
   set.seed(seed)
 
@@ -265,8 +265,9 @@ DynamicPlot <- function(
     }
     if (length(fit_groups) == 0) {
       log_message(
-        "No non-missing groups found for {.arg fit.by} in the selected cells.",
-        message_type = "error"
+        "No non-missing groups found for {.arg fit.by} in the selected cells. Raw points and rugs will be retained without fitted trajectories.",
+        message_type = "warning",
+        verbose = verbose
       )
     }
     raw_feature_matrix <- GetAssayData5(
@@ -281,6 +282,47 @@ DynamicPlot <- function(
       )
     }
     raw_feature_matrix <- raw_feature_matrix[features, , drop = FALSE]
+  }
+  add_group_matrices <- function(
+    raw_matrix,
+    fitted_matrix,
+    upr_matrix,
+    lwr_matrix,
+    lineage,
+    fit_group
+  ) {
+    fit_id <- paste0("fit", length(raw_matrix_list) + 1L)
+    raw_matrix_list[[fit_id]] <<- raw_matrix
+    fitted_matrix_list[[fit_id]] <<- fitted_matrix
+    upr_matrix_list[[fit_id]] <<- upr_matrix
+    lwr_matrix_list[[fit_id]] <<- lwr_matrix
+    fit_lineage_list[[fit_id]] <<- lineage
+    fit_group_list[[fit_id]] <<- fit_group
+    cell_union <<- unique(c(cell_union, rownames(raw_matrix)))
+  }
+  empty_fit_matrix <- function(cell_names) {
+    matrix(
+      NA_real_,
+      nrow = length(cell_names),
+      ncol = length(features),
+      dimnames = list(cell_names, features)
+    )
+  }
+  subset_family <- function(features_fit) {
+    if (is.null(family) || length(family) == 1) {
+      return(family)
+    }
+    if (length(family) != length(features)) {
+      log_message(
+        "{.arg family} must be one character or a vector of the same length as features",
+        message_type = "error"
+      )
+    }
+    family_all <- family
+    if (is.null(names(family_all))) {
+      names(family_all) <- features
+    }
+    family_all[features_fit]
   }
   for (l in lineages) {
     if (!is.null(fit.by)) {
@@ -304,24 +346,57 @@ DynamicPlot <- function(
           raw_matrix <- t(as_matrix(
             raw_feature_matrix[, ordered_cells, drop = FALSE]
           ))
-          empty_fit <- matrix(
-            NA_real_,
-            nrow = length(ordered_cells),
-            ncol = length(features),
-            dimnames = list(ordered_cells, features)
+          empty_fit <- empty_fit_matrix(ordered_cells)
+          add_group_matrices(
+            raw_matrix,
+            empty_fit,
+            empty_fit,
+            empty_fit,
+            l,
+            g
           )
-          fit_id <- paste0("fit", length(raw_matrix_list) + 1L)
-          raw_matrix_list[[fit_id]] <- raw_matrix
-          fitted_matrix_list[[fit_id]] <- empty_fit
-          upr_matrix_list[[fit_id]] <- empty_fit
-          lwr_matrix_list[[fit_id]] <- empty_fit
-          fit_lineage_list[[fit_id]] <- l
-          fit_group_list[[fit_id]] <- g
-          cell_union <- unique(c(cell_union, ordered_cells))
           log_message(
             "Skip the fitted trajectory for {.val {g}} in {.val {l}}: the default GAM requires at least ten cells and ten unique pseudotime values. Raw points and rugs are retained.",
             message_type = "warning",
             verbose = verbose
+          )
+          next
+        }
+
+        feature_values <- as_matrix(
+          raw_feature_matrix[, valid_cells, drop = FALSE]
+        )
+        feature_supported <- vapply(
+          seq_along(features),
+          function(i) {
+            valid_feature <- is.finite(feature_values[i, ])
+            sum(valid_feature) >= 10 &&
+              length(unique(valid_pseudotime[valid_feature])) >= 10
+          },
+          logical(1)
+        )
+        features_fit <- features[feature_supported]
+        features_raw_only <- features[!feature_supported]
+        if (length(features_raw_only) > 0) {
+          log_message(
+            "Skip the fitted trajectory for {.val {features_raw_only}} in {.val {g}} / {.val {l}}: each feature requires at least ten finite observations and ten unique pseudotime values. Raw points and rugs are retained.",
+            message_type = "warning",
+            verbose = verbose
+          )
+        }
+        ordered_cells <- valid_cells[order(valid_pseudotime)]
+        if (length(features_fit) == 0) {
+          raw_matrix <- t(as_matrix(
+            raw_feature_matrix[, ordered_cells, drop = FALSE]
+          ))
+          empty_fit <- empty_fit_matrix(ordered_cells)
+          add_group_matrices(
+            raw_matrix,
+            empty_fit,
+            empty_fit,
+            empty_fit,
+            l,
+            g
           )
           next
         }
@@ -332,34 +407,66 @@ DynamicPlot <- function(
         srt_tmp <- RunDynamicFeatures(
           srt_tmp,
           lineages = l,
-          features = features,
+          features = features_fit,
           assay = assay,
           layer = layer,
-          family = family,
+          family = subset_family(features_fit),
           libsize = libsize,
           cores = cores,
           verbose = verbose
         )
         fit_result <- srt_tmp@tools[[paste0("DynamicFeatures_", l)]]
-        fit_id <- paste0("fit", length(raw_matrix_list) + 1L)
-        raw_matrix_list[[fit_id]] <- as_matrix(
-          fit_result[["raw_matrix"]][, features, drop = FALSE]
-        )
-        fitted_matrix_list[[fit_id]] <- as_matrix(
-          fit_result[["fitted_matrix"]][, features, drop = FALSE]
-        )
-        upr_matrix_list[[fit_id]] <- as_matrix(
-          fit_result[["upr_matrix"]][, features, drop = FALSE]
-        )
-        lwr_matrix_list[[fit_id]] <- as_matrix(
-          fit_result[["lwr_matrix"]][, features, drop = FALSE]
-        )
-        fit_lineage_list[[fit_id]] <- l
-        fit_group_list[[fit_id]] <- g
-        cell_union <- unique(c(
-          cell_union,
-          rownames(fit_result[["raw_matrix"]])
+        fitted_cells <- rownames(fit_result[["raw_matrix"]])
+        raw_matrix <- t(as_matrix(
+          raw_feature_matrix[, fitted_cells, drop = FALSE]
         ))
+        fitted_matrix <- empty_fit_matrix(fitted_cells)
+        upr_matrix <- empty_fit_matrix(fitted_cells)
+        lwr_matrix <- empty_fit_matrix(fitted_cells)
+        fitted_matrix[, features_fit] <- as_matrix(
+          fit_result[["fitted_matrix"]][, features_fit, drop = FALSE]
+        )
+        upr_matrix[, features_fit] <- as_matrix(
+          fit_result[["upr_matrix"]][, features_fit, drop = FALSE]
+        )
+        lwr_matrix[, features_fit] <- as_matrix(
+          fit_result[["lwr_matrix"]][, features_fit, drop = FALSE]
+        )
+        add_group_matrices(
+          raw_matrix,
+          fitted_matrix,
+          upr_matrix,
+          lwr_matrix,
+          l,
+          g
+        )
+      }
+      unassigned_cells <- fit_cells[
+        is.na(fit_values) | !nzchar(as.character(fit_values))
+      ]
+      unassigned_pseudotime <- srt@meta.data[
+        unassigned_cells,
+        l,
+        drop = TRUE
+      ]
+      unassigned_cells <- unassigned_cells[is.finite(unassigned_pseudotime)]
+      unassigned_pseudotime <- unassigned_pseudotime[
+        is.finite(unassigned_pseudotime)
+      ]
+      if (length(unassigned_cells) > 0) {
+        ordered_cells <- unassigned_cells[order(unassigned_pseudotime)]
+        raw_matrix <- t(as_matrix(
+          raw_feature_matrix[, ordered_cells, drop = FALSE]
+        ))
+        empty_fit <- empty_fit_matrix(ordered_cells)
+        add_group_matrices(
+          raw_matrix,
+          empty_fit,
+          empty_fit,
+          empty_fit,
+          l,
+          NA_character_
+        )
       }
       next
     }

--- a/R/DynamicPlot.R
+++ b/R/DynamicPlot.R
@@ -14,7 +14,8 @@
 #' @param fit.by Optional metadata column used to fit an independent trajectory
 #' for each group over that group's observed pseudotime range. The fit is not
 #' extrapolated beyond observed cells. This does not change the existing
-#' point-coloring behavior of `group.by`.
+#' point-coloring behavior of `group.by`. Groups with fewer than 10 cells or 10
+#' unique pseudotime values are shown as raw points or rugs but are not fitted.
 #' @param cells Cell names to use.
 #' @param family GLM family. `NULL` chooses automatically.
 #' @param exp_method Expression transform: `"log1p"`, `"raw"`, `"zscore"`, `"fc"`,
@@ -240,24 +241,43 @@ DynamicPlot <- function(
   fit_group_list <- list()
   if (is.null(fit.by)) {
     fit_groups <- NA_character_
+    fit_group_levels <- "all"
   } else {
     fit_cells <- rownames(srt@meta.data)
     if (!is.null(cells)) {
       fit_cells <- intersect(fit_cells, cells)
     }
     fit_values <- srt@meta.data[fit_cells, fit.by, drop = TRUE]
-    fit_groups <- unique(as.character(fit_values[!is.na(fit_values)]))
-    fit_groups <- fit_groups[nzchar(fit_groups)]
+    fit_values_present <- as.character(fit_values[!is.na(fit_values)])
+    fit_values_present <- fit_values_present[nzchar(fit_values_present)]
+    if (is.factor(srt@meta.data[[fit.by]])) {
+      fit_group_levels <- levels(srt@meta.data[[fit.by]])
+      fit_groups <- fit_group_levels[fit_group_levels %in% fit_values_present]
+    } else {
+      fit_groups <- unique(fit_values_present)
+      fit_group_levels <- fit_groups
+    }
     if (length(fit_groups) == 0) {
       log_message(
         "No non-missing groups found for {.arg fit.by} in the selected cells.",
         message_type = "error"
       )
     }
+    raw_feature_matrix <- GetAssayData5(
+      srt,
+      assay = assay,
+      layer = layer
+    )[gene, , drop = FALSE]
+    if (length(meta) > 0) {
+      raw_feature_matrix <- rbind(
+        raw_feature_matrix,
+        Matrix::t(srt@meta.data[, meta, drop = FALSE])
+      )
+    }
+    raw_feature_matrix <- raw_feature_matrix[features, , drop = FALSE]
   }
   for (l in lineages) {
     if (!is.null(fit.by)) {
-      n_fit_before <- length(raw_matrix_list)
       for (g in fit_groups) {
         group_cells <- fit_cells[
           !is.na(fit_values) & as.character(fit_values) == g
@@ -265,9 +285,27 @@ DynamicPlot <- function(
         lineage_values <- srt@meta.data[group_cells, l, drop = TRUE]
         valid_cells <- group_cells[is.finite(lineage_values)]
         valid_pseudotime <- lineage_values[is.finite(lineage_values)]
-        if (length(valid_cells) < 4 || length(unique(valid_pseudotime)) < 3) {
+        if (length(valid_cells) < 10 || length(unique(valid_pseudotime)) < 10) {
+          ordered_cells <- valid_cells[order(valid_pseudotime)]
+          raw_matrix <- t(as_matrix(
+            raw_feature_matrix[, ordered_cells, drop = FALSE]
+          ))
+          empty_fit <- matrix(
+            NA_real_,
+            nrow = length(ordered_cells),
+            ncol = length(features),
+            dimnames = list(ordered_cells, features)
+          )
+          fit_id <- paste0("fit", length(raw_matrix_list) + 1L)
+          raw_matrix_list[[fit_id]] <- raw_matrix
+          fitted_matrix_list[[fit_id]] <- empty_fit
+          upr_matrix_list[[fit_id]] <- empty_fit
+          lwr_matrix_list[[fit_id]] <- empty_fit
+          fit_lineage_list[[fit_id]] <- l
+          fit_group_list[[fit_id]] <- g
+          cell_union <- unique(c(cell_union, ordered_cells))
           log_message(
-            "Skip {.val {g}} in {.val {l}}: at least four cells and three unique pseudotime values are required.",
+            "Skip the fitted trajectory for {.val {g}} in {.val {l}}: the default GAM requires at least ten cells and ten unique pseudotime values. Raw points and rugs are retained.",
             message_type = "warning",
             verbose = verbose
           )
@@ -308,12 +346,6 @@ DynamicPlot <- function(
           cell_union,
           rownames(fit_result[["raw_matrix"]])
         ))
-      }
-      if (length(raw_matrix_list) == n_fit_before) {
-        log_message(
-          "No group in {.val {fit.by}} has enough observations for {.val {l}}.",
-          message_type = "error"
-        )
       }
       next
     }
@@ -435,7 +467,6 @@ DynamicPlot <- function(
   }
 
   df_list <- list()
-  fit_groups_fitted <- unique(unlist(fit_group_list, use.names = FALSE))
   y_libsize <- Matrix::colSums(
     GetAssayData5(
       srt,
@@ -443,16 +474,33 @@ DynamicPlot <- function(
       layer = "counts"
     )
   )
+  if (!is.null(libsize)) {
+    if (!length(libsize) %in% c(1, ncol(srt))) {
+      log_message(
+        "{.arg libsize} must be length of 1 or the number of cells",
+        message_type = "error"
+      )
+    }
+    libsize_all <- if (length(libsize) == 1) {
+      stats::setNames(rep(libsize, ncol(srt)), colnames(srt))
+    } else {
+      stats::setNames(as.numeric(libsize), colnames(srt))
+    }
+    normalization_center <- stats::median(libsize_all)
+  } else {
+    libsize_all <- NULL
+    normalization_center <- stats::median(y_libsize)
+  }
+
   for (fit_id in names(raw_matrix_list)) {
-    l <- fit_lineage_list[[fit_id]]
-    fit_group <- fit_group_list[[fit_id]]
     raw_matrix <- raw_matrix_list[[fit_id]]
-    fitted_matrix <- fitted_matrix_list[[fit_id]]
-    upr_matrix <- upr_matrix_list[[fit_id]]
-    lwr_matrix <- lwr_matrix_list[[fit_id]]
-    if (isTRUE(lib_normalize) && min(raw_matrix[, gene], na.rm = TRUE) >= 0) {
-      if (!is.null(libsize)) {
-        libsize_use <- libsize
+    if (
+      isTRUE(lib_normalize) &&
+        length(gene) > 0 &&
+        min(raw_matrix[, gene, drop = FALSE], na.rm = TRUE) >= 0
+    ) {
+      if (!is.null(libsize_all)) {
+        libsize_use <- libsize_all[rownames(raw_matrix)]
       } else {
         libsize_use <- y_libsize[rownames(raw_matrix)]
         isfloat <- any(libsize_use %% 1 != 0, na.rm = TRUE)
@@ -466,8 +514,43 @@ DynamicPlot <- function(
       }
       raw_matrix[, gene] <- raw_matrix[, gene, drop = FALSE] /
         libsize_use *
-        stats::median(y_libsize)
+        normalization_center
     }
+    raw_matrix_list[[fit_id]] <- raw_matrix
+  }
+
+  transform_reference_list <- stats::setNames(
+    lapply(lineages, function(l) {
+      fit_ids <- names(fit_lineage_list)[
+        unlist(fit_lineage_list, use.names = FALSE) == l
+      ]
+      do.call(rbind, raw_matrix_list[fit_ids])
+    }),
+    lineages
+  )
+  replace_infinite <- function(x) {
+    infinite <- is.infinite(x)
+    if (!any(infinite)) {
+      return(x)
+    }
+    finite_values <- x[is.finite(x)]
+    cap <- if (length(finite_values) > 0) {
+      max(abs(finite_values))
+    } else {
+      NA_real_
+    }
+    x[infinite] <- cap * ifelse(x[infinite] > 0, 1, -1)
+    x
+  }
+
+  for (fit_id in names(raw_matrix_list)) {
+    l <- fit_lineage_list[[fit_id]]
+    fit_group <- fit_group_list[[fit_id]]
+    raw_matrix <- raw_matrix_list[[fit_id]]
+    fitted_matrix <- fitted_matrix_list[[fit_id]]
+    upr_matrix <- upr_matrix_list[[fit_id]]
+    lwr_matrix <- lwr_matrix_list[[fit_id]]
+    transform_reference <- transform_reference_list[[l]]
 
     if (is.function(exp_method)) {
       raw_matrix <- t(exp_method(t(raw_matrix)))
@@ -480,20 +563,20 @@ DynamicPlot <- function(
       upr_matrix <- upr_matrix
       lwr_matrix <- lwr_matrix
     } else if (exp_method == "zscore") {
-      center <- Matrix::colMeans(raw_matrix)
-      sd <- MatrixGenerics::colSds(raw_matrix)
-      raw_matrix <- scale(raw_matrix, center = center, scale = sd)
-      fitted_matrix <- scale(fitted_matrix, center = center, scale = sd)
-      upr_matrix <- scale(upr_matrix, center = center, scale = sd)
-      lwr_matrix <- scale(lwr_matrix, center = center, scale = sd)
+      center <- Matrix::colMeans(transform_reference)
+      scale_sd <- MatrixGenerics::colSds(transform_reference)
+      raw_matrix <- scale(raw_matrix, center = center, scale = scale_sd)
+      fitted_matrix <- scale(fitted_matrix, center = center, scale = scale_sd)
+      upr_matrix <- scale(upr_matrix, center = center, scale = scale_sd)
+      lwr_matrix <- scale(lwr_matrix, center = center, scale = scale_sd)
     } else if (exp_method == "fc") {
-      colm <- Matrix::colMeans(raw_matrix)
+      colm <- Matrix::colMeans(transform_reference)
       raw_matrix <- t(t(raw_matrix) / colm)
       fitted_matrix <- t(t(fitted_matrix) / colm)
       upr_matrix <- t(t(upr_matrix) / colm)
       lwr_matrix <- t(t(lwr_matrix) / colm)
     } else if (exp_method == "log2fc") {
-      colm <- Matrix::colMeans(raw_matrix)
+      colm <- Matrix::colMeans(transform_reference)
       raw_matrix <- t(log2(t(raw_matrix) / colm))
       fitted_matrix <- t(log2(t(fitted_matrix) / colm))
       upr_matrix <- t(log2(t(upr_matrix) / colm))
@@ -504,25 +587,10 @@ DynamicPlot <- function(
       upr_matrix <- log1p(upr_matrix)
       lwr_matrix <- log1p(lwr_matrix)
     }
-    raw_matrix[is.infinite(raw_matrix)] <- max(
-      abs(raw_matrix[!is.infinite(raw_matrix)]),
-      na.rm = TRUE
-    ) *
-      ifelse(raw_matrix[is.infinite(raw_matrix)] > 0, 1, -1)
-    fitted_matrix[is.infinite(fitted_matrix)] <- max(abs(fitted_matrix[
-      !is.infinite(fitted_matrix)
-    ])) *
-      ifelse(fitted_matrix[is.infinite(fitted_matrix)] > 0, 1, -1)
-    upr_matrix[is.infinite(upr_matrix)] <- max(
-      abs(upr_matrix[!is.infinite(upr_matrix)]),
-      na.rm = TRUE
-    ) *
-      ifelse(upr_matrix[is.infinite(upr_matrix)] > 0, 1, -1)
-    lwr_matrix[is.infinite(lwr_matrix)] <- max(
-      abs(lwr_matrix[!is.infinite(lwr_matrix)]),
-      na.rm = TRUE
-    ) *
-      ifelse(lwr_matrix[is.infinite(lwr_matrix)] > 0, 1, -1)
+    raw_matrix <- replace_infinite(raw_matrix)
+    fitted_matrix <- replace_infinite(fitted_matrix)
+    upr_matrix <- replace_infinite(upr_matrix)
+    lwr_matrix <- replace_infinite(lwr_matrix)
 
     raw <- as.data.frame(cbind(
       cell_metadata[rownames(raw_matrix), c(l, "x_assign")],
@@ -592,7 +660,7 @@ DynamicPlot <- function(
     df_tmp[["FitGroup"]] <- if (is.null(fit.by)) {
       factor("all")
     } else {
-      factor(fit_group, levels = fit_groups_fitted)
+      factor(fit_group, levels = fit_group_levels)
     }
     df_list[[fit_id]] <- df_tmp
   }
@@ -672,8 +740,24 @@ DynamicPlot <- function(
       }
       df_point <- unique(df[
         df[["Value"]] == "raw",
-        c("Cell", "x_assign", "exp", group.by)
+        unique(c(
+          "Cell", "x_assign", "exp", "Features", "Lineages", group.by
+        ))
       ])
+      fitted_groups <- unique(as.character(df[["FitGroup"]][
+        df[["Value"]] == "fitted" & is.finite(df[["exp"]])
+      ]))
+      point_groups <- if (is.null(fit.by)) {
+        character()
+      } else {
+        unique(as.character(df[["FitGroup"]][df[["Value"]] == "raw"]))
+      }
+      hide_point_guide <- identical(group.by, fit.by) &&
+        isTRUE(add_line) &&
+        all(point_groups %in% fitted_groups)
+      fit_series <- unique(as.character(df[["LineagesFeatures"]]))
+      fit_series <- fit_series[nzchar(fit_series)]
+      distinguish_fit_series <- !is.null(fit.by) && length(fit_series) > 1
       if (isTRUE(compare_features)) {
         raw_point <- NULL
       } else {
@@ -703,7 +787,7 @@ DynamicPlot <- function(
                   palette = point_palette,
                   palcolor = point_palcolor
                 ),
-                guide = if (identical(group.by, fit.by)) {
+                guide = if (isTRUE(hide_point_guide)) {
                   "none"
                 } else {
                   guide_legend(
@@ -712,23 +796,7 @@ DynamicPlot <- function(
                   )
                 }
               ),
-              scale_fill_manual(
-                values = palette_colors(
-                  df[[group.by]],
-                  palette = point_palette,
-                  palcolor = point_palcolor
-                ),
-                guide = if (identical(group.by, fit.by)) {
-                  "none"
-                } else {
-                  guide_legend(
-                    override.aes = list(alpha = 1, size = 3),
-                    order = 1
-                  )
-                }
-              ),
-              ggnewscale::new_scale_color(),
-              ggnewscale::new_scale_fill()
+              ggnewscale::new_scale_color()
             )
           }
         } else {
@@ -773,7 +841,13 @@ DynamicPlot <- function(
       if (isTRUE(add_interval)) {
         interval <- list(
           geom_ribbon(
-            data = subset(df, df[["Value"]] == "fitted"),
+            data = subset(
+              df,
+              df[["Value"]] == "fitted" &
+                is.finite(df[["exp"]]) &
+                is.finite(df[["lwr"]]) &
+                is.finite(df[["upr"]])
+            ),
             mapping = aes(
               x = .data[["Pseudotime"]],
               y = .data[["exp"]],
@@ -800,8 +874,10 @@ DynamicPlot <- function(
               }
             ),
             name = if (is.null(fit.by)) NULL else fit.by,
-            guide = if (!is.null(fit.by)) {
+            guide = if (!is.null(fit.by) && isTRUE(add_line)) {
               "none"
+            } else if (!is.null(fit.by)) {
+              guide_legend(order = 2)
             } else if (
               fill_by == "Features" || lineages_guide || length(l) == 1
             ) {
@@ -817,15 +893,43 @@ DynamicPlot <- function(
       }
       if (!is.null(fit.by)) {
         if (isTRUE(add_line)) {
+          line_mapping <- if (isTRUE(distinguish_fit_series)) {
+            aes(
+              x = .data[["Pseudotime"]],
+              y = .data[["exp"]],
+              color = .data[["FitGroup"]],
+              linetype = .data[["LineagesFeatures"]],
+              group = .data[["LineagesFeaturesFitGroups"]]
+            )
+          } else {
+            aes(
+              x = .data[["Pseudotime"]],
+              y = .data[["exp"]],
+              color = .data[["FitGroup"]],
+              group = .data[["LineagesFeaturesFitGroups"]]
+            )
+          }
+          linetype_scale <- if (isTRUE(distinguish_fit_series)) {
+            linetype_values <- rep(
+              c("solid", "dashed", "dotted", "dotdash", "longdash", "twodash"),
+              length.out = length(fit_series)
+            )
+            names(linetype_values) <- fit_series
+            scale_linetype_manual(
+              name = "Lineage - feature",
+              values = linetype_values,
+              guide = guide_legend(order = 3)
+            )
+          } else {
+            NULL
+          }
           line <- list(
             geom_line(
-              data = subset(df, df[["Value"]] == "fitted"),
-              mapping = aes(
-                x = .data[["Pseudotime"]],
-                y = .data[["exp"]],
-                color = .data[["FitGroup"]],
-                group = .data[["LineagesFeaturesFitGroups"]]
+              data = subset(
+                df,
+                df[["Value"]] == "fitted" & is.finite(df[["exp"]])
               ),
+              mapping = line_mapping,
               linewidth = line.size,
               alpha = 0.8
             ),
@@ -849,6 +953,7 @@ DynamicPlot <- function(
                 order = 2
               )
             ),
+            linetype_scale,
             ggnewscale::new_scale_color()
           )
         } else {

--- a/R/DynamicPlot.R
+++ b/R/DynamicPlot.R
@@ -225,6 +225,15 @@ DynamicPlot <- function(
   }
 
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
+  if (!is.null(family) && length(family) > 1 && is.null(names(family))) {
+    if (length(family) != length(features)) {
+      log_message(
+        "{.arg family} must be one character or a vector of the same length as features",
+        message_type = "error"
+      )
+    }
+    names(family) <- features
+  }
   internal_cols <- make.unique(c(
     colnames(srt@meta.data),
     ".scop_fit_group",
@@ -983,6 +992,14 @@ DynamicPlot <- function(
     ]))
     fit_group_levels[fit_group_levels %in% fitted_groups_all]
   }
+  fitted_series_all <- unique(as.character(df_all[[fit_series_col]][
+    df_all[["Value"]] == "fitted" & is.finite(df_all[["exp"]])
+  ]))
+  fit_series <- fit_series_levels[fit_series_levels %in% fitted_series_all]
+  linetype_values <- c(
+    "solid", "dashed", "dotted", "dotdash", "longdash", "twodash"
+  )[seq_along(fit_series_levels)]
+  names(linetype_values) <- fit_series_levels
 
   if (!is.null(cells)) {
     df_all <- df_all[df_all[["Cell"]] %in% cells, , drop = FALSE]
@@ -1056,15 +1073,11 @@ DynamicPlot <- function(
       hide_point_guide <- identical(group.by, fit.by) &&
         isTRUE(add_line) &&
         all(point_groups %in% fitted_groups)
-      fitted_series <- unique(as.character(df[[fit_series_col]][
-        df[["Value"]] == "fitted" & is.finite(df[["exp"]])
-      ]))
-      fit_series <- fit_series_levels[fit_series_levels %in% fitted_series]
       distinguish_fit_series <- !is.null(fit.by) && length(fit_series) > 1
       if (
         (isTRUE(add_line) || isTRUE(add_interval)) &&
           isTRUE(distinguish_fit_series) &&
-          length(fit_series) > 6
+          length(fit_series_levels) > 6
       ) {
         log_message(
           "Grouped combined plots support at most six lineage-feature series. Set {.arg compare_lineages} or {.arg compare_features} to {.val FALSE}.",
@@ -1199,10 +1212,6 @@ DynamicPlot <- function(
           )
         }
         interval_linetype_scale <- if (isTRUE(distinguish_interval_series)) {
-          linetype_values <- c(
-            "solid", "dashed", "dotted", "dotdash", "longdash", "twodash"
-          )[seq_along(fit_series)]
-          names(linetype_values) <- fit_series
           scale_linetype_manual(
             name = "Lineage - feature",
             values = linetype_values,
@@ -1270,10 +1279,6 @@ DynamicPlot <- function(
             )
           }
           linetype_scale <- if (isTRUE(distinguish_fit_series)) {
-            linetype_values <- c(
-              "solid", "dashed", "dotted", "dotdash", "longdash", "twodash"
-            )[seq_along(fit_series)]
-            names(linetype_values) <- fit_series
             scale_linetype_manual(
               name = "Lineage - feature",
               values = linetype_values,

--- a/R/DynamicPlot.R
+++ b/R/DynamicPlot.R
@@ -19,11 +19,14 @@
 #' @param cells Cell names to use.
 #' @param family GLM family. `NULL` chooses automatically.
 #' @param exp_method Expression transform: `"log1p"`, `"raw"`, `"zscore"`, `"fc"`,
-#' or `"log2fc"`.
+#' or `"log2fc"`. With `fit.by`, transform parameters are shared across groups
+#' within each lineage.
 #' @param lib_normalize Library-size normalize. Defaults to `TRUE` when `layer`
 #' is counts.
 #' @param libsize Library size for each cell.
-#' @param compare_lineages,compare_features Compare lineages or features on one plot.
+#' @param compare_lineages,compare_features Compare lineages or features on one
+#' plot. Grouped line or interval plots support up to six combined
+#' lineage-feature series.
 #' @param add_line,add_interval,line.size,line_palette,line_palcolor Fitted line and CI.
 #' @param add_point,pt.size,point_palette,point_palcolor Overlay points.
 #' @param add_rug Draw rugs.
@@ -222,6 +225,9 @@ DynamicPlot <- function(
   }
 
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
+  fit_group_col <- make.unique(
+    c(colnames(srt@meta.data), ".scop_fit_group")
+  )[[ncol(srt@meta.data) + 1L]]
   gene <- features[features %in% rownames(srt@assays[[assay]])]
   meta <- features[features %in% colnames(srt@meta.data)]
   features <- c(gene, meta)
@@ -285,6 +291,14 @@ DynamicPlot <- function(
         lineage_values <- srt@meta.data[group_cells, l, drop = TRUE]
         valid_cells <- group_cells[is.finite(lineage_values)]
         valid_pseudotime <- lineage_values[is.finite(lineage_values)]
+        if (length(valid_cells) == 0) {
+          log_message(
+            "Skip {.val {g}} in {.val {l}}: no cells have finite pseudotime values.",
+            message_type = "warning",
+            verbose = verbose
+          )
+          next
+        }
         if (length(valid_cells) < 10 || length(unique(valid_pseudotime)) < 10) {
           ordered_cells <- valid_cells[order(valid_pseudotime)]
           raw_matrix <- t(as_matrix(
@@ -528,20 +542,136 @@ DynamicPlot <- function(
     }),
     lineages
   )
+  map_lineage_matrices <- function(matrix_list, transform) {
+    transformed_list <- matrix_list
+    for (l in lineages) {
+      fit_ids <- names(fit_lineage_list)[
+        unlist(fit_lineage_list, use.names = FALSE) == l
+      ]
+      if (length(fit_ids) == 0) {
+        next
+      }
+      row_counts <- vapply(matrix_list[fit_ids], nrow, integer(1))
+      combined <- do.call(rbind, matrix_list[fit_ids])
+      transformed <- as_matrix(transform(combined))
+      if (!identical(dim(transformed), dim(combined))) {
+        log_message(
+          "{.arg exp_method} must preserve the dimensions of the expression matrix.",
+          message_type = "error"
+        )
+      }
+      dimnames(transformed) <- dimnames(combined)
+      row_ends <- cumsum(row_counts)
+      row_starts <- row_ends - row_counts + 1L
+      for (i in seq_along(fit_ids)) {
+        rows <- if (row_counts[[i]] == 0) {
+          integer()
+        } else {
+          seq.int(row_starts[[i]], row_ends[[i]])
+        }
+        transformed_list[[fit_ids[[i]]]] <- transformed[
+          rows, ,
+          drop = FALSE
+        ]
+      }
+    }
+    transformed_list
+  }
+
+  if (is.function(exp_method)) {
+    apply_exp_method <- function(x) t(exp_method(t(x)))
+    raw_matrix_list <- map_lineage_matrices(
+      raw_matrix_list,
+      apply_exp_method
+    )
+    fitted_matrix_list <- map_lineage_matrices(
+      fitted_matrix_list,
+      apply_exp_method
+    )
+    upr_matrix_list <- map_lineage_matrices(upr_matrix_list, apply_exp_method)
+    lwr_matrix_list <- map_lineage_matrices(lwr_matrix_list, apply_exp_method)
+  } else {
+    for (fit_id in names(raw_matrix_list)) {
+      l <- fit_lineage_list[[fit_id]]
+      transform_reference <- transform_reference_list[[l]]
+      raw_matrix <- raw_matrix_list[[fit_id]]
+      fitted_matrix <- fitted_matrix_list[[fit_id]]
+      upr_matrix <- upr_matrix_list[[fit_id]]
+      lwr_matrix <- lwr_matrix_list[[fit_id]]
+
+      if (exp_method == "zscore") {
+        center <- Matrix::colMeans(transform_reference)
+        scale_sd <- MatrixGenerics::colSds(transform_reference)
+        raw_matrix <- scale(raw_matrix, center = center, scale = scale_sd)
+        fitted_matrix <- scale(fitted_matrix, center = center, scale = scale_sd)
+        upr_matrix <- scale(upr_matrix, center = center, scale = scale_sd)
+        lwr_matrix <- scale(lwr_matrix, center = center, scale = scale_sd)
+      } else if (exp_method == "fc") {
+        colm <- Matrix::colMeans(transform_reference)
+        raw_matrix <- t(t(raw_matrix) / colm)
+        fitted_matrix <- t(t(fitted_matrix) / colm)
+        upr_matrix <- t(t(upr_matrix) / colm)
+        lwr_matrix <- t(t(lwr_matrix) / colm)
+      } else if (exp_method == "log2fc") {
+        colm <- Matrix::colMeans(transform_reference)
+        raw_matrix <- t(log2(t(raw_matrix) / colm))
+        fitted_matrix <- t(log2(t(fitted_matrix) / colm))
+        upr_matrix <- t(log2(t(upr_matrix) / colm))
+        lwr_matrix <- t(log2(t(lwr_matrix) / colm))
+      } else if (exp_method == "log1p") {
+        raw_matrix <- log1p(raw_matrix)
+        fitted_matrix <- log1p(fitted_matrix)
+        upr_matrix <- log1p(upr_matrix)
+        lwr_matrix <- log1p(lwr_matrix)
+      }
+      raw_matrix_list[[fit_id]] <- raw_matrix
+      fitted_matrix_list[[fit_id]] <- fitted_matrix
+      upr_matrix_list[[fit_id]] <- upr_matrix
+      lwr_matrix_list[[fit_id]] <- lwr_matrix
+    }
+  }
+
   replace_infinite <- function(x) {
-    infinite <- is.infinite(x)
-    if (!any(infinite)) {
+    if (is.null(fit.by)) {
+      infinite <- is.infinite(x)
+      if (!any(infinite)) {
+        return(x)
+      }
+      finite_values <- x[is.finite(x)]
+      cap <- if (length(finite_values) > 0) {
+        max(abs(finite_values))
+      } else {
+        NA_real_
+      }
+      x[infinite] <- cap * ifelse(x[infinite] > 0, 1, -1)
       return(x)
     }
-    finite_values <- x[is.finite(x)]
-    cap <- if (length(finite_values) > 0) {
-      max(abs(finite_values))
-    } else {
-      NA_real_
+    for (feature in colnames(x)) {
+      infinite <- is.infinite(x[, feature])
+      if (!any(infinite)) {
+        next
+      }
+      finite_values <- x[is.finite(x[, feature]), feature]
+      cap <- if (length(finite_values) > 0) {
+        max(abs(finite_values))
+      } else {
+        NA_real_
+      }
+      x[infinite, feature] <- cap * ifelse(
+        x[infinite, feature] > 0,
+        1,
+        -1
+      )
     }
-    x[infinite] <- cap * ifelse(x[infinite] > 0, 1, -1)
     x
   }
+  raw_matrix_list <- map_lineage_matrices(raw_matrix_list, replace_infinite)
+  fitted_matrix_list <- map_lineage_matrices(
+    fitted_matrix_list,
+    replace_infinite
+  )
+  upr_matrix_list <- map_lineage_matrices(upr_matrix_list, replace_infinite)
+  lwr_matrix_list <- map_lineage_matrices(lwr_matrix_list, replace_infinite)
 
   for (fit_id in names(raw_matrix_list)) {
     l <- fit_lineage_list[[fit_id]]
@@ -550,47 +680,6 @@ DynamicPlot <- function(
     fitted_matrix <- fitted_matrix_list[[fit_id]]
     upr_matrix <- upr_matrix_list[[fit_id]]
     lwr_matrix <- lwr_matrix_list[[fit_id]]
-    transform_reference <- transform_reference_list[[l]]
-
-    if (is.function(exp_method)) {
-      raw_matrix <- t(exp_method(t(raw_matrix)))
-      fitted_matrix <- t(exp_method(t(fitted_matrix)))
-      upr_matrix <- t(exp_method(t(upr_matrix)))
-      lwr_matrix <- t(exp_method(t(lwr_matrix)))
-    } else if (exp_method == "raw") {
-      raw_matrix <- raw_matrix
-      fitted_matrix <- fitted_matrix
-      upr_matrix <- upr_matrix
-      lwr_matrix <- lwr_matrix
-    } else if (exp_method == "zscore") {
-      center <- Matrix::colMeans(transform_reference)
-      scale_sd <- MatrixGenerics::colSds(transform_reference)
-      raw_matrix <- scale(raw_matrix, center = center, scale = scale_sd)
-      fitted_matrix <- scale(fitted_matrix, center = center, scale = scale_sd)
-      upr_matrix <- scale(upr_matrix, center = center, scale = scale_sd)
-      lwr_matrix <- scale(lwr_matrix, center = center, scale = scale_sd)
-    } else if (exp_method == "fc") {
-      colm <- Matrix::colMeans(transform_reference)
-      raw_matrix <- t(t(raw_matrix) / colm)
-      fitted_matrix <- t(t(fitted_matrix) / colm)
-      upr_matrix <- t(t(upr_matrix) / colm)
-      lwr_matrix <- t(t(lwr_matrix) / colm)
-    } else if (exp_method == "log2fc") {
-      colm <- Matrix::colMeans(transform_reference)
-      raw_matrix <- t(log2(t(raw_matrix) / colm))
-      fitted_matrix <- t(log2(t(fitted_matrix) / colm))
-      upr_matrix <- t(log2(t(upr_matrix) / colm))
-      lwr_matrix <- t(log2(t(lwr_matrix) / colm))
-    } else if (exp_method == "log1p") {
-      raw_matrix <- log1p(raw_matrix)
-      fitted_matrix <- log1p(fitted_matrix)
-      upr_matrix <- log1p(upr_matrix)
-      lwr_matrix <- log1p(lwr_matrix)
-    }
-    raw_matrix <- replace_infinite(raw_matrix)
-    fitted_matrix <- replace_infinite(fitted_matrix)
-    upr_matrix <- replace_infinite(upr_matrix)
-    lwr_matrix <- replace_infinite(lwr_matrix)
 
     raw <- as.data.frame(cbind(
       cell_metadata[rownames(raw_matrix), c(l, "x_assign")],
@@ -657,7 +746,7 @@ DynamicPlot <- function(
 
     df_tmp <- rbind(raw, fitted)
     df_tmp[["Lineages"]] <- factor(l, levels = lineages)
-    df_tmp[["FitGroup"]] <- if (is.null(fit.by)) {
+    df_tmp[[fit_group_col]] <- if (is.null(fit.by)) {
       factor("all")
     } else {
       factor(fit_group, levels = fit_group_levels)
@@ -684,9 +773,18 @@ DynamicPlot <- function(
   )
   df_all[["LineagesFeaturesFitGroups"]] <- paste(
     df_all[["LineagesFeatures"]],
-    df_all[["FitGroup"]],
+    df_all[[fit_group_col]],
     sep = "-"
   )
+
+  fitted_group_levels <- if (is.null(fit.by)) {
+    character()
+  } else {
+    fitted_groups_all <- unique(as.character(df_all[[fit_group_col]][
+      df_all[["Value"]] == "fitted" & is.finite(df_all[["exp"]])
+    ]))
+    fit_group_levels[fit_group_levels %in% fitted_groups_all]
+  }
 
   if (!is.null(cells)) {
     df_all <- df_all[df_all[["Cell"]] %in% cells, , drop = FALSE]
@@ -725,7 +823,7 @@ DynamicPlot <- function(
     features_guide <- FALSE
   }
   if (!is.null(fit.by)) {
-    fill_by <- "FitGroup"
+    fill_by <- fit_group_col
   }
 
   for (l in lineages_use) {
@@ -738,19 +836,24 @@ DynamicPlot <- function(
         df[, "x_assign"] <- rank(df[, "x_assign"])
         df[, "Pseudotime"] <- rank(df[, "Pseudotime"])
       }
+      point_columns <- c("Cell", "x_assign", "exp", group.by)
+      if (!isTRUE(compare_features)) {
+        point_columns <- c(point_columns, "Features")
+      }
+      if (!isTRUE(compare_lineages)) {
+        point_columns <- c(point_columns, "Lineages")
+      }
       df_point <- unique(df[
         df[["Value"]] == "raw",
-        unique(c(
-          "Cell", "x_assign", "exp", "Features", "Lineages", group.by
-        ))
+        unique(point_columns)
       ])
-      fitted_groups <- unique(as.character(df[["FitGroup"]][
+      fitted_groups <- unique(as.character(df[[fit_group_col]][
         df[["Value"]] == "fitted" & is.finite(df[["exp"]])
       ]))
       point_groups <- if (is.null(fit.by)) {
         character()
       } else {
-        unique(as.character(df[["FitGroup"]][df[["Value"]] == "raw"]))
+        unique(as.character(df[[fit_group_col]][df[["Value"]] == "raw"]))
       }
       hide_point_guide <- identical(group.by, fit.by) &&
         isTRUE(add_line) &&
@@ -758,6 +861,16 @@ DynamicPlot <- function(
       fit_series <- unique(as.character(df[["LineagesFeatures"]]))
       fit_series <- fit_series[nzchar(fit_series)]
       distinguish_fit_series <- !is.null(fit.by) && length(fit_series) > 1
+      if (
+        (isTRUE(add_line) || isTRUE(add_interval)) &&
+          isTRUE(distinguish_fit_series) &&
+          length(fit_series) > 6
+      ) {
+        log_message(
+          "Grouped combined plots support at most six lineage-feature series. Set {.arg compare_lineages} or {.arg compare_features} to {.val FALSE}.",
+          message_type = "error"
+        )
+      }
       if (isTRUE(compare_features)) {
         raw_point <- NULL
       } else {
@@ -839,26 +952,69 @@ DynamicPlot <- function(
       }
 
       if (isTRUE(add_interval)) {
-        interval <- list(
+        interval_data <- subset(
+          df,
+          df[["Value"]] == "fitted" &
+            is.finite(df[["exp"]]) &
+            is.finite(df[["lwr"]]) &
+            is.finite(df[["upr"]])
+        )
+        distinguish_interval_series <- !is.null(fit.by) &&
+          !isTRUE(add_line) &&
+          isTRUE(distinguish_fit_series)
+        interval_mapping <- if (isTRUE(distinguish_interval_series)) {
+          aes(
+            x = .data[["Pseudotime"]],
+            y = .data[["exp"]],
+            ymin = .data[["lwr"]],
+            ymax = .data[["upr"]],
+            fill = .data[[fill_by]],
+            linetype = .data[["LineagesFeatures"]],
+            group = .data[["LineagesFeaturesFitGroups"]]
+          )
+        } else {
+          aes(
+            x = .data[["Pseudotime"]],
+            y = .data[["exp"]],
+            ymin = .data[["lwr"]],
+            ymax = .data[["upr"]],
+            fill = .data[[fill_by]],
+            group = .data[["LineagesFeaturesFitGroups"]]
+          )
+        }
+        interval_geom <- if (isTRUE(distinguish_interval_series)) {
           geom_ribbon(
-            data = subset(
-              df,
-              df[["Value"]] == "fitted" &
-                is.finite(df[["exp"]]) &
-                is.finite(df[["lwr"]]) &
-                is.finite(df[["upr"]])
-            ),
-            mapping = aes(
-              x = .data[["Pseudotime"]],
-              y = .data[["exp"]],
-              ymin = .data[["lwr"]],
-              ymax = .data[["upr"]],
-              fill = .data[[fill_by]],
-              group = .data[["LineagesFeaturesFitGroups"]]
-            ),
+            data = interval_data,
+            mapping = interval_mapping,
+            alpha = 0.4,
+            color = "grey30",
+            linewidth = 0.4
+          )
+        } else {
+          geom_ribbon(
+            data = interval_data,
+            mapping = interval_mapping,
             alpha = 0.4,
             color = "grey90"
-          ),
+          )
+        }
+        interval_linetype_scale <- if (isTRUE(distinguish_interval_series)) {
+          linetype_values <- c(
+            "solid", "dashed", "dotted", "dotdash", "longdash", "twodash"
+          )[seq_along(fit_series)]
+          names(linetype_values) <- fit_series
+          scale_linetype_manual(
+            name = "Lineage - feature",
+            values = linetype_values,
+            limits = fit_series,
+            drop = FALSE,
+            guide = guide_legend(order = 3)
+          )
+        } else {
+          NULL
+        }
+        interval <- list(
+          interval_geom,
           scale_fill_manual(
             values = palette_colors(
               df[[fill_by]],
@@ -874,6 +1030,8 @@ DynamicPlot <- function(
               }
             ),
             name = if (is.null(fit.by)) NULL else fit.by,
+            limits = if (is.null(fit.by)) NULL else fitted_group_levels,
+            drop = is.null(fit.by),
             guide = if (!is.null(fit.by) && isTRUE(add_line)) {
               "none"
             } else if (!is.null(fit.by)) {
@@ -886,6 +1044,7 @@ DynamicPlot <- function(
               guide_legend()
             }
           ),
+          interval_linetype_scale,
           ggnewscale::new_scale_fill()
         )
       } else {
@@ -897,7 +1056,7 @@ DynamicPlot <- function(
             aes(
               x = .data[["Pseudotime"]],
               y = .data[["exp"]],
-              color = .data[["FitGroup"]],
+              color = .data[[fit_group_col]],
               linetype = .data[["LineagesFeatures"]],
               group = .data[["LineagesFeaturesFitGroups"]]
             )
@@ -905,15 +1064,14 @@ DynamicPlot <- function(
             aes(
               x = .data[["Pseudotime"]],
               y = .data[["exp"]],
-              color = .data[["FitGroup"]],
+              color = .data[[fit_group_col]],
               group = .data[["LineagesFeaturesFitGroups"]]
             )
           }
           linetype_scale <- if (isTRUE(distinguish_fit_series)) {
-            linetype_values <- rep(
-              c("solid", "dashed", "dotted", "dotdash", "longdash", "twodash"),
-              length.out = length(fit_series)
-            )
+            linetype_values <- c(
+              "solid", "dashed", "dotted", "dotdash", "longdash", "twodash"
+            )[seq_along(fit_series)]
             names(linetype_values) <- fit_series
             scale_linetype_manual(
               name = "Lineage - feature",
@@ -936,7 +1094,7 @@ DynamicPlot <- function(
             scale_color_manual(
               name = fit.by,
               values = palette_colors(
-                df[["FitGroup"]],
+                df[[fit_group_col]],
                 palette = if (identical(group.by, fit.by)) {
                   point_palette
                 } else {
@@ -948,6 +1106,8 @@ DynamicPlot <- function(
                   line_palcolor
                 }
               ),
+              limits = fitted_group_levels,
+              drop = FALSE,
               guide = guide_legend(
                 override.aes = list(alpha = 1, linewidth = 2),
                 order = 2

--- a/R/DynamicPlot.R
+++ b/R/DynamicPlot.R
@@ -682,10 +682,26 @@ DynamicPlot <- function(
     } else {
       stats::setNames(as.numeric(libsize), colnames(srt))
     }
-    normalization_center <- stats::median(libsize_all)
   } else {
     libsize_all <- NULL
-    normalization_center <- stats::median(y_libsize)
+  }
+  normalization_libsize <- libsize_all %||% y_libsize
+  valid_normalization_libsize <- is.finite(normalization_libsize) &
+    normalization_libsize > 0
+  normalization_center <- if (any(valid_normalization_libsize)) {
+    stats::median(normalization_libsize[valid_normalization_libsize])
+  } else {
+    NA_real_
+  }
+  if (
+    isTRUE(lib_normalize) &&
+      length(gene) > 0 &&
+      !is.finite(normalization_center)
+  ) {
+    log_message(
+      "No finite positive library sizes are available for normalization.",
+      message_type = "error"
+    )
   }
 
   for (fit_id in names(raw_matrix_list)) {
@@ -782,20 +798,23 @@ DynamicPlot <- function(
       lwr_matrix <- lwr_matrix_list[[fit_id]]
 
       if (exp_method == "zscore") {
-        center <- Matrix::colMeans(transform_reference)
-        scale_sd <- MatrixGenerics::colSds(transform_reference)
+        center <- Matrix::colMeans(transform_reference, na.rm = TRUE)
+        scale_sd <- MatrixGenerics::colSds(
+          transform_reference,
+          na.rm = TRUE
+        )
         raw_matrix <- scale(raw_matrix, center = center, scale = scale_sd)
         fitted_matrix <- scale(fitted_matrix, center = center, scale = scale_sd)
         upr_matrix <- scale(upr_matrix, center = center, scale = scale_sd)
         lwr_matrix <- scale(lwr_matrix, center = center, scale = scale_sd)
       } else if (exp_method == "fc") {
-        colm <- Matrix::colMeans(transform_reference)
+        colm <- Matrix::colMeans(transform_reference, na.rm = TRUE)
         raw_matrix <- t(t(raw_matrix) / colm)
         fitted_matrix <- t(t(fitted_matrix) / colm)
         upr_matrix <- t(t(upr_matrix) / colm)
         lwr_matrix <- t(t(lwr_matrix) / colm)
       } else if (exp_method == "log2fc") {
-        colm <- Matrix::colMeans(transform_reference)
+        colm <- Matrix::colMeans(transform_reference, na.rm = TRUE)
         raw_matrix <- t(log2(t(raw_matrix) / colm))
         fitted_matrix <- t(log2(t(fitted_matrix) / colm))
         upr_matrix <- t(log2(t(upr_matrix) / colm))
@@ -1000,6 +1019,31 @@ DynamicPlot <- function(
     "solid", "dashed", "dotted", "dotdash", "longdash", "twodash"
   )[seq_along(fit_series_levels)]
   names(linetype_values) <- fit_series_levels
+  point_group_levels <- character()
+  point_palette_values <- NULL
+  if (!is.null(group.by)) {
+    point_groups_present <- unique(as.character(df_all[[group.by]][
+      df_all[["Value"]] == "raw"
+    ]))
+    point_groups_present <- point_groups_present[
+      !is.na(point_groups_present) & nzchar(point_groups_present)
+    ]
+    point_group_levels <- if (is.factor(df_all[[group.by]])) {
+      levels(df_all[[group.by]])[
+        levels(df_all[[group.by]]) %in% point_groups_present
+      ]
+    } else {
+      point_groups_present
+    }
+    point_palette_values <- palette_colors(
+      df_all[[group.by]],
+      palette = point_palette,
+      palcolor = point_palcolor
+    )
+  }
+  hide_point_guide <- identical(group.by, fit.by) &&
+    isTRUE(add_line) &&
+    all(point_group_levels %in% fitted_group_levels)
 
   if (!is.null(cells)) {
     df_all <- df_all[df_all[["Cell"]] %in% cells, , drop = FALSE]
@@ -1062,17 +1106,6 @@ DynamicPlot <- function(
         df[["Value"]] == "raw",
         unique(point_columns)
       ])
-      fitted_groups <- unique(as.character(df[[fit_group_col]][
-        df[["Value"]] == "fitted" & is.finite(df[["exp"]])
-      ]))
-      point_groups <- if (is.null(fit.by)) {
-        character()
-      } else {
-        unique(as.character(df[[fit_group_col]][df[["Value"]] == "raw"]))
-      }
-      hide_point_guide <- identical(group.by, fit.by) &&
-        isTRUE(add_line) &&
-        all(point_groups %in% fitted_groups)
       distinguish_fit_series <- !is.null(fit.by) && length(fit_series) > 1
       if (
         (isTRUE(add_line) || isTRUE(add_interval)) &&
@@ -1108,11 +1141,13 @@ DynamicPlot <- function(
                 alpha = 0.8
               ),
               scale_color_manual(
-                values = palette_colors(
-                  df[[group.by]],
-                  palette = point_palette,
-                  palcolor = point_palcolor
-                ),
+                values = point_palette_values,
+                limits = if (identical(group.by, fit.by)) {
+                  point_group_levels
+                } else {
+                  NULL
+                },
+                drop = !identical(group.by, fit.by),
                 guide = if (isTRUE(hide_point_guide)) {
                   "none"
                 } else {
@@ -1151,11 +1186,13 @@ DynamicPlot <- function(
               show.legend = isTRUE(compare_features)
             ),
             scale_color_manual(
-              values = palette_colors(
-                df[[group.by]],
-                palette = point_palette,
-                palcolor = point_palcolor
-              )
+              values = point_palette_values,
+              limits = if (identical(group.by, fit.by)) {
+                point_group_levels
+              } else {
+                NULL
+              },
+              drop = !identical(group.by, fit.by)
             ),
             ggnewscale::new_scale_color()
           )

--- a/R/RunDynamicFeatures.R
+++ b/R/RunDynamicFeatures.R
@@ -390,6 +390,14 @@ dynamic_features_gam <- function(
   verbose
 ) {
   l_libsize <- y_libsize[names(t_ordered)]
+  valid_libsize <- is.finite(y_libsize) & y_libsize > 0
+  if (!any(valid_libsize)) {
+    log_message(
+      "No finite positive library sizes are available for GAM fitting.",
+      message_type = "error"
+    )
+  }
+  libsize_center <- stats::median(y_libsize[valid_libsize])
   gam_out <- parallelize_fun(
     rownames(y_ordered),
     function(n) {
@@ -413,7 +421,7 @@ dynamic_features_gam <- function(
       if (layer == "counts" && family_use != "gaussian" && !n %in% meta) {
         l_use <- l_libsize
       } else {
-        l_use <- rep(stats::median(y_libsize), ncol(y_ordered))
+        l_use <- rep(libsize_center, ncol(y_ordered))
       }
       valid <- is.finite(y) & is.finite(t_ordered) & is.finite(l_use) & l_use > 0
       if (sum(valid) < 4 || length(unique(t_ordered[valid])) < 3) {
@@ -424,7 +432,7 @@ dynamic_features_gam <- function(
         )
         log_message("insufficient finite observations", message_type = "error")
       }
-      sizefactror <- stats::median(y_libsize) / l_use
+      sizefactror <- libsize_center / l_use
       mod <- mgcv::gam(
         y ~ s(x, bs = "cs") + offset(log(l_use)),
         family = family_use,

--- a/R/RunDynamicFeatures.R
+++ b/R/RunDynamicFeatures.R
@@ -255,10 +255,7 @@ RunDynamicFeatures <- function(
     verbose = verbose
   )
 
-  if (layer == "counts") {
-    gene_status <- status
-  }
-  gene_status <- status <- CheckDataType(srt, assay = assay, layer = layer)
+  gene_status <- CheckDataType(srt, assay = assay, layer = layer)
   meta_status <- sapply(meta, function(x) {
     CheckDataType(srt[[x]])
   })

--- a/man/DynamicPlot.Rd
+++ b/man/DynamicPlot.Rd
@@ -63,7 +63,8 @@ be used.}
 \item{fit.by}{Optional metadata column used to fit an independent trajectory
 for each group over that group's observed pseudotime range. The fit is not
 extrapolated beyond observed cells. This does not change the existing
-point-coloring behavior of \code{group.by}.}
+point-coloring behavior of \code{group.by}. Groups with fewer than 10 cells or 10
+unique pseudotime values are shown as raw points or rugs but are not fitted.}
 
 \item{cells}{Cell names to use.}
 

--- a/man/DynamicPlot.Rd
+++ b/man/DynamicPlot.Rd
@@ -10,6 +10,7 @@ DynamicPlot(
   features,
   group.by = NULL,
   group_use = NULL,
+  fit.by = NULL,
   cells = NULL,
   layer = "counts",
   assay = NULL,
@@ -58,6 +59,11 @@ DynamicPlot(
 \item{group_use}{Groups from \code{group.by} to
 keep. If both \code{group_use} and \code{cells} are provided, their intersection will
 be used.}
+
+\item{fit.by}{Optional metadata column used to fit an independent trajectory
+for each group over that group's observed pseudotime range. The fit is not
+extrapolated beyond observed cells. This does not change the existing
+point-coloring behavior of \code{group.by}.}
 
 \item{cells}{Cell names to use.}
 
@@ -133,6 +139,23 @@ DynamicPlot(
   group.by = "SubCellType",
   group_use = c("Ductal", "Beta"),
   compare_features = TRUE
+)
+
+# Demonstration only: create two conditions spanning the same pseudotime.
+lineage1_cells <- rownames(pancreas_sub@meta.data)[
+  order(pancreas_sub$Lineage1, na.last = NA)
+]
+pancreas_sub$condition <- NA_character_
+pancreas_sub$condition[lineage1_cells] <- rep(
+  c("control", "HUA"),
+  length.out = length(lineage1_cells)
+)
+DynamicPlot(
+  pancreas_sub,
+  lineages = "Lineage1",
+  features = "Vim",
+  group.by = "condition",
+  fit.by = "condition"
 )
 
 DynamicPlot(

--- a/man/DynamicPlot.Rd
+++ b/man/DynamicPlot.Rd
@@ -10,7 +10,6 @@ DynamicPlot(
   features,
   group.by = NULL,
   group_use = NULL,
-  fit.by = NULL,
   cells = NULL,
   layer = "counts",
   assay = NULL,
@@ -44,7 +43,8 @@ DynamicPlot(
   byrow = TRUE,
   cores = 1,
   verbose = TRUE,
-  seed = 11
+  seed = 11,
+  fit.by = NULL
 )
 }
 \arguments{

--- a/man/DynamicPlot.Rd
+++ b/man/DynamicPlot.Rd
@@ -75,14 +75,17 @@ unique pseudotime values are shown as raw points or rugs but are not fitted.}
 \item{family}{GLM family. \code{NULL} chooses automatically.}
 
 \item{exp_method}{Expression transform: \code{"log1p"}, \code{"raw"}, \code{"zscore"}, \code{"fc"},
-or \code{"log2fc"}.}
+or \code{"log2fc"}. With \code{fit.by}, transform parameters are shared across groups
+within each lineage.}
 
 \item{lib_normalize}{Library-size normalize. Defaults to \code{TRUE} when \code{layer}
 is counts.}
 
 \item{libsize}{Library size for each cell.}
 
-\item{compare_lineages, compare_features}{Compare lineages or features on one plot.}
+\item{compare_lineages, compare_features}{Compare lineages or features on one
+plot. Grouped line or interval plots support up to six combined
+lineage-feature series.}
 
 \item{add_line, add_interval, line.size, line_palette, line_palcolor}{Fitted line and CI.}
 

--- a/tests/testthat/test-dynamic-features-gam.R
+++ b/tests/testthat/test-dynamic-features-gam.R
@@ -118,3 +118,29 @@ test_that("dynamic raw matrix matches legacy construction", {
 
   expect_equal(dynamic_raw_matrix(y_ordered, t_ordered), legacy)
 })
+
+test_that("RunDynamicFeatures accepts custom library sizes for counts", {
+  if (identical(Sys.info()[["sysname"]], "Darwin") && getRversion() >= "4.6.0") {
+    skip("mgcv can segfault while loading on macOS ARM with R >= 4.6")
+  }
+  skip_if_not_installed("mgcv")
+
+  cells <- paste0("cell", seq_len(24))
+  counts <- Matrix::Matrix(
+    rbind(Gene1 = seq_len(24), Gene2 = rev(seq_len(24))),
+    sparse = TRUE
+  )
+  colnames(counts) <- cells
+  srt <- Seurat::CreateSeuratObject(counts)
+  srt$Lineage1 <- seq(0, 1, length.out = ncol(srt))
+
+  expect_no_error(
+    RunDynamicFeatures(
+      srt,
+      lineages = "Lineage1",
+      features = "Gene1",
+      libsize = rep(1, ncol(srt)),
+      verbose = FALSE
+    )
+  )
+})

--- a/tests/testthat/test-dynamic-features-gam.R
+++ b/tests/testthat/test-dynamic-features-gam.R
@@ -144,3 +144,33 @@ test_that("RunDynamicFeatures accepts custom library sizes for counts", {
     )
   )
 })
+
+test_that("RunDynamicFeatures ignores unusable library sizes outside a lineage", {
+  if (identical(Sys.info()[["sysname"]], "Darwin") && getRversion() >= "4.6.0") {
+    skip("mgcv can segfault while loading on macOS ARM with R >= 4.6")
+  }
+  skip_if_not_installed("mgcv")
+
+  cells <- paste0("cell", seq_len(24))
+  counts <- Matrix::Matrix(
+    rbind(Gene1 = seq_len(24)),
+    sparse = TRUE
+  )
+  colnames(counts) <- cells
+  srt <- Seurat::CreateSeuratObject(counts)
+  srt$Lineage1 <- c(seq(0, 1, length.out = 12), rep(NA_real_, 12))
+  srt$score <- rep(c(1, 3, 2, 5, 4, 6, 5, 8, 7, 9, 8, 10), 2)
+  custom_libsize <- rep(1, ncol(srt))
+  custom_libsize[24] <- NA_real_
+
+  out <- RunDynamicFeatures(
+    srt,
+    lineages = "Lineage1",
+    features = "score",
+    family = "gaussian",
+    libsize = custom_libsize,
+    verbose = FALSE
+  )
+  fitted <- out@tools[["DynamicFeatures_Lineage1"]]$fitted_matrix[, "score"]
+  expect_equal(sum(is.finite(fitted)), 12)
+})

--- a/tests/testthat/test-dynamic-plot-group-fit.R
+++ b/tests/testthat/test-dynamic-plot-group-fit.R
@@ -255,6 +255,7 @@ test_that("DynamicPlot keeps raw points when a group lacks enough GAM support", 
 test_that("DynamicPlot subsets custom library sizes for grouped raw points", {
   srt <- make_dynamic_plot_test_object()
   custom_libsize <- seq_len(ncol(srt))
+  custom_libsize[24] <- NA_real_
 
   testthat::local_mocked_bindings(
     RunDynamicFeatures = function(srt, lineages, features, ...) {
@@ -263,7 +264,7 @@ test_that("DynamicPlot subsets custom library sizes for grouped raw points", {
     .package = "scop"
   )
 
-  plots <- DynamicPlot(
+  plots <- suppressWarnings(DynamicPlot(
     srt,
     lineages = "Lineage1",
     features = "Gene1",
@@ -276,10 +277,14 @@ test_that("DynamicPlot subsets custom library sizes for grouped raw points", {
     add_rug = FALSE,
     combine = FALSE,
     verbose = FALSE
-  )
+  ))
 
   point_data <- dynamic_plot_built_layer(plots[[1]], "point")
-  expect_equal(unique(point_data$y), stats::median(custom_libsize))
+  expect_equal(sum(is.finite(point_data$y)), 23)
+  expect_equal(
+    unique(point_data$y[is.finite(point_data$y)]),
+    stats::median(custom_libsize, na.rm = TRUE)
+  )
 })
 
 test_that("DynamicPlot uses shared expression transforms across fit groups", {
@@ -324,6 +329,37 @@ test_that("DynamicPlot uses shared expression transforms across fit groups", {
       tolerance = 1e-8,
       info = method
     )
+  }
+})
+
+test_that("DynamicPlot shared transforms ignore partial missing values", {
+  srt <- make_dynamic_plot_test_object()
+  srt$score <- seq_len(ncol(srt))
+  srt$score[3] <- NA_real_
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  for (method in c("zscore", "fc", "log2fc")) {
+    plots <- suppressWarnings(DynamicPlot(
+      srt,
+      lineages = "Lineage1",
+      features = "score",
+      fit.by = "condition",
+      exp_method = method,
+      lib_normalize = FALSE,
+      add_line = FALSE,
+      add_interval = FALSE,
+      add_rug = FALSE,
+      combine = FALSE,
+      verbose = FALSE
+    ))
+    point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+    expect_equal(sum(is.finite(point_data$y)), 23)
   }
 })
 
@@ -645,6 +681,65 @@ test_that("DynamicPlot builds grouped legends from every panel", {
   )
   expect_length(fit_scales, 1)
   expect_setequal(fit_scales[[1]]$get_breaks(), c("control", "HUA"))
+})
+
+test_that("DynamicPlot keeps a point guide for globally raw-only fit groups", {
+  cells <- paste0("cell", seq_len(25))
+  counts <- Matrix::Matrix(
+    rbind(Gene1 = seq_len(25)),
+    sparse = TRUE
+  )
+  colnames(counts) <- cells
+  srt <- Seurat::CreateSeuratObject(counts)
+  srt$condition <- c(rep("A", 10), rep("B", 10), rep("C", 5))
+  srt$Lineage1 <- c(
+    seq(0, 1, length.out = 10),
+    seq(0, 1, length.out = 10),
+    rep(NA_real_, 5)
+  )
+  srt$Lineage2 <- c(
+    seq(0, 1, length.out = 10),
+    rep(NA_real_, 10),
+    seq(0, 1, length.out = 5)
+  )
+  legend_plot <- NULL
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(
+        srt,
+        lineages,
+        features,
+        fitted_by_group = c(A = 1, B = 2, C = 3)
+      )
+    },
+    get_legend = function(plot) {
+      legend_plot <<- plot
+      grid::nullGrob()
+    },
+    .package = "scop"
+  )
+
+  DynamicPlot(
+    srt,
+    lineages = c("Lineage1", "Lineage2"),
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    compare_lineages = FALSE,
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  scales <- ggplot2::ggplot_build(legend_plot)$plot$scales$scales
+  has_raw_only_guide <- any(vapply(scales, function(x) {
+    "C" %in% x$get_breaks() && !identical(x$guide, "none")
+  }, logical(1)))
+  expect_true(has_raw_only_guide)
 })
 
 test_that("DynamicPlot deduplicates points across compared lineages", {

--- a/tests/testthat/test-dynamic-plot-group-fit.R
+++ b/tests/testthat/test-dynamic-plot-group-fit.R
@@ -287,6 +287,38 @@ test_that("DynamicPlot subsets custom library sizes for grouped raw points", {
   )
 })
 
+test_that("DynamicPlot masks zero library sizes before shared transforms", {
+  srt <- make_dynamic_plot_test_object()
+  custom_libsize <- rep(1, ncol(srt))
+  custom_libsize[24] <- 0
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- suppressWarnings(DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    libsize = custom_libsize,
+    exp_method = "zscore",
+    add_line = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  ))
+
+  point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+  expect_equal(sum(is.finite(point_data$y)), 23)
+  expect_false(any(is.infinite(point_data$y)))
+})
+
 test_that("DynamicPlot uses shared expression transforms across fit groups", {
   values <- c(rep(1, 12), rep(3, 12))
   srt <- make_dynamic_plot_test_object(gene1_values = values)
@@ -740,6 +772,115 @@ test_that("DynamicPlot keeps a point guide for globally raw-only fit groups", {
     "C" %in% x$get_breaks() && !identical(x$guide, "none")
   }, logical(1)))
   expect_true(has_raw_only_guide)
+})
+
+test_that("DynamicPlot keeps a rug guide for globally raw-only fit groups", {
+  cells <- paste0("cell", seq_len(25))
+  counts <- Matrix::Matrix(rbind(Gene1 = seq_len(25)), sparse = TRUE)
+  colnames(counts) <- cells
+  srt <- Seurat::CreateSeuratObject(counts)
+  srt$condition <- c(rep("A", 10), rep("B", 10), rep("C", 5))
+  srt$Lineage1 <- c(
+    seq(0, 1, length.out = 10),
+    seq(0, 1, length.out = 10),
+    rep(NA_real_, 5)
+  )
+  srt$Lineage2 <- c(
+    seq(0, 1, length.out = 10),
+    rep(NA_real_, 10),
+    seq(0, 1, length.out = 5)
+  )
+  legend_plot <- NULL
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(
+        srt,
+        lineages,
+        features,
+        fitted_by_group = c(A = 1, B = 2, C = 3)
+      )
+    },
+    get_legend = function(plot) {
+      legend_plot <<- plot
+      grid::nullGrob()
+    },
+    .package = "scop"
+  )
+
+  DynamicPlot(
+    srt,
+    lineages = c("Lineage1", "Lineage2"),
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    compare_lineages = FALSE,
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_point = FALSE,
+    add_rug = TRUE,
+    add_interval = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  built <- ggplot2::ggplot_build(legend_plot)$plot
+  rug_layers <- Filter(
+    function(x) inherits(x$geom, "GeomRug"),
+    built$layers
+  )
+  expect_length(rug_layers, 1)
+  expect_true(rug_layers[[1]]$show.legend)
+  expect_true(any(vapply(built$scales$scales, function(x) {
+    "C" %in% x$get_breaks() && !identical(x$guide, "none")
+  }, logical(1))))
+})
+
+test_that("DynamicPlot disambiguates combined series legend labels", {
+  srt <- make_dynamic_plot_test_object()
+  srt@meta.data[["A - B"]] <- srt$Lineage1
+  srt@meta.data[["A"]] <- srt$Lineage2
+  srt@meta.data[["C"]] <- seq_len(ncol(srt))
+  srt@meta.data[["B - C"]] <- rev(seq_len(ncol(srt)))
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = c("A - B", "A"),
+    features = c("C", "B - C"),
+    fit.by = "condition",
+    compare_lineages = TRUE,
+    compare_features = TRUE,
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_point = FALSE,
+    add_rug = FALSE,
+    add_interval = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  scales <- ggplot2::ggplot_build(plots[[1]])$plot$scales$scales
+  linetype_scale <- Filter(
+    function(x) "linetype" %in% x$aesthetics,
+    scales
+  )[[1]]
+  expect_length(unique(linetype_scale$get_labels()), 4)
+  expect_setequal(
+    linetype_scale$get_labels(),
+    c(
+      "Lineage: A - B; feature: C",
+      "Lineage: A; feature: C",
+      "Lineage: A - B; feature: B - C",
+      "Lineage: A; feature: B - C"
+    )
+  )
 })
 
 test_that("DynamicPlot deduplicates points across compared lineages", {

--- a/tests/testthat/test-dynamic-plot-group-fit.R
+++ b/tests/testthat/test-dynamic-plot-group-fit.R
@@ -424,3 +424,238 @@ test_that("DynamicPlot uses factor levels for matching point and line colors", {
   )
   expect_identical(line_colors[names(point_colors)], point_colors)
 })
+
+test_that("DynamicPlot preserves metadata named FitGroup", {
+  srt <- make_dynamic_plot_test_object()
+  srt$FitGroup <- rep(c("meta-A", "meta-B"), times = 12)
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "FitGroup",
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_line = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+  expect_equal(length(unique(point_data$colour)), 2)
+})
+
+test_that("DynamicPlot applies custom transforms over the shared lineage", {
+  srt <- make_dynamic_plot_test_object(
+    gene1_values = c(rep(1, 12), rep(3, 12))
+  )
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(
+        srt,
+        lineages,
+        features,
+        fitted_by_group = c(control = 1, HUA = 3)
+      )
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    exp_method = function(x) x - mean(x, na.rm = TRUE),
+    lib_normalize = FALSE,
+    add_line = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+  group_means <- sort(as.numeric(tapply(
+    point_data$y,
+    point_data$colour,
+    mean
+  )))
+  expect_equal(group_means, c(-1, 1))
+})
+
+test_that("DynamicPlot caps log2fc infinities over the shared lineage", {
+  values <- c(0, 1:11, 0, rep(100, 11))
+  srt <- make_dynamic_plot_test_object(gene1_values = values)
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    exp_method = "log2fc",
+    lib_normalize = FALSE,
+    add_line = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+  group_minima <- tapply(point_data$y, point_data$colour, min)
+  expect_equal(length(unique(round(group_minima, 8))), 1)
+})
+
+test_that("DynamicPlot distinguishes interval-only combined series", {
+  srt <- make_dynamic_plot_test_object()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = c("Lineage1", "Lineage2"),
+    features = c("Gene1", "Gene2"),
+    fit.by = "condition",
+    compare_lineages = TRUE,
+    compare_features = TRUE,
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_point = FALSE,
+    add_line = FALSE,
+    add_interval = TRUE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  built <- ggplot2::ggplot_build(plots[[1]])$data
+  ribbon_data <- built[[which(vapply(
+    built,
+    function(x) "ymin" %in% names(x),
+    logical(1)
+  ))[1]]]
+  expect_equal(length(unique(ribbon_data$linetype)), 4)
+})
+
+test_that("DynamicPlot rejects more than six grouped combined series", {
+  srt <- make_dynamic_plot_test_object()
+  for (i in 3:7) {
+    srt[[paste0("Lineage", i)]] <- srt$Lineage1
+  }
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  expect_error(
+    DynamicPlot(
+      srt,
+      lineages = paste0("Lineage", 1:7),
+      features = "Gene1",
+      fit.by = "condition",
+      compare_lineages = TRUE,
+      exp_method = "raw",
+      lib_normalize = FALSE,
+      add_point = FALSE,
+      add_interval = FALSE,
+      add_rug = FALSE,
+      combine = FALSE,
+      verbose = FALSE
+    ),
+    "at most six"
+  )
+})
+
+test_that("DynamicPlot builds grouped legends from every panel", {
+  srt <- make_dynamic_plot_test_object()
+  srt$Lineage1[paste0("cell", 13:24)] <- NA_real_
+  srt$Lineage2[paste0("cell", 1:12)] <- NA_real_
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = c("Lineage1", "Lineage2"),
+    features = "Gene1",
+    fit.by = "condition",
+    compare_lineages = FALSE,
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_point = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  built <- ggplot2::ggplot_build(plots[[1]])
+  fit_scales <- Filter(
+    function(x) identical(x$name, "condition"),
+    built$plot$scales$scales
+  )
+  expect_length(fit_scales, 1)
+  expect_setequal(fit_scales[[1]]$get_breaks(), c("control", "HUA"))
+})
+
+test_that("DynamicPlot deduplicates points across compared lineages", {
+  srt <- make_dynamic_plot_test_object()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = c("Lineage1", "Lineage2"),
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    compare_lineages = TRUE,
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_line = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+  expect_equal(nrow(point_data), ncol(srt))
+})

--- a/tests/testthat/test-dynamic-plot-group-fit.R
+++ b/tests/testthat/test-dynamic-plot-group-fit.R
@@ -914,3 +914,102 @@ test_that("DynamicPlot preserves metadata named LineagesFeaturesFitGroups", {
   point_data <- dynamic_plot_built_layer(plots[[1]], "point")
   expect_equal(length(unique(point_data$colour)), 2)
 })
+
+test_that("DynamicPlot keeps global linetypes when panel fits differ", {
+  srt <- make_dynamic_plot_test_object()
+  srt$condition <- "all"
+  srt$Lineage1[13:24] <- NA_real_
+  srt$Lineage2[1:12] <- NA_real_
+  srt$score1 <- seq_len(ncol(srt))
+  srt$score1[1:12] <- NA_real_
+  srt$score2 <- rev(seq_len(ncol(srt)))
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(
+        srt,
+        lineages,
+        features,
+        fitted_by_group = c(all = 1)
+      )
+    },
+    .package = "scop"
+  )
+
+  for (add_line in c(TRUE, FALSE)) {
+    plots <- DynamicPlot(
+      srt,
+      lineages = c("Lineage1", "Lineage2"),
+      features = c("score1", "score2"),
+      fit.by = "condition",
+      compare_lineages = FALSE,
+      compare_features = TRUE,
+      exp_method = "raw",
+      lib_normalize = FALSE,
+      add_line = add_line,
+      add_interval = !add_line,
+      add_point = FALSE,
+      add_rug = FALSE,
+      combine = FALSE,
+      verbose = FALSE
+    )
+
+    plot_layers <- lapply(plots, function(plot) {
+      layers <- ggplot2::ggplot_build(plot)$data
+      is_target <- vapply(layers, function(x) {
+        if (add_line) {
+          "linewidth" %in% names(x) && !"ymin" %in% names(x)
+        } else {
+          "ymin" %in% names(x)
+        }
+      }, logical(1))
+      layers[[which(is_target)[1]]]
+    })
+    lineage1_score2 <- as.character(unique(plot_layers[[1]]$linetype))
+    score2_rows <- if (add_line) {
+      plot_layers[[2]]$y == 2
+    } else {
+      plot_layers[[2]]$group == max(plot_layers[[2]]$group)
+    }
+    lineage2_score2 <- as.character(unique(
+      plot_layers[[2]]$linetype[score2_rows]
+    ))
+    expect_identical(lineage1_score2, lineage2_score2)
+  }
+})
+
+test_that("DynamicPlot preserves unnamed family order before feature regrouping", {
+  srt <- make_dynamic_plot_test_object()
+  srt$score <- seq_len(ncol(srt))
+  fitted_families <- list()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, family, ...) {
+      cells <- rownames(srt@meta.data)[is.finite(srt@meta.data[[lineages]])]
+      group <- as.character(srt$condition[cells][1])
+      fitted_families[[group]] <<- family
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = c("score", "Gene1"),
+    fit.by = "condition",
+    family = c("gaussian", "nb"),
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_line = TRUE,
+    add_interval = FALSE,
+    add_point = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  expected <- c(Gene1 = "nb", score = "gaussian")
+  expect_identical(fitted_families[["control"]], expected)
+  expect_identical(fitted_families[["HUA"]], expected)
+})

--- a/tests/testthat/test-dynamic-plot-group-fit.R
+++ b/tests/testthat/test-dynamic-plot-group-fit.R
@@ -1,0 +1,178 @@
+make_dynamic_plot_test_object <- function() {
+  cells <- paste0("cell", seq_len(12))
+  counts <- Matrix::Matrix(
+    matrix(
+      seq_len(12),
+      nrow = 1,
+      dimnames = list("Gene1", cells)
+    ),
+    sparse = TRUE
+  )
+  srt <- Seurat::CreateSeuratObject(counts)
+  srt$Lineage1 <- rep(seq(0, 1, length.out = 6), 2)
+  srt$condition <- rep(c("control", "HUA"), each = 6)
+  srt
+}
+
+test_that("DynamicPlot fits each fit.by group independently", {
+  srt <- make_dynamic_plot_test_object()
+  fitted_cells <- list()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      cells <- rownames(srt@meta.data)[is.finite(srt@meta.data[[lineages]])]
+      fitted_cells[[length(fitted_cells) + 1L]] <<- cells
+      fit_value <- if (all(srt$condition[cells] == "control")) 1 else 2
+      pseudotime <- srt@meta.data[cells, lineages, drop = TRUE]
+      raw <- cbind(
+        pseudotime = pseudotime,
+        Gene1 = as.numeric(srt[["RNA"]]$counts["Gene1", cells])
+      )
+      rownames(raw) <- cells
+      fitted <- cbind(
+        pseudotime = pseudotime,
+        Gene1 = rep(fit_value, length(cells))
+      )
+      rownames(fitted) <- cells
+      upr <- lwr <- fitted
+      upr[, "Gene1"] <- upr[, "Gene1"] + 0.1
+      lwr[, "Gene1"] <- lwr[, "Gene1"] - 0.1
+      srt@tools[[paste0("DynamicFeatures_", lineages)]] <- list(
+        raw_matrix = raw,
+        fitted_matrix = fitted,
+        upr_matrix = upr,
+        lwr_matrix = lwr
+      )
+      srt
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    layer = "counts",
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_point = FALSE,
+    add_rug = FALSE,
+    add_interval = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  expect_length(fitted_cells, 2)
+  expect_setequal(fitted_cells[[1]], paste0("cell", 1:6))
+  expect_setequal(fitted_cells[[2]], paste0("cell", 7:12))
+
+  built <- ggplot2::ggplot_build(plots[[1]])
+  line_data <- built$data[[1]]
+  expect_equal(length(unique(line_data$group)), 2)
+  expect_equal(sort(unique(line_data$y)), c(1, 2))
+})
+
+test_that("DynamicPlot group_use limits independently fitted groups", {
+  srt <- make_dynamic_plot_test_object()
+  fitted_cells <- list()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      cells <- rownames(srt@meta.data)[is.finite(srt@meta.data[[lineages]])]
+      fitted_cells[[length(fitted_cells) + 1L]] <<- cells
+      pseudotime <- srt@meta.data[cells, lineages, drop = TRUE]
+      matrix_out <- cbind(
+        pseudotime = pseudotime,
+        Gene1 = rep(1, length(cells))
+      )
+      rownames(matrix_out) <- cells
+      srt@tools[[paste0("DynamicFeatures_", lineages)]] <- list(
+        raw_matrix = matrix_out,
+        fitted_matrix = matrix_out,
+        upr_matrix = matrix_out,
+        lwr_matrix = matrix_out
+      )
+      srt
+    },
+    .package = "scop"
+  )
+
+  expect_no_error(DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "condition",
+    group_use = "HUA",
+    fit.by = "condition",
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_point = FALSE,
+    add_rug = FALSE,
+    add_interval = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  ))
+
+  expect_length(fitted_cells, 1)
+  expect_setequal(fitted_cells[[1]], paste0("cell", 7:12))
+})
+
+test_that("DynamicPlot preserves the existing overall fit by default", {
+  srt <- make_dynamic_plot_test_object()
+  cells <- rownames(srt@meta.data)
+  pseudotime <- srt$Lineage1
+  raw <- cbind(
+    pseudotime = pseudotime,
+    Gene1 = as.numeric(srt[["RNA"]]$counts["Gene1", cells])
+  )
+  fitted <- cbind(pseudotime = pseudotime, Gene1 = rep(3, length(cells)))
+  rownames(raw) <- rownames(fitted) <- cells
+  srt@tools$DynamicFeatures_Lineage1 <- list(
+    raw_matrix = raw,
+    fitted_matrix = fitted,
+    upr_matrix = fitted,
+    lwr_matrix = fitted
+  )
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(...) {
+      stop("The cached overall fit should be reused")
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "condition",
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_point = FALSE,
+    add_rug = FALSE,
+    add_interval = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  line_data <- ggplot2::ggplot_build(plots[[1]])$data[[1]]
+  expect_equal(length(unique(line_data$group)), 1)
+  expect_equal(unique(line_data$y), 3)
+})
+
+test_that("DynamicPlot validates fit.by", {
+  srt <- make_dynamic_plot_test_object()
+
+  expect_error(
+    DynamicPlot(
+      srt,
+      lineages = "Lineage1",
+      features = "Gene1",
+      fit.by = "missing_column",
+      verbose = FALSE
+    ),
+    "not in the meta.data"
+  )
+})

--- a/tests/testthat/test-dynamic-plot-group-fit.R
+++ b/tests/testthat/test-dynamic-plot-group-fit.R
@@ -1,16 +1,73 @@
-make_dynamic_plot_test_object <- function() {
-  cells <- paste0("cell", seq_len(12))
+make_dynamic_plot_test_object <- function(
+  n_per_group = 12,
+  factor_condition = FALSE,
+  gene1_values = NULL
+) {
+  n_cells <- 2 * n_per_group
+  cells <- paste0("cell", seq_len(n_cells))
+  gene1_values <- gene1_values %||% seq_len(n_cells)
   counts <- Matrix::Matrix(
-    matrix(
-      seq_len(12),
-      nrow = 1,
-      dimnames = list("Gene1", cells)
+    rbind(
+      Gene1 = gene1_values,
+      Gene2 = rev(seq_len(n_cells))
     ),
     sparse = TRUE
   )
+  colnames(counts) <- cells
   srt <- Seurat::CreateSeuratObject(counts)
-  srt$Lineage1 <- rep(seq(0, 1, length.out = 6), 2)
-  srt$condition <- rep(c("control", "HUA"), each = 6)
+  srt$Lineage1 <- rep(seq(0, 1, length.out = n_per_group), 2)
+  srt$Lineage2 <- rep(seq(1, 0, length.out = n_per_group), 2)
+  condition <- rep(c("control", "HUA"), each = n_per_group)
+  srt$condition <- if (isTRUE(factor_condition)) {
+    factor(condition, levels = c("HUA", "control"))
+  } else {
+    condition
+  }
+  srt
+}
+
+dynamic_plot_built_layer <- function(plot, type = c("point", "line")) {
+  type <- match.arg(type)
+  layers <- ggplot2::ggplot_build(plot)$data
+  matches <- vapply(layers, function(x) {
+    if (type == "point") {
+      "shape" %in% names(x)
+    } else {
+      "linewidth" %in% names(x) && !"ymin" %in% names(x)
+    }
+  }, logical(1))
+  layers[[which(matches)[1]]]
+}
+
+mock_dynamic_fit_result <- function(
+  srt,
+  lineages,
+  features,
+  fitted_by_group = c(control = 1, HUA = 2)
+) {
+  cells <- rownames(srt@meta.data)[is.finite(srt@meta.data[[lineages]])]
+  pseudotime <- srt@meta.data[cells, lineages, drop = TRUE]
+  raw_values <- as.matrix(srt[["RNA"]]$counts[features, cells, drop = FALSE])
+  raw <- cbind(pseudotime = pseudotime, t(raw_values))
+  group <- as.character(srt$condition[cells][1])
+  fit_base <- fitted_by_group[[group]]
+  fitted_values <- vapply(
+    seq_along(features),
+    function(i) rep(fit_base + i - 1, length(cells)),
+    numeric(length(cells))
+  )
+  fitted <- cbind(pseudotime = pseudotime, fitted_values)
+  colnames(fitted) <- c("pseudotime", features)
+  rownames(raw) <- rownames(fitted) <- cells
+  upr <- lwr <- fitted
+  upr[, features] <- upr[, features, drop = FALSE] + 0.1
+  lwr[, features] <- lwr[, features, drop = FALSE] - 0.1
+  srt@tools[[paste0("DynamicFeatures_", lineages)]] <- list(
+    raw_matrix = raw,
+    fitted_matrix = fitted,
+    upr_matrix = upr,
+    lwr_matrix = lwr
+  )
   srt
 }
 
@@ -22,28 +79,7 @@ test_that("DynamicPlot fits each fit.by group independently", {
     RunDynamicFeatures = function(srt, lineages, features, ...) {
       cells <- rownames(srt@meta.data)[is.finite(srt@meta.data[[lineages]])]
       fitted_cells[[length(fitted_cells) + 1L]] <<- cells
-      fit_value <- if (all(srt$condition[cells] == "control")) 1 else 2
-      pseudotime <- srt@meta.data[cells, lineages, drop = TRUE]
-      raw <- cbind(
-        pseudotime = pseudotime,
-        Gene1 = as.numeric(srt[["RNA"]]$counts["Gene1", cells])
-      )
-      rownames(raw) <- cells
-      fitted <- cbind(
-        pseudotime = pseudotime,
-        Gene1 = rep(fit_value, length(cells))
-      )
-      rownames(fitted) <- cells
-      upr <- lwr <- fitted
-      upr[, "Gene1"] <- upr[, "Gene1"] + 0.1
-      lwr[, "Gene1"] <- lwr[, "Gene1"] - 0.1
-      srt@tools[[paste0("DynamicFeatures_", lineages)]] <- list(
-        raw_matrix = raw,
-        fitted_matrix = fitted,
-        upr_matrix = upr,
-        lwr_matrix = lwr
-      )
-      srt
+      mock_dynamic_fit_result(srt, lineages, features)
     },
     .package = "scop"
   )
@@ -65,8 +101,8 @@ test_that("DynamicPlot fits each fit.by group independently", {
   )
 
   expect_length(fitted_cells, 2)
-  expect_setequal(fitted_cells[[1]], paste0("cell", 1:6))
-  expect_setequal(fitted_cells[[2]], paste0("cell", 7:12))
+  expect_setequal(fitted_cells[[1]], paste0("cell", 1:12))
+  expect_setequal(fitted_cells[[2]], paste0("cell", 13:24))
 
   built <- ggplot2::ggplot_build(plots[[1]])
   line_data <- built$data[[1]]
@@ -82,19 +118,7 @@ test_that("DynamicPlot group_use limits independently fitted groups", {
     RunDynamicFeatures = function(srt, lineages, features, ...) {
       cells <- rownames(srt@meta.data)[is.finite(srt@meta.data[[lineages]])]
       fitted_cells[[length(fitted_cells) + 1L]] <<- cells
-      pseudotime <- srt@meta.data[cells, lineages, drop = TRUE]
-      matrix_out <- cbind(
-        pseudotime = pseudotime,
-        Gene1 = rep(1, length(cells))
-      )
-      rownames(matrix_out) <- cells
-      srt@tools[[paste0("DynamicFeatures_", lineages)]] <- list(
-        raw_matrix = matrix_out,
-        fitted_matrix = matrix_out,
-        upr_matrix = matrix_out,
-        lwr_matrix = matrix_out
-      )
-      srt
+      mock_dynamic_fit_result(srt, lineages, features)
     },
     .package = "scop"
   )
@@ -116,7 +140,7 @@ test_that("DynamicPlot group_use limits independently fitted groups", {
   ))
 
   expect_length(fitted_cells, 1)
-  expect_setequal(fitted_cells[[1]], paste0("cell", 7:12))
+  expect_setequal(fitted_cells[[1]], paste0("cell", 13:24))
 })
 
 test_that("DynamicPlot preserves the existing overall fit by default", {
@@ -175,4 +199,228 @@ test_that("DynamicPlot validates fit.by", {
     ),
     "not in the meta.data"
   )
+})
+
+test_that("DynamicPlot keeps raw points when a group lacks enough GAM support", {
+  srt <- make_dynamic_plot_test_object()
+  srt$Lineage1[paste0("cell", 10:12)] <- NA_real_
+  fitted_groups <- character()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      cells <- rownames(srt@meta.data)[is.finite(srt@meta.data[[lineages]])]
+      fitted_groups <<- c(fitted_groups, as.character(srt$condition[cells][1]))
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  expect_identical(fitted_groups, "HUA")
+  point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+  expect_equal(nrow(point_data), 21)
+  expect_equal(length(unique(point_data$group)), 2)
+})
+
+test_that("DynamicPlot subsets custom library sizes for grouped raw points", {
+  srt <- make_dynamic_plot_test_object()
+  custom_libsize <- seq_len(ncol(srt))
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    libsize = custom_libsize,
+    exp_method = "raw",
+    add_line = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+  expect_equal(unique(point_data$y), stats::median(custom_libsize))
+})
+
+test_that("DynamicPlot uses shared expression transforms across fit groups", {
+  values <- c(rep(1, 12), rep(3, 12))
+  srt <- make_dynamic_plot_test_object(gene1_values = values)
+  expected <- list(
+    fc = c(0.5, 1.5),
+    log2fc = log2(c(0.5, 1.5)),
+    zscore = sort(unique(as.numeric(scale(values))))
+  )
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(
+        srt,
+        lineages,
+        features,
+        fitted_by_group = c(control = 1, HUA = 3)
+      )
+    },
+    .package = "scop"
+  )
+
+  for (method in names(expected)) {
+    plots <- DynamicPlot(
+      srt,
+      lineages = "Lineage1",
+      features = "Gene1",
+      fit.by = "condition",
+      exp_method = method,
+      lib_normalize = FALSE,
+      add_point = FALSE,
+      add_interval = FALSE,
+      add_rug = FALSE,
+      combine = FALSE,
+      verbose = FALSE
+    )
+    line_data <- dynamic_plot_built_layer(plots[[1]], "line")
+    expect_equal(
+      sort(unique(line_data$y)),
+      expected[[method]],
+      tolerance = 1e-8,
+      info = method
+    )
+  }
+})
+
+test_that("DynamicPlot retains series identity in grouped combined panels", {
+  srt <- make_dynamic_plot_test_object()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = c("Lineage1", "Lineage2"),
+    features = c("Gene1", "Gene2"),
+    fit.by = "condition",
+    compare_lineages = TRUE,
+    compare_features = TRUE,
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_point = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  line_data <- dynamic_plot_built_layer(plots[[1]], "line")
+  expect_equal(length(unique(line_data$linetype)), 4)
+})
+
+test_that("DynamicPlot keeps a grouped interval legend without fitted lines", {
+  srt <- make_dynamic_plot_test_object()
+  captured_plot <- NULL
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    get_legend = function(plot) {
+      captured_plot <<- plot
+      grid::nullGrob()
+    },
+    .package = "scop"
+  )
+
+  DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    fit.by = "condition",
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_point = FALSE,
+    add_line = FALSE,
+    add_interval = TRUE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  fill_scales <- Filter(
+    function(x) any(grepl("fill", x$aesthetics, fixed = TRUE)),
+    captured_plot$scales$scales
+  )
+  expect_true(any(vapply(
+    fill_scales,
+    function(x) !identical(x$guide, "none"),
+    logical(1)
+  )))
+})
+
+test_that("DynamicPlot uses factor levels for matching point and line colors", {
+  values <- c(rep(1, 12), rep(2, 12))
+  srt <- make_dynamic_plot_test_object(
+    factor_condition = TRUE,
+    gene1_values = values
+  )
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    point_palcolor = c("#D73027", "#2C7FB8"),
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+  line_data <- dynamic_plot_built_layer(plots[[1]], "line")
+  point_colors <- vapply(
+    split(point_data$colour, point_data$y),
+    function(x) unique(x)[1],
+    character(1)
+  )
+  line_colors <- vapply(
+    split(line_data$colour, line_data$y),
+    function(x) unique(x)[1],
+    character(1)
+  )
+  expect_identical(line_colors[names(point_colors)], point_colors)
 })

--- a/tests/testthat/test-dynamic-plot-group-fit.R
+++ b/tests/testthat/test-dynamic-plot-group-fit.R
@@ -773,3 +773,144 @@ test_that("DynamicPlot appends fit.by after the positional API", {
     )
   ))
 })
+
+test_that("DynamicPlot keeps grouped series keys collision safe", {
+  srt <- make_dynamic_plot_test_object()
+  srt[["A-B"]] <- seq_len(ncol(srt))
+  srt[["A"]] <- rev(seq_len(ncol(srt)))
+  srt$condition <- rep(c("C", "B-C"), each = 12)
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(
+        srt,
+        lineages,
+        features,
+        fitted_by_group = c(C = 1, `B-C` = 2)
+      )
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = c("A-B", "A"),
+    fit.by = "condition",
+    compare_features = TRUE,
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_interval = FALSE,
+    add_point = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  line_data <- dynamic_plot_built_layer(plots[[1]], "line")
+  expect_equal(length(unique(line_data$group)), 4)
+})
+
+test_that("DynamicPlot keeps feature linetypes stable across lineage panels", {
+  srt <- make_dynamic_plot_test_object()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(
+        srt,
+        lineages,
+        features,
+        fitted_by_group = c(control = 0, HUA = 10)
+      )
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = c("Lineage1", "Lineage2"),
+    features = c("Gene1", "Gene2"),
+    fit.by = "condition",
+    compare_lineages = FALSE,
+    compare_features = TRUE,
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_interval = FALSE,
+    add_point = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  linetypes <- lapply(plots, function(plot) {
+    line_data <- dynamic_plot_built_layer(plot, "line")
+    vapply(
+      split(line_data$linetype, line_data$y),
+      function(x) unique(x)[1],
+      character(1)
+    )
+  })
+  expect_identical(linetypes[[1]], linetypes[[2]])
+})
+
+test_that("DynamicPlot includes usable library sizes in feature support", {
+  srt <- make_dynamic_plot_test_object()
+  custom_libsize <- rep(1, ncol(srt))
+  custom_libsize[10:12] <- 0
+  fitted_groups <- character()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      cells <- rownames(srt@meta.data)[is.finite(srt@meta.data[[lineages]])]
+      fitted_groups <<- c(fitted_groups, as.character(srt$condition[cells][1]))
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    fit.by = "condition",
+    libsize = custom_libsize,
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_interval = FALSE,
+    add_point = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  expect_identical(fitted_groups, "HUA")
+})
+
+test_that("DynamicPlot preserves metadata named LineagesFeaturesFitGroups", {
+  srt <- make_dynamic_plot_test_object()
+  srt$LineagesFeaturesFitGroups <- rep(c("meta-A", "meta-B"), times = 12)
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "LineagesFeaturesFitGroups",
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_line = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+  expect_equal(length(unique(point_data$colour)), 2)
+})

--- a/tests/testthat/test-dynamic-plot-group-fit.R
+++ b/tests/testthat/test-dynamic-plot-group-fit.R
@@ -47,7 +47,24 @@ mock_dynamic_fit_result <- function(
 ) {
   cells <- rownames(srt@meta.data)[is.finite(srt@meta.data[[lineages]])]
   pseudotime <- srt@meta.data[cells, lineages, drop = TRUE]
-  raw_values <- as.matrix(srt[["RNA"]]$counts[features, cells, drop = FALSE])
+  gene_features <- features[features %in% rownames(srt[["RNA"]])]
+  meta_features <- features[features %in% colnames(srt@meta.data)]
+  raw_values <- matrix(
+    NA_real_,
+    nrow = length(features),
+    ncol = length(cells),
+    dimnames = list(features, cells)
+  )
+  if (length(gene_features) > 0) {
+    raw_values[gene_features, ] <- as.matrix(
+      srt[["RNA"]]$counts[gene_features, cells, drop = FALSE]
+    )
+  }
+  if (length(meta_features) > 0) {
+    raw_values[meta_features, ] <- t(as.matrix(
+      srt@meta.data[cells, meta_features, drop = FALSE]
+    ))
+  }
   raw <- cbind(pseudotime = pseudotime, t(raw_values))
   group <- as.character(srt$condition[cells][1])
   fit_base <- fitted_by_group[[group]]
@@ -658,4 +675,101 @@ test_that("DynamicPlot deduplicates points across compared lineages", {
 
   point_data <- dynamic_plot_built_layer(plots[[1]], "point")
   expect_equal(nrow(point_data), ncol(srt))
+})
+
+test_that("DynamicPlot keeps cells with missing fit groups as raw points", {
+  srt <- make_dynamic_plot_test_object()
+  srt$condition[c("cell1", "cell13")] <- c(NA_character_, "")
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = "Gene1",
+    group.by = "condition",
+    fit.by = "condition",
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_line = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  point_data <- dynamic_plot_built_layer(plots[[1]], "point")
+  expect_equal(nrow(point_data), ncol(srt))
+})
+
+test_that("DynamicPlot checks finite support for each fitted feature", {
+  srt <- make_dynamic_plot_test_object()
+  srt$score <- seq_len(ncol(srt))
+  srt$score[paste0("cell", 4:12)] <- NA_real_
+  fitted_features <- list()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      group <- as.character(srt$condition[
+        is.finite(srt@meta.data[[lineages]])
+      ][1])
+      fitted_features[[group]] <<- features
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  plots <- DynamicPlot(
+    srt,
+    lineages = "Lineage1",
+    features = c("Gene1", "score"),
+    fit.by = "condition",
+    exp_method = "raw",
+    lib_normalize = FALSE,
+    add_point = FALSE,
+    add_interval = FALSE,
+    add_rug = FALSE,
+    combine = FALSE,
+    verbose = FALSE
+  )
+
+  expect_identical(fitted_features[["control"]], "Gene1")
+  expect_setequal(fitted_features[["HUA"]], c("Gene1", "score"))
+  score_line <- dynamic_plot_built_layer(plots[["Lineage1.score"]], "line")
+  expect_equal(length(unique(score_line$colour)), 1)
+})
+
+test_that("DynamicPlot appends fit.by after the positional API", {
+  srt <- make_dynamic_plot_test_object()
+
+  testthat::local_mocked_bindings(
+    RunDynamicFeatures = function(srt, lineages, features, ...) {
+      mock_dynamic_fit_result(srt, lineages, features)
+    },
+    .package = "scop"
+  )
+
+  expect_identical(names(formals(DynamicPlot))[[6]], "cells")
+  expect_identical(tail(names(formals(DynamicPlot)), 1), "fit.by")
+  expect_no_error(do.call(
+    DynamicPlot,
+    list(
+      srt,
+      "Lineage1",
+      "Gene1",
+      NULL,
+      NULL,
+      colnames(srt),
+      add_point = FALSE,
+      add_interval = FALSE,
+      add_rug = FALSE,
+      combine = FALSE,
+      verbose = FALSE
+    )
+  ))
 })


### PR DESCRIPTION
## Summary

- add an optional `fit.by` metadata column to `DynamicPlot()` without changing the existing positional API
- fit each selected group independently while preserving the existing overall-fit behavior when `fit.by = NULL`
- draw group-specific fitted lines and confidence intervals over each group’s observed pseudotime range without extrapolation
- retain raw points and rugs for groups, features, and unassigned cells that do not meet the default GAM support threshold
- check finite observations, unique pseudotime values, and usable library sizes independently for every feature before fitting
- use collision-safe internal columns and tuple identities for grouped paths without overwriting user metadata
- keep linetype assignments stable across separate lineage or feature panels
- apply built-in and function-valued transforms over a shared per-lineage comparison scope
- cap grouped transformed infinities consistently per feature and lineage
- preserve user metadata named `FitGroup` and other helper-like names through collision-proof internal columns
- keep grouped colors and legends consistent across factors and multiple panels
- preserve feature/lineage identity with linetypes in grouped line and interval-only panels
- reject more than six combined grouped series instead of recycling linetypes
- deduplicate raw points and rugs across compared lineages
- allow `RunDynamicFeatures()` count-layer fits with a custom `libsize` vector

## Validation

- `devtools::test(filter = "dynamic", stop_on_failure = FALSE)`: 74 passed, 0 failed, 0 warnings, 0 skipped
- grouped-fit coverage: 56 passed, including all twenty-nine Codex review regressions
- real `pancreas_sub` smoke: grouped lines and interval-only plots both preserve two group encodings and two feature linetypes with complete legends
- real GAM support smoke: a count feature with insufficient positive custom library sizes is skipped only in the affected group while the supported group remains fitted
- all-unassigned synthetic smoke: all 24 raw points remain visible without fitted trajectories
- `tools::checkRd("man/DynamicPlot.Rd")`: passed
- `styler`: all four newly touched source/test files unchanged
- `git diff --check`: passed
- the previous full local suite reached an unrelated network-dependent `cccdb` failure because Ensembl was unavailable; GitHub macOS, Windows, Ubuntu, and pkgdown checks passed on preceding grouped-fit commits