### PR TITLE
Redesign ClusterTreePlot layout and legends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     reticulate,
     rlang,
     ggforce,
-    ggplot2,
+    ggplot2 (>= 3.5.0),
     methods,
     Matrix,
     Rcpp,

--- a/R/ClusterTreePlot.R
+++ b/R/ClusterTreePlot.R
@@ -2,7 +2,10 @@
 #'
 #' @description
 #' Visualize how cells move between clusters across multiple Seurat clustering
-#' resolutions.
+#' resolutions. In the default direction, nodes are bottom-aligned so the tree
+#' expands from lower left to upper right; the direction can be reversed or
+#' transposed. Automatically detected resolutions are ordered numerically;
+#' explicit `cluster_cols` keep the supplied order.
 #'
 #' @md
 #' @inheritParams FeatureDimPlot
@@ -20,8 +23,21 @@
 #' @param edge_palette,edge_palcolor Palette used for edge colors.
 #' @param node_size Numeric range used for node sizes.
 #' @param edge_size Numeric range used for edge widths.
-#' @param legend.position The position of the legend. The default is
-#' `"bottom"` to keep the multiple cluster-tree guides compact.
+#' @param label Whether to draw cluster IDs inside nodes.
+#' @param label.size,label.fg Size and color of cluster-ID labels.
+#' `label.fg = "auto"` chooses black or white for each node from its fill.
+#' @param family Font family used for node labels, axes, titles, and legends.
+#' @param direction Tree direction: `"left-to-right"`, `"right-to-left"`,
+#' `"top-to-bottom"`, or `"bottom-to-top"`.
+#' @param title Plot title. `NULL` (the default) hides the redundant overall
+#' cluster-tree title; feature names are still shown as panel subtitles.
+#' @param subtitle Optional plot subtitle. When features are supplied and
+#' `subtitle = NULL`, the feature or feature-set name is used.
+#' @param xlab,ylab Axis titles.
+#' @param legend.position The position of the legend. The default is `"auto"`:
+#' a compact legend card is placed in the open corner on the starting side of
+#' the tree, with an automatic fallback to `"right"` for start-heavy trees.
+#' @param theme_use,theme_args Plot theme and additional theme arguments.
 #' @param return_data Whether to return plot data along with the plot.
 #'
 #' @return A `ggplot`, `patchwork`, list of `ggplot` objects, or a list with
@@ -62,22 +78,29 @@ ClusterTreePlot <- function(
   node_palcolor = NULL,
   edge_palette = "YlOrRd",
   edge_palcolor = NULL,
-  node_size = c(3, 10),
-  edge_size = c(0.25, 1.8),
+  node_size = c(4, 8.5),
+  edge_size = c(0.35, 2),
   label = TRUE,
-  label.size = 3,
-  label.fg = "black",
-  title = "Cluster tree",
+  label.size = 2.8,
+  label.fg = "auto",
+  title = NULL,
   subtitle = NULL,
   xlab = "Resolution",
   ylab = "Cluster",
-  legend.position = "bottom",
+  legend.position = "auto",
   theme_use = "theme_scop",
   theme_args = list(),
   combine = TRUE,
   ncol = NULL,
   return_data = FALSE,
-  verbose = TRUE
+  verbose = TRUE,
+  family = "Arial",
+  direction = c(
+    "left-to-right",
+    "right-to-left",
+    "top-to-bottom",
+    "bottom-to-top"
+  )
 ) {
   if (!inherits(srt, "Seurat")) {
     log_message(
@@ -85,6 +108,7 @@ ClusterTreePlot <- function(
       message_type = "error"
     )
   }
+  direction <- match.arg(direction)
   cluster_info <- clustertree_resolve_cluster_cols(
     srt = srt,
     cluster_cols = cluster_cols,
@@ -95,7 +119,12 @@ ClusterTreePlot <- function(
   tree_data <- clustertree_build_data(
     meta_data = srt@meta.data,
     cluster_info = cluster_info,
-    edge_threshold = edge_threshold
+    edge_threshold = edge_threshold,
+    node_size = node_size
+  )
+  legend.position <- clustertree_resolve_legend_position(
+    legend.position = legend.position,
+    nodes = tree_data$nodes
   )
 
   feature_values <- clustertree_feature_values(
@@ -121,17 +150,21 @@ ClusterTreePlot <- function(
         label = label,
         label.size = label.size,
         label.fg = label.fg,
+        family = family,
         title = title,
         subtitle = subtitle,
         xlab = xlab,
         ylab = ylab,
         legend.position = legend.position,
         theme_use = theme_use,
-        theme_args = theme_args
+        theme_args = theme_args,
+        show_shared_guides = TRUE,
+        direction = direction
       )
     )
   } else {
-    plots <- lapply(feature_names, function(feature_name) {
+    plots <- lapply(seq_along(feature_names), function(feature_index) {
+      feature_name <- feature_names[feature_index]
       plot_data <- tree_data
       plot_data$nodes <- merge(
         plot_data$nodes,
@@ -153,13 +186,18 @@ ClusterTreePlot <- function(
         label = label,
         label.size = label.size,
         label.fg = label.fg,
-        title = title %||% "Cluster tree",
+        family = family,
+        title = title,
         subtitle = subtitle,
         xlab = xlab,
         ylab = ylab,
         legend.position = legend.position,
         theme_use = theme_use,
-        theme_args = theme_args
+        theme_args = theme_args,
+        show_shared_guides = !isTRUE(combine) ||
+          length(feature_names) == 1L ||
+          feature_index == 1L,
+        direction = direction
       )
     })
     names(plots) <- feature_names
@@ -169,7 +207,9 @@ ClusterTreePlot <- function(
     plots = plots,
     combine = combine,
     ncol = ncol,
-    legend.position = legend.position
+    legend.position = legend.position,
+    family = family,
+    direction = direction
   )
   if (isTRUE(return_data)) {
     return(list(
@@ -288,7 +328,12 @@ clustertree_resolution_label <- function(resolution, column) {
   )
 }
 
-clustertree_build_data <- function(meta_data, cluster_info, edge_threshold = 0) {
+clustertree_build_data <- function(
+  meta_data,
+  cluster_info,
+  edge_threshold = 0,
+  node_size = c(4, 8.5)
+) {
   if (!is.numeric(edge_threshold) || length(edge_threshold) != 1L || is.na(edge_threshold) || edge_threshold < 0) {
     log_message(
       "{.arg edge_threshold} must be a non-negative number",
@@ -348,7 +393,11 @@ clustertree_build_data <- function(meta_data, cluster_info, edge_threshold = 0) 
   edges$in_prop <- edges$count / edges$to_size
   edges$out_prop <- edges$count / edges$from_size
 
-  nodes <- clustertree_layout_nodes(nodes = nodes, edges = edges)
+  nodes <- clustertree_layout_nodes(
+    nodes = nodes,
+    edges = edges,
+    node_size = node_size
+  )
   all_edges <- clustertree_attach_edge_coords(edges = edges, nodes = nodes)
   visible_edges <- all_edges[all_edges$in_prop >= edge_threshold, , drop = FALSE]
   list(nodes = nodes, edges = visible_edges, all_edges = all_edges)
@@ -363,13 +412,18 @@ clustertree_sort_clusters <- function(x) {
   x[order(x)]
 }
 
-clustertree_layout_nodes <- function(nodes, edges) {
+clustertree_layout_nodes <- function(nodes, edges, node_size = c(4, 8.5)) {
   level_ids <- sort(unique(nodes$resolution_index))
+  size_limits <- range(nodes$size, na.rm = TRUE)
   for (level_id in level_ids) {
     idx <- which(nodes$resolution_index == level_id)
     if (level_id == min(level_ids)) {
       node_order <- idx[order(match(nodes$cluster[idx], clustertree_sort_clusters(nodes$cluster[idx])))]
-      nodes$y[node_order] <- rev(seq_along(node_order))
+      nodes$y[node_order] <- clustertree_anchored_positions(
+        sizes = nodes$size[node_order],
+        size_limits = size_limits,
+        node_size = node_size
+      )
       next
     }
     incoming <- edges[edges$to_node %in% nodes$node_id[idx], , drop = FALSE]
@@ -382,9 +436,44 @@ clustertree_layout_nodes <- function(nodes, edges) {
       stats::weighted.mean(parent_y[edge_i$from_node], edge_i$count, na.rm = TRUE)
     }, numeric(1))
     node_order <- idx[order(-weighted_y, match(nodes$cluster[idx], clustertree_sort_clusters(nodes$cluster[idx])))]
-    nodes$y[node_order] <- rev(seq_along(node_order))
+    nodes$y[node_order] <- clustertree_anchored_positions(
+      sizes = nodes$size[node_order],
+      size_limits = size_limits,
+      node_size = node_size
+    )
   }
   nodes
+}
+
+clustertree_anchored_positions <- function(
+  sizes,
+  size_limits,
+  node_size = c(4, 8.5),
+  padding = 0.18
+) {
+  n_nodes <- length(sizes)
+  if (n_nodes <= 1L) {
+    return(0)
+  }
+  size_span <- diff(size_limits)
+  size_scaled <- if (is.finite(size_span) && size_span > 0) {
+    (sizes - size_limits[1L]) / size_span
+  } else {
+    rep(0.5, n_nodes)
+  }
+  size_scaled <- pmin(1, pmax(0, size_scaled))
+  diameters <- node_size[1L] + sqrt(size_scaled) * diff(node_size)
+  positive_scale_sizes <- node_size[is.finite(node_size) & node_size > 0]
+  baseline <- if (length(positive_scale_sizes) > 0L) {
+    min(positive_scale_sizes)
+  } else {
+    1
+  }
+  relative_diameters <- diameters / baseline
+  gaps <- 0.5 * (
+    relative_diameters[-n_nodes] + relative_diameters[-1L]
+  ) + padding
+  rev(c(0, cumsum(rev(gaps))))
 }
 
 clustertree_attach_edge_coords <- function(edges, nodes) {
@@ -548,6 +637,44 @@ clustertree_aggregate_feature_values <- function(values, meta_data, cluster_cols
   feature_nodes
 }
 
+clustertree_gradient_colors <- function(values, colors, na_color = "grey85") {
+  out <- rep(na_color, length(values))
+  keep <- is.finite(values)
+  if (!any(keep)) {
+    return(out)
+  }
+  value_range <- range(values[keep])
+  scaled <- if (diff(value_range) > 0) {
+    (values[keep] - value_range[1L]) / diff(value_range)
+  } else {
+    rep(0.5, sum(keep))
+  }
+  rgb_values <- grDevices::colorRamp(colors, space = "Lab")(scaled)
+  out[keep] <- grDevices::rgb(
+    rgb_values[, 1L],
+    rgb_values[, 2L],
+    rgb_values[, 3L],
+    maxColorValue = 255
+  )
+  out
+}
+
+clustertree_contrast_text <- function(fill_colors) {
+  fill_colors[is.na(fill_colors) | !nzchar(fill_colors)] <- "grey85"
+  rgb_values <- t(grDevices::col2rgb(fill_colors)) / 255
+  rgb_linear <- ifelse(
+    rgb_values <= 0.04045,
+    rgb_values / 12.92,
+    ((rgb_values + 0.055) / 1.055)^2.4
+  )
+  luminance <- 0.2126 * rgb_linear[, 1L] +
+    0.7152 * rgb_linear[, 2L] +
+    0.0722 * rgb_linear[, 3L]
+  contrast_black <- (luminance + 0.05) / 0.05
+  contrast_white <- 1.05 / (luminance + 0.05)
+  ifelse(contrast_white >= contrast_black, "white", "black")
+}
+
 clustertree_single_plot <- function(
   tree_data,
   feature_name = NULL,
@@ -555,27 +682,62 @@ clustertree_single_plot <- function(
   node_palcolor = NULL,
   edge_palette = "YlOrRd",
   edge_palcolor = NULL,
-  node_size = c(3, 10),
-  edge_size = c(0.25, 1.8),
+  node_size = c(4, 8.5),
+  edge_size = c(0.35, 2),
   label = TRUE,
-  label.size = 3,
-  label.fg = "black",
-  title = "Cluster tree",
+  label.size = 2.8,
+  label.fg = "auto",
+  family = "Arial",
+  title = NULL,
   subtitle = NULL,
   xlab = "Resolution",
   ylab = "Cluster",
-  legend.position = "bottom",
+  legend.position = "inside",
   theme_use = "theme_scop",
-  theme_args = list()
+  theme_args = list(),
+  show_shared_guides = TRUE,
+  direction = c(
+    "left-to-right",
+    "right-to-left",
+    "top-to-bottom",
+    "bottom-to-top"
+  )
 ) {
   theme_use <- resolve_plot_theme_use(theme_use)
+  direction <- match.arg(direction)
   nodes <- tree_data$nodes
   edges <- tree_data$edges
+  positive_node_sizes <- node_size[is.finite(node_size) & node_size > 0]
+  node_clearance <- if (length(positive_node_sizes) > 0L) {
+    max(positive_node_sizes) / (2 * min(positive_node_sizes)) + 0.18
+  } else {
+    0.5
+  }
   edge_cols <- palette_colors(
     palette = edge_palette,
     palcolor = edge_palcolor,
     n = 9
   )
+  reverse_resolution <- direction %in% c("right-to-left", "top-to-bottom")
+  vertical_tree <- direction %in% c("top-to-bottom", "bottom-to-top")
+  resolution_scale <- if (reverse_resolution) {
+    ggplot2::scale_x_reverse(
+      breaks = unique(nodes$x),
+      labels = unique(nodes$resolution_label),
+      expand = ggplot2::expansion(mult = c(0.04, 0.07))
+    )
+  } else {
+    ggplot2::scale_x_continuous(
+      breaks = unique(nodes$x),
+      labels = unique(nodes$resolution_label),
+      expand = ggplot2::expansion(mult = c(0.04, 0.07))
+    )
+  }
+  tree_coord <- if (vertical_tree) {
+    ggplot2::coord_flip(clip = "off")
+  } else {
+    ggplot2::coord_cartesian(clip = "off")
+  }
   p <- ggplot2::ggplot() +
     ggplot2::geom_segment(
       data = edges,
@@ -585,51 +747,74 @@ clustertree_single_plot <- function(
         xend = .data$xend,
         yend = .data$yend,
         linewidth = .data$count,
-        color = .data$count,
-        alpha = .data$in_prop
+        color = .data$in_prop
       ),
+      alpha = 0.9,
       lineend = "round",
-      arrow = grid::arrow(length = grid::unit(0.055, "inches"), type = "closed"),
       show.legend = TRUE
     ) +
-    ggplot2::scale_linewidth_continuous(name = "Cells moved", range = edge_size, guide = "none") +
-    ggplot2::scale_color_gradientn(
+    ggplot2::scale_linewidth_continuous(
       name = "Cells moved",
-      colours = edge_cols,
-      guide = clustertree_colorbar_guide(legend.position, order = 1)
+      range = edge_size,
+      breaks = clustertree_compact_breaks(2),
+      guide = if (isTRUE(show_shared_guides)) {
+        ggplot2::guide_legend(
+          order = 1,
+          title.position = "top",
+          title.hjust = 0,
+          nrow = 1,
+          byrow = TRUE,
+          override.aes = list(color = "black", alpha = 1)
+        )
+      } else {
+        "none"
+      }
     ) +
-    ggplot2::scale_alpha_continuous(
+    ggplot2::scale_color_gradientn(
       name = "Incoming share",
-      range = c(0.18, 0.9),
+      colours = edge_cols,
       limits = c(0, 1),
+      breaks = c(0, 0.5, 1),
       labels = function(x) paste0(round(x * 100), "%"),
-      guide = ggplot2::guide_legend(
-        order = 2,
-        title.position = "top",
-        title.hjust = 0.5,
-        override.aes = list(color = "grey45", linewidth = 1.3)
-      )
+      guide = if (isTRUE(show_shared_guides)) {
+        clustertree_colorbar_guide(legend.position, order = 2)
+      } else {
+        "none"
+      }
     ) +
     ggplot2::scale_size_continuous(
       name = "Cluster size",
       range = node_size,
-      guide = ggplot2::guide_legend(
-        order = 3,
-        title.position = "top",
-        title.hjust = 0.5,
-        override.aes = list(fill = "grey70", color = "grey95", alpha = 1)
-      )
+      breaks = clustertree_compact_breaks(3),
+      guide = if (isTRUE(show_shared_guides)) {
+        ggplot2::guide_legend(
+          order = 3,
+          title.position = "top",
+          title.hjust = 0,
+          nrow = 1,
+          byrow = TRUE,
+          override.aes = list(
+            fill = "white",
+            color = "black",
+            alpha = 1,
+            stroke = 0.45,
+            linewidth = 0,
+            linetype = 0
+          )
+        )
+      } else {
+        "none"
+      }
     ) +
-    ggplot2::scale_x_continuous(
-      breaks = unique(nodes$x),
-      labels = unique(nodes$resolution_label),
-      expand = ggplot2::expansion(mult = c(0.08, 0.16))
-    ) +
+    resolution_scale +
     ggplot2::scale_y_continuous(
       breaks = NULL,
-      expand = ggplot2::expansion(mult = c(0.12, 0.12), add = c(0.35, 0.35))
+      expand = ggplot2::expansion(
+        mult = c(0.035, 0.08),
+        add = c(node_clearance, node_clearance)
+      )
     ) +
-    ggplot2::coord_cartesian(clip = "off") +
+    tree_coord +
     ggplot2::labs(
       title = title,
       subtitle = subtitle %||% feature_name,
@@ -642,6 +827,10 @@ clustertree_single_plot <- function(
       palette = node_palette,
       palcolor = node_palcolor
     )
+    node_fill <- node_cols[match(
+      nodes$resolution_label,
+      unique(nodes$resolution_label)
+    )]
     p <- p +
       ggplot2::geom_point(
         data = nodes,
@@ -652,24 +841,24 @@ clustertree_single_plot <- function(
           fill = .data$resolution_label
         ),
         shape = 21,
-        color = "grey95",
-        stroke = 0.7
+        color = "white",
+        stroke = 0.8
       ) +
       ggplot2::scale_fill_manual(
         name = "Resolution",
         values = node_cols,
-        guide = ggplot2::guide_legend(
-          order = 4,
-          title.position = "top",
-          title.hjust = 0.5,
-          override.aes = list(color = "grey95", alpha = 1)
-        )
+        guide = "none"
       )
   } else {
     node_cols <- palette_colors(
       palette = node_palette,
       palcolor = node_palcolor,
       n = 9
+    )
+    node_fill <- clustertree_gradient_colors(
+      values = nodes$feature_value,
+      colors = node_cols,
+      na_color = "grey85"
     )
     p <- p +
       ggplot2::geom_point(
@@ -681,29 +870,49 @@ clustertree_single_plot <- function(
           fill = .data$feature_value
         ),
         shape = 21,
-        color = "grey95",
-        stroke = 0.7
+        color = "white",
+        stroke = 0.8
       ) +
       ggplot2::scale_fill_gradientn(
-        name = feature_name,
+        name = if (
+          clustertree_is_inside_legend(legend.position) && is.null(subtitle)
+        ) {
+          NULL
+        } else {
+          feature_name
+        },
         colours = node_cols,
         na.value = "grey85",
+        breaks = clustertree_compact_breaks(3),
         guide = clustertree_colorbar_guide(legend.position, order = 4)
       )
   }
+  nodes$.label_color <- if (identical(label.fg, "auto")) {
+    clustertree_contrast_text(node_fill)
+  } else {
+    rep_len(as.character(label.fg), nrow(nodes))
+  }
   if (isTRUE(label)) {
-    p <- p +
-      ggplot2::geom_text(
-        data = nodes,
-        ggplot2::aes(x = .data$x, y = .data$y, label = .data$cluster),
-        size = label.size,
-        color = label.fg,
-        show.legend = FALSE
-      )
+    for (label_color in unique(nodes$.label_color)) {
+      label_nodes <- nodes[nodes$.label_color == label_color, , drop = FALSE]
+      p <- p +
+        ggplot2::geom_text(
+          data = label_nodes,
+          ggplot2::aes(x = .data$x, y = .data$y, label = .data$cluster),
+          size = label.size,
+          color = label_color,
+          family = family,
+          show.legend = FALSE
+        )
+    }
   }
   p +
     do.call(theme_use, theme_args) +
-    clustertree_legend_theme(legend.position)
+    clustertree_legend_theme(
+      legend.position,
+      family = family,
+      direction = direction
+    )
 }
 
 clustertree_is_horizontal_legend <- function(legend.position) {
@@ -712,41 +921,222 @@ clustertree_is_horizontal_legend <- function(legend.position) {
     legend.position %in% c("bottom", "top")
 }
 
+clustertree_is_inside_legend <- function(legend.position) {
+  is.character(legend.position) &&
+    length(legend.position) == 1L &&
+    identical(legend.position, "inside")
+}
+
+clustertree_resolve_legend_position <- function(legend.position, nodes) {
+  if (!identical(legend.position, "auto")) {
+    return(legend.position)
+  }
+  level_ids <- sort(unique(nodes$resolution_index))
+  early_n <- max(1L, ceiling(length(level_ids) * 0.3))
+  early_ids <- level_ids[seq_len(early_n)]
+  early_top <- max(nodes$y[nodes$resolution_index %in% early_ids], na.rm = TRUE)
+  tree_top <- max(nodes$y, na.rm = TRUE)
+  first_count <- sum(nodes$resolution_index == level_ids[1L])
+  last_count <- sum(nodes$resolution_index == level_ids[length(level_ids)])
+  upper_left_clear <- is.finite(tree_top) &&
+    tree_top > 0 &&
+    early_top / tree_top <= 0.65 &&
+    first_count < last_count
+  if (isTRUE(upper_left_clear)) "inside" else "right"
+}
+
+clustertree_legend_anchor <- function(direction = "left-to-right") {
+  switch(
+    direction,
+    "left-to-right" = list(
+      position = c(0.022, 0.978),
+      justification = c(0, 1)
+    ),
+    "right-to-left" = list(
+      position = c(0.978, 0.978),
+      justification = c(1, 1)
+    ),
+    "top-to-bottom" = list(
+      position = c(0.978, 0.978),
+      justification = c(1, 1)
+    ),
+    "bottom-to-top" = list(
+      position = c(0.978, 0.022),
+      justification = c(1, 0)
+    ),
+    list(position = c(0.022, 0.978), justification = c(0, 1))
+  )
+}
+
+clustertree_compact_breaks <- function(n = 3L) {
+  force(n)
+  function(limits) {
+    limits <- as.numeric(limits)
+    limits <- limits[is.finite(limits)]
+    if (length(limits) == 0L) {
+      return(numeric())
+    }
+    limits <- range(limits)
+    if (diff(limits) == 0) {
+      return(limits[1L])
+    }
+    breaks <- pretty(limits, n = n)
+    breaks <- breaks[breaks >= limits[1L] & breaks <= limits[2L]]
+    if (length(breaks) <= n) {
+      return(breaks)
+    }
+    breaks[unique(round(seq(1, length(breaks), length.out = n)))]
+  }
+}
+
 clustertree_colorbar_guide <- function(legend.position, order = 1) {
-  horizontal <- clustertree_is_horizontal_legend(legend.position)
+  horizontal <- clustertree_is_horizontal_legend(legend.position) ||
+    clustertree_is_inside_legend(legend.position)
   ggplot2::guide_colorbar(
     order = order,
+    direction = if (horizontal) "horizontal" else "vertical",
     title.position = "top",
-    title.hjust = 0.5,
-    barwidth = if (horizontal) grid::unit(42, "pt") else grid::unit(5, "pt"),
-    barheight = if (horizontal) grid::unit(4, "pt") else grid::unit(42, "pt")
+    title.hjust = 0,
+    barwidth = if (horizontal) grid::unit(74, "pt") else grid::unit(7, "pt"),
+    barheight = if (horizontal) grid::unit(8, "pt") else grid::unit(48, "pt")
   )
 }
 
-clustertree_legend_theme <- function(legend.position) {
+clustertree_legend_theme <- function(
+  legend.position,
+  family = "Arial",
+  direction = "left-to-right"
+) {
   horizontal <- clustertree_is_horizontal_legend(legend.position)
+  inside <- clustertree_is_inside_legend(legend.position)
+  guide_horizontal <- horizontal || inside
+  vertical_tree <- direction %in% c("top-to-bottom", "bottom-to-top")
+  legend_anchor <- clustertree_legend_anchor(direction)
   ggplot2::theme(
+    text = ggplot2::element_text(family = family, color = "black"),
+    plot.title = ggplot2::element_text(
+      family = family,
+      face = "bold",
+      size = 13,
+      color = "black",
+      margin = ggplot2::margin(b = 4)
+    ),
+    plot.subtitle = ggplot2::element_text(
+      family = family,
+      face = "bold",
+      size = 11.5,
+      color = "black",
+      margin = ggplot2::margin(b = 7)
+    ),
+    axis.title = ggplot2::element_text(
+      family = family,
+      face = "plain",
+      size = 11,
+      color = "black"
+    ),
+    axis.text.x = if (vertical_tree) {
+      ggplot2::element_blank()
+    } else {
+      ggplot2::element_text(
+        family = family,
+        size = 10,
+        color = "black",
+        margin = ggplot2::margin(t = 4)
+      )
+    },
     legend.position = legend.position,
-    legend.direction = if (horizontal) "horizontal" else "vertical",
-    legend.box = if (horizontal) "horizontal" else "vertical",
-    legend.justification = if (horizontal) "center" else "top",
-    legend.box.just = if (horizontal) "center" else "left",
-    legend.title = ggplot2::element_text(size = 8),
-    legend.text = ggplot2::element_text(size = 7),
-    legend.key.height = grid::unit(8, "pt"),
-    legend.key.width = grid::unit(16, "pt"),
-    legend.spacing.x = grid::unit(4, "pt"),
-    legend.spacing.y = grid::unit(1, "pt"),
-    legend.margin = ggplot2::margin(t = 2, r = 2, b = 2, l = 2),
-    legend.box.margin = ggplot2::margin(t = 2, r = 4, b = 0, l = 4),
-    panel.grid.minor = ggplot2::element_blank(),
-    axis.text.y = ggplot2::element_blank(),
-    axis.ticks.y = ggplot2::element_blank(),
-    plot.margin = ggplot2::margin(t = 6, r = 12, b = 6, l = 6)
+    legend.position.inside = legend_anchor$position,
+    legend.direction = if (guide_horizontal) "horizontal" else "vertical",
+    legend.box = if (inside) "vertical" else if (horizontal) "horizontal" else "vertical",
+    legend.justification = if (inside) legend_anchor$justification else if (horizontal) "center" else "top",
+    legend.justification.inside = legend_anchor$justification,
+    legend.box.just = if (inside && legend_anchor$justification[1L] == 1) {
+      "right"
+    } else if (horizontal) {
+      "center"
+    } else {
+      "left"
+    },
+    legend.title = ggplot2::element_text(
+      family = family,
+      face = "bold",
+      size = 9.5,
+      color = "black"
+    ),
+    legend.text = ggplot2::element_text(
+      family = family,
+      size = 8.5,
+      color = "black"
+    ),
+    legend.key.height = grid::unit(14, "pt"),
+    legend.key.width = grid::unit(if (guide_horizontal) 24 else 16, "pt"),
+    legend.spacing.x = grid::unit(5, "pt"),
+    legend.spacing.y = grid::unit(if (inside) 1 else 4, "pt"),
+    legend.box.spacing = grid::unit(if (inside) 0 else 6, "pt"),
+    legend.margin = if (inside) {
+      ggplot2::margin(t = 0, r = 0, b = 0, l = 0)
+    } else {
+      ggplot2::margin(t = 2, r = 2, b = 2, l = 2)
+    },
+    legend.box.margin = if (inside) {
+      ggplot2::margin(t = 3, r = 5, b = 3, l = 5)
+    } else {
+      ggplot2::margin(t = 7, r = 5, b = 2, l = 5)
+    },
+    legend.background = ggplot2::element_blank(),
+    legend.box.background = if (inside) {
+      ggplot2::element_rect(
+        fill = grDevices::adjustcolor("white", alpha.f = 0.96),
+        color = NA
+      )
+    } else {
+      ggplot2::element_blank()
+    },
+    panel.grid = ggplot2::element_blank(),
+    panel.border = ggplot2::element_blank(),
+    axis.line.x = if (vertical_tree) {
+      ggplot2::element_blank()
+    } else {
+      ggplot2::element_line(color = "black", linewidth = 0.5)
+    },
+    axis.ticks.x = if (vertical_tree) {
+      ggplot2::element_blank()
+    } else {
+      ggplot2::element_line(color = "black", linewidth = 0.45)
+    },
+    axis.ticks.length = grid::unit(3, "pt"),
+    axis.line.y = if (vertical_tree) {
+      ggplot2::element_line(color = "black", linewidth = 0.5)
+    } else {
+      ggplot2::element_blank()
+    },
+    axis.text.y = if (vertical_tree) {
+      ggplot2::element_text(
+        family = family,
+        size = 10,
+        color = "black",
+        margin = ggplot2::margin(r = 4)
+      )
+    } else {
+      ggplot2::element_blank()
+    },
+    axis.ticks.y = if (vertical_tree) {
+      ggplot2::element_line(color = "black", linewidth = 0.45)
+    } else {
+      ggplot2::element_blank()
+    },
+    plot.margin = ggplot2::margin(t = 8, r = 12, b = 8, l = 8)
   )
 }
 
-clustertree_combine_plots <- function(plots, combine = TRUE, ncol = NULL, legend.position = "bottom") {
+clustertree_combine_plots <- function(
+  plots,
+  combine = TRUE,
+  ncol = NULL,
+  legend.position = "inside",
+  family = "Arial",
+  direction = "left-to-right"
+) {
   if (length(plots) == 1L) {
     return(plots[[1L]])
   }
@@ -754,6 +1144,15 @@ clustertree_combine_plots <- function(plots, combine = TRUE, ncol = NULL, legend
     return(plots)
   }
   check_r("patchwork", verbose = FALSE)
-  patchwork::wrap_plots(plotlist = plots, ncol = ncol, guides = "collect") &
-    clustertree_legend_theme(legend.position)
+  guides_mode <- if (clustertree_is_inside_legend(legend.position)) {
+    "keep"
+  } else {
+    "collect"
+  }
+  patchwork::wrap_plots(plotlist = plots, ncol = ncol, guides = guides_mode) &
+    clustertree_legend_theme(
+      legend.position,
+      family = family,
+      direction = direction
+    )
 }

--- a/R/ClusterTreePlot.R
+++ b/R/ClusterTreePlot.R
@@ -35,8 +35,9 @@
 #' `subtitle = NULL`, the feature or feature-set name is used.
 #' @param xlab,ylab Axis titles.
 #' @param legend.position The position of the legend. The default is `"auto"`:
-#' a compact legend card is placed in the open corner on the starting side of
-#' the tree, with an automatic fallback to `"right"` for start-heavy trees.
+#' horizontal trees place a compact guide row above the panel, aligned to the
+#' starting side, while vertical trees place guides on the right. Use
+#' `"inside"` to force an in-panel legend.
 #' @param theme_use,theme_args Plot theme and additional theme arguments.
 #' @param return_data Whether to return plot data along with the plot.
 #'
@@ -124,7 +125,8 @@ ClusterTreePlot <- function(
   )
   legend.position <- clustertree_resolve_legend_position(
     legend.position = legend.position,
-    nodes = tree_data$nodes
+    nodes = tree_data$nodes,
+    direction = direction
   )
 
   feature_values <- clustertree_feature_values(
@@ -785,7 +787,7 @@ clustertree_single_plot <- function(
     ggplot2::scale_size_continuous(
       name = "Cluster size",
       range = node_size,
-      breaks = clustertree_compact_breaks(3),
+      breaks = clustertree_compact_breaks(2),
       guide = if (isTRUE(show_shared_guides)) {
         ggplot2::guide_legend(
           order = 3,
@@ -875,7 +877,7 @@ clustertree_single_plot <- function(
       ) +
       ggplot2::scale_fill_gradientn(
         name = if (
-          clustertree_is_inside_legend(legend.position) && is.null(subtitle)
+          clustertree_is_compact_legend(legend.position) && is.null(subtitle)
         ) {
           NULL
         } else {
@@ -918,7 +920,7 @@ clustertree_single_plot <- function(
 clustertree_is_horizontal_legend <- function(legend.position) {
   is.character(legend.position) &&
     length(legend.position) == 1L &&
-    legend.position %in% c("bottom", "top")
+    legend.position %in% c("bottom", "top", "top-left", "top-right")
 }
 
 clustertree_is_inside_legend <- function(legend.position) {
@@ -927,22 +929,33 @@ clustertree_is_inside_legend <- function(legend.position) {
     identical(legend.position, "inside")
 }
 
-clustertree_resolve_legend_position <- function(legend.position, nodes) {
+clustertree_is_corner_legend <- function(legend.position) {
+  is.character(legend.position) &&
+    length(legend.position) == 1L &&
+    legend.position %in% c("top-left", "top-right")
+}
+
+clustertree_is_compact_legend <- function(legend.position) {
+  clustertree_is_inside_legend(legend.position) ||
+    clustertree_is_corner_legend(legend.position)
+}
+
+clustertree_resolve_legend_position <- function(
+  legend.position,
+  nodes = NULL,
+  direction = "left-to-right"
+) {
   if (!identical(legend.position, "auto")) {
     return(legend.position)
   }
-  level_ids <- sort(unique(nodes$resolution_index))
-  early_n <- max(1L, ceiling(length(level_ids) * 0.3))
-  early_ids <- level_ids[seq_len(early_n)]
-  early_top <- max(nodes$y[nodes$resolution_index %in% early_ids], na.rm = TRUE)
-  tree_top <- max(nodes$y, na.rm = TRUE)
-  first_count <- sum(nodes$resolution_index == level_ids[1L])
-  last_count <- sum(nodes$resolution_index == level_ids[length(level_ids)])
-  upper_left_clear <- is.finite(tree_top) &&
-    tree_top > 0 &&
-    early_top / tree_top <= 0.65 &&
-    first_count < last_count
-  if (isTRUE(upper_left_clear)) "inside" else "right"
+  switch(
+    direction,
+    "left-to-right" = "top-left",
+    "right-to-left" = "top-right",
+    "top-to-bottom" = "right",
+    "bottom-to-top" = "right",
+    "right"
+  )
 }
 
 clustertree_legend_anchor <- function(direction = "left-to-right") {
@@ -992,12 +1005,19 @@ clustertree_compact_breaks <- function(n = 3L) {
 clustertree_colorbar_guide <- function(legend.position, order = 1) {
   horizontal <- clustertree_is_horizontal_legend(legend.position) ||
     clustertree_is_inside_legend(legend.position)
+  corner <- clustertree_is_corner_legend(legend.position)
   ggplot2::guide_colorbar(
     order = order,
     direction = if (horizontal) "horizontal" else "vertical",
     title.position = "top",
     title.hjust = 0,
-    barwidth = if (horizontal) grid::unit(74, "pt") else grid::unit(7, "pt"),
+    barwidth = if (corner) {
+      grid::unit(60, "pt")
+    } else if (horizontal) {
+      grid::unit(74, "pt")
+    } else {
+      grid::unit(7, "pt")
+    },
     barheight = if (horizontal) grid::unit(8, "pt") else grid::unit(48, "pt")
   )
 }
@@ -1009,9 +1029,17 @@ clustertree_legend_theme <- function(
 ) {
   horizontal <- clustertree_is_horizontal_legend(legend.position)
   inside <- clustertree_is_inside_legend(legend.position)
+  corner <- clustertree_is_corner_legend(legend.position)
+  compact <- inside || corner
   guide_horizontal <- horizontal || inside
   vertical_tree <- direction %in% c("top-to-bottom", "bottom-to-top")
   legend_anchor <- clustertree_legend_anchor(direction)
+  legend_position_use <- if (corner) "top" else legend.position
+  corner_justification <- if (identical(legend.position, "top-right")) {
+    "right"
+  } else {
+    "left"
+  }
   ggplot2::theme(
     text = ggplot2::element_text(family = family, color = "black"),
     plot.title = ggplot2::element_text(
@@ -1044,13 +1072,29 @@ clustertree_legend_theme <- function(
         margin = ggplot2::margin(t = 4)
       )
     },
-    legend.position = legend.position,
+    legend.position = legend_position_use,
     legend.position.inside = legend_anchor$position,
     legend.direction = if (guide_horizontal) "horizontal" else "vertical",
-    legend.box = if (inside) "vertical" else if (horizontal) "horizontal" else "vertical",
-    legend.justification = if (inside) legend_anchor$justification else if (horizontal) "center" else "top",
+    legend.box = if (inside) {
+      "vertical"
+    } else if (corner || horizontal) {
+      "horizontal"
+    } else {
+      "vertical"
+    },
+    legend.justification = if (inside) {
+      legend_anchor$justification
+    } else if (corner) {
+      corner_justification
+    } else if (horizontal) {
+      "center"
+    } else {
+      "top"
+    },
     legend.justification.inside = legend_anchor$justification,
-    legend.box.just = if (inside && legend_anchor$justification[1L] == 1) {
+    legend.box.just = if (corner) {
+      corner_justification
+    } else if (inside && legend_anchor$justification[1L] == 1) {
       "right"
     } else if (horizontal) {
       "center"
@@ -1069,17 +1113,25 @@ clustertree_legend_theme <- function(
       color = "black"
     ),
     legend.key.height = grid::unit(14, "pt"),
-    legend.key.width = grid::unit(if (guide_horizontal) 24 else 16, "pt"),
-    legend.spacing.x = grid::unit(5, "pt"),
-    legend.spacing.y = grid::unit(if (inside) 1 else 4, "pt"),
-    legend.box.spacing = grid::unit(if (inside) 0 else 6, "pt"),
-    legend.margin = if (inside) {
+    legend.key.width = grid::unit(
+      if (corner) 20 else if (guide_horizontal) 24 else 16,
+      "pt"
+    ),
+    legend.spacing.x = grid::unit(if (corner) 3 else 5, "pt"),
+    legend.spacing.y = grid::unit(if (compact) 1 else 4, "pt"),
+    legend.box.spacing = grid::unit(if (compact) 0 else 6, "pt"),
+    legend.margin = if (compact) {
       ggplot2::margin(t = 0, r = 0, b = 0, l = 0)
     } else {
       ggplot2::margin(t = 2, r = 2, b = 2, l = 2)
     },
-    legend.box.margin = if (inside) {
-      ggplot2::margin(t = 3, r = 5, b = 3, l = 5)
+    legend.box.margin = if (compact) {
+      ggplot2::margin(
+        t = 3,
+        r = if (corner) 2 else 4,
+        b = 3,
+        l = if (corner) 2 else 4
+      )
     } else {
       ggplot2::margin(t = 7, r = 5, b = 2, l = 5)
     },

--- a/man/ClusterTreePlot.Rd
+++ b/man/ClusterTreePlot.Rd
@@ -87,8 +87,9 @@ cluster-tree title; feature names are still shown as panel subtitles.}
 \item{xlab, ylab}{Axis titles.}
 
 \item{legend.position}{The position of the legend. The default is \code{"auto"}:
-a compact legend card is placed in the open corner on the starting side of
-the tree, with an automatic fallback to \code{"right"} for start-heavy trees.}
+horizontal trees place a compact guide row above the panel, aligned to the
+starting side, while vertical trees place guides on the right. Use
+\code{"inside"} to force an in-panel legend.}
 
 \item{theme_use, theme_args}{Plot theme and additional theme arguments.}
 

--- a/man/ClusterTreePlot.Rd
+++ b/man/ClusterTreePlot.Rd
@@ -17,22 +17,29 @@ ClusterTreePlot(
   node_palcolor = NULL,
   edge_palette = "YlOrRd",
   edge_palcolor = NULL,
-  node_size = c(3, 10),
-  edge_size = c(0.25, 1.8),
+  node_size = c(4, 8.5),
+  edge_size = c(0.35, 2),
   label = TRUE,
-  label.size = 3,
-  label.fg = "black",
-  title = "Cluster tree",
+  label.size = 2.8,
+  label.fg = "auto",
+  title = NULL,
   subtitle = NULL,
   xlab = "Resolution",
   ylab = "Cluster",
-  legend.position = "bottom",
+  legend.position = "auto",
   theme_use = "theme_scop",
   theme_args = list(),
   combine = TRUE,
   ncol = NULL,
   return_data = FALSE,
-  verbose = TRUE
+  verbose = TRUE,
+  family = "Arial",
+  direction = c(
+    "left-to-right",
+    "right-to-left",
+    "top-to-bottom",
+    "bottom-to-top"
+  )
 )
 }
 \arguments{
@@ -66,32 +73,37 @@ Edges below this threshold are still available when \code{return_data = TRUE}.}
 
 \item{edge_size}{Numeric range used for edge widths.}
 
-\item{label}{Label high-expressing cells.}
+\item{label}{Whether to draw cluster IDs inside nodes.}
 
-\item{label.size}{Group labels. \code{label_insitu = FALSE} uses numbers instead of group names.}
+\item{label.size, label.fg}{Size and color of cluster-ID labels.
+\code{label.fg = "auto"} chooses black or white for each node from its fill.}
 
-\item{label.fg}{Group labels. \code{label_insitu = FALSE} uses numbers instead of group names.}
+\item{title}{Plot title. \code{NULL} (the default) hides the redundant overall
+cluster-tree title; feature names are still shown as panel subtitles.}
 
-\item{title}{Plot title. \code{NULL} hides the title for merged/single panels. When multiple lineages are plotted and \code{title} is \code{NULL}, each panel is titled with its lineage column.}
+\item{subtitle}{Optional plot subtitle. When features are supplied and
+\code{subtitle = NULL}, the feature or feature-set name is used.}
 
-\item{subtitle}{Plot subtitle.}
+\item{xlab, ylab}{Axis titles.}
 
-\item{xlab}{Plot labels.}
+\item{legend.position}{The position of the legend. The default is \code{"auto"}:
+a compact legend card is placed in the open corner on the starting side of
+the tree, with an automatic fallback to \code{"right"} for start-heavy trees.}
 
-\item{ylab}{Plot labels.}
+\item{theme_use, theme_args}{Plot theme and additional theme arguments.}
 
-\item{legend.position}{The position of the legend. The default is
-\code{"bottom"} to keep the multiple cluster-tree guides compact.}
-
-\item{theme_args}{Theme name or function, plus extra theme arguments.}
-
-\item{combine}{Combine plots with \link[patchwork:patchwork]{patchwork}. \code{combine = FALSE} returns a list of ggplots.}
+\item{combine}{Combine plots with \link[patchwork:patchwork-package]{patchwork::patchwork}. \code{combine = FALSE} returns a list of ggplots.}
 
 \item{ncol}{Number of columns of the combined plot.}
 
 \item{return_data}{Whether to return plot data along with the plot.}
 
 \item{verbose}{Whether to print messages.}
+
+\item{family}{Font family used for node labels, axes, titles, and legends.}
+
+\item{direction}{Tree direction: \code{"left-to-right"}, \code{"right-to-left"},
+\code{"top-to-bottom"}, or \code{"bottom-to-top"}.}
 }
 \value{
 A \code{ggplot}, \code{patchwork}, list of \code{ggplot} objects, or a list with
@@ -99,7 +111,10 @@ plot data when \code{return_data = TRUE}.
 }
 \description{
 Visualize how cells move between clusters across multiple Seurat clustering
-resolutions.
+resolutions. In the default direction, nodes are bottom-aligned so the tree
+expands from lower left to upper right; the direction can be reversed or
+transposed. Automatically detected resolutions are ordered numerically;
+explicit \code{cluster_cols} keep the supplied order.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-cluster-tree-plot.R
+++ b/tests/testthat/test-cluster-tree-plot.R
@@ -203,7 +203,7 @@ test_that("ClusterTreePlot supports all tree directions", {
   }
 })
 
-test_that("ClusterTreePlot moves auto legends away from left-heavy trees", {
+test_that("ClusterTreePlot keeps auto legends outside the plot panel", {
   srt <- make_cluster_tree_seurat()
 
   auto_plot <- ClusterTreePlot(
@@ -224,8 +224,41 @@ test_that("ClusterTreePlot moves auto legends away from left-heavy trees", {
     legend.position = "inside"
   )
 
-  expect_identical(auto_plot$theme$legend.position, "right")
+  expect_identical(auto_plot$theme$legend.position, "top")
+  expect_identical(auto_plot$theme$legend.justification, "left")
   expect_identical(forced_inside$theme$legend.position, "inside")
+})
+
+test_that("ClusterTreePlot auto legends follow tree direction without overlap", {
+  srt <- make_cluster_tree_seurat()
+  expected_positions <- c(
+    "left-to-right" = "top",
+    "right-to-left" = "top",
+    "top-to-bottom" = "right",
+    "bottom-to-top" = "right"
+  )
+  expected_top_justification <- c(
+    "left-to-right" = "left",
+    "right-to-left" = "right"
+  )
+
+  for (tree_direction in names(expected_positions)) {
+    plot <- ClusterTreePlot(
+      srt,
+      prefix = "RNA_snn",
+      direction = tree_direction
+    )
+    expect_identical(
+      plot$theme$legend.position,
+      unname(expected_positions[tree_direction])
+    )
+    if (tree_direction %in% names(expected_top_justification)) {
+      expect_identical(
+        plot$theme$legend.justification,
+        unname(expected_top_justification[tree_direction])
+      )
+    }
+  }
 })
 
 test_that("ClusterTreePlot respects explicit titles and font families", {

--- a/tests/testthat/test-cluster-tree-plot.R
+++ b/tests/testthat/test-cluster-tree-plot.R
@@ -89,24 +89,192 @@ test_that("ClusterTreePlot builds node and edge statistics", {
   expect_equal(edge$count, 2)
   expect_equal(edge$in_prop, 1)
   expect_equal(edge$out_prop, 2 / 3)
+
+  column_bottoms <- tapply(
+    tree_data$nodes$y,
+    tree_data$nodes$resolution_index,
+    min
+  )
+  expect_equal(as.numeric(column_bottoms), rep(0, length(column_bottoms)))
+
+  column_tops <- tapply(
+    tree_data$nodes$y,
+    tree_data$nodes$resolution_index,
+    max
+  )
+  expect_gt(tail(column_tops, 1), column_tops[1])
+
+  first_column_y <- tree_data$nodes$y[
+    tree_data$nodes$resolution_index == min(tree_data$nodes$resolution_index)
+  ]
+  expect_gt(min(diff(sort(first_column_y))), 1)
 })
 
 test_that("ClusterTreePlot returns ggplot for cluster tree", {
   srt <- make_cluster_tree_seurat()
 
-  plot <- ClusterTreePlot(srt, prefix = "RNA_snn")
+  plot <- ClusterTreePlot(
+    srt,
+    prefix = "RNA_snn",
+    legend.position = "inside"
+  )
 
   expect_s3_class(plot, "ggplot")
-  expect_identical(plot$theme$legend.position, "bottom")
+  expect_identical(formals(ClusterTreePlot)$legend.position, "auto")
+  expect_identical(plot$theme$legend.position, "inside")
+  expect_equal(plot$theme$legend.position.inside, c(0.022, 0.978))
+  expect_null(plot$labels$title)
+  expect_identical(plot$theme$text$family, "Arial")
+  expect_identical(plot$theme$text$colour, "black")
+  expect_identical(plot$theme$plot.subtitle$colour, "black")
+  expect_identical(plot$theme$axis.title$colour, "black")
+  expect_identical(plot$theme$axis.text.x$colour, "black")
+  expect_identical(plot$theme$axis.line.x$colour, "black")
+  expect_identical(plot$theme$axis.ticks.x$colour, "black")
+  expect_identical(plot$theme$legend.title$colour, "black")
+  expect_identical(plot$theme$legend.text$colour, "black")
+  expect_identical(plot$theme$legend.direction, "horizontal")
+  expect_identical(plot$theme$legend.box, "vertical")
+  text_layers <- Filter(
+    function(layer) inherits(layer$geom, "GeomText"),
+    plot$layers
+  )
+  label_colors <- vapply(
+    text_layers,
+    function(layer) layer$aes_params$colour,
+    character(1)
+  )
+  expect_true(all(label_colors %in% c("black", "white")))
+  expect_s3_class(plot$theme$panel.border, "element_blank")
 })
 
 test_that("ClusterTreePlot respects explicit legend position", {
   srt <- make_cluster_tree_seurat()
 
-  plot <- ClusterTreePlot(srt, prefix = "RNA_snn", legend.position = "right")
+  for (legend_position in c("inside", "bottom", "right", "none")) {
+    plot <- ClusterTreePlot(
+      srt,
+      prefix = "RNA_snn",
+      legend.position = legend_position
+    )
 
-  expect_s3_class(plot, "ggplot")
-  expect_identical(plot$theme$legend.position, "right")
+    expect_s3_class(plot, "ggplot")
+    expect_identical(plot$theme$legend.position, legend_position)
+  }
+})
+
+test_that("ClusterTreePlot supports all tree directions", {
+  srt <- make_cluster_tree_seurat()
+  directions <- c(
+    "left-to-right",
+    "right-to-left",
+    "top-to-bottom",
+    "bottom-to-top"
+  )
+  expected_anchors <- list(
+    "left-to-right" = c(0.022, 0.978),
+    "right-to-left" = c(0.978, 0.978),
+    "top-to-bottom" = c(0.978, 0.978),
+    "bottom-to-top" = c(0.978, 0.022)
+  )
+
+  for (tree_direction in directions) {
+    plot <- ClusterTreePlot(
+      srt,
+      prefix = "RNA_snn",
+      legend.position = "inside",
+      direction = tree_direction
+    )
+
+    expect_s3_class(plot, "ggplot")
+    expect_equal(
+      plot$theme$legend.position.inside,
+      expected_anchors[[tree_direction]]
+    )
+    if (tree_direction %in% c("top-to-bottom", "bottom-to-top")) {
+      expect_s3_class(plot$coordinates, "CoordFlip")
+      expect_s3_class(plot$theme$axis.line.x, "element_blank")
+      expect_s3_class(plot$theme$axis.line.y, "element_line")
+    } else {
+      expect_false(inherits(plot$coordinates, "CoordFlip"))
+      expect_s3_class(plot$theme$axis.line.x, "element_line")
+      expect_s3_class(plot$theme$axis.line.y, "element_blank")
+    }
+  }
+})
+
+test_that("ClusterTreePlot moves auto legends away from left-heavy trees", {
+  srt <- make_cluster_tree_seurat()
+
+  auto_plot <- ClusterTreePlot(
+    srt,
+    cluster_cols = c(
+      "RNA_snn_res.1",
+      "RNA_snn_res.0.8",
+      "RNA_snn_res.0.2"
+    )
+  )
+  forced_inside <- ClusterTreePlot(
+    srt,
+    cluster_cols = c(
+      "RNA_snn_res.1",
+      "RNA_snn_res.0.8",
+      "RNA_snn_res.0.2"
+    ),
+    legend.position = "inside"
+  )
+
+  expect_identical(auto_plot$theme$legend.position, "right")
+  expect_identical(forced_inside$theme$legend.position, "inside")
+})
+
+test_that("ClusterTreePlot respects explicit titles and font families", {
+  srt <- make_cluster_tree_seurat()
+
+  plot <- ClusterTreePlot(
+    srt,
+    prefix = "RNA_snn",
+    title = "My cluster tree",
+    family = "Helvetica",
+    label.fg = "black"
+  )
+  text_layers <- Filter(
+    function(layer) inherits(layer$geom, "GeomText"),
+    plot$layers
+  )
+
+  expect_identical(plot$labels$title, "My cluster tree")
+  expect_identical(plot$theme$text$family, "Helvetica")
+  expect_length(text_layers, 1L)
+  expect_identical(text_layers[[1L]]$aes_params$family, "Helvetica")
+})
+
+test_that("ClusterTreePlot uses compact non-redundant guides", {
+  srt <- make_cluster_tree_seurat()
+
+  plot <- ClusterTreePlot(srt, prefix = "RNA_snn")
+
+  expect_s3_class(
+    plot$scales$get_scales("linewidth")$guide,
+    "GuideLegend"
+  )
+  expect_s3_class(plot$scales$get_scales("colour")$guide, "GuideColourbar")
+  expect_identical(plot$scales$get_scales("colour")$name, "Incoming share")
+  expect_equal(plot$scales$get_scales("colour")$breaks, c(0, 0.5, 1))
+  expect_null(plot$scales$get_scales("alpha"))
+  expect_identical(plot$scales$get_scales("fill")$guide, "none")
+  expect_identical(
+    rlang::as_label(plot$layers[[1L]]$mapping$linewidth),
+    "count"
+  )
+  expect_identical(
+    rlang::as_label(plot$layers[[1L]]$mapping$colour),
+    "in_prop"
+  )
+  expect_identical(plot$layers[[1L]]$aes_params$alpha, 0.9)
+  expect_gte(plot$theme$legend.title$size, 9.5)
+  expect_gte(plot$theme$legend.text$size, 8.5)
+  expect_gte(as.numeric(plot$theme$legend.key.height), 14)
 })
 
 test_that("ClusterTreePlot returns ggplot for a single marker overlay", {
@@ -115,6 +283,9 @@ test_that("ClusterTreePlot returns ggplot for a single marker overlay", {
   plot <- ClusterTreePlot(srt, prefix = "RNA_snn", features = "Gene1")
 
   expect_s3_class(plot, "ggplot")
+  expect_null(plot$labels$title)
+  expect_identical(plot$labels$subtitle, "Gene1")
+  expect_s3_class(plot$scales$get_scales("fill")$guide, "GuideColourbar")
 })
 
 test_that("ClusterTreePlot accepts numeric metadata feature overlays", {
@@ -154,6 +325,42 @@ test_that("ClusterTreePlot combines or lists multiple marker overlays", {
   expect_s3_class(plot, "patchwork")
 })
 
+test_that("inside multi-feature patchwork retains guide titles", {
+  testthat::skip_if_not_installed("patchwork")
+  srt <- make_cluster_tree_seurat()
+
+  plot <- ClusterTreePlot(
+    srt,
+    prefix = "RNA_snn",
+    features = c("Gene1", "Gene2"),
+    combine = TRUE,
+    family = "sans"
+  )
+  grob <- patchwork::patchworkGrob(plot)
+  grob_labels <- function(x) {
+    out <- if (!is.null(x$label)) as.character(x$label) else character()
+    if (!is.null(x$children)) {
+      for (i in seq_along(x$children)) {
+        out <- c(out, grob_labels(x$children[[i]]))
+      }
+    }
+    if (!is.null(x$grobs)) {
+      for (i in seq_along(x$grobs)) {
+        out <- c(out, grob_labels(x$grobs[[i]]))
+      }
+    }
+    out
+  }
+
+  expect_true(all(c(
+    "Cells moved",
+    "Incoming share",
+    "Cluster size",
+    "Gene1",
+    "Gene2"
+  ) %in% grob_labels(grob)))
+})
+
 test_that("ClusterTreePlot preserves named feature-list groups", {
   srt <- make_cluster_tree_seurat()
 
@@ -186,6 +393,86 @@ test_that("ClusterTreePlot aligns feature values to metadata cells", {
     feature_nodes$feature_value[feature_nodes$node_id == "RNA_snn_res.0.2::1"],
     7
   )
+})
+
+test_that("cluster-tree compact breaks are finite and bounded", {
+  breaks <- clustertree_compact_breaks(3)
+
+  expect_equal(breaks(c(5, 5)), 5)
+  expect_length(breaks(c(NA_real_, Inf)), 0L)
+
+  values <- breaks(c(1, 4000))
+  expect_lte(length(values), 3L)
+  expect_true(all(values >= 1 & values <= 4000))
+})
+
+test_that("cluster-tree labels choose readable black or white text", {
+  expect_identical(
+    clustertree_contrast_text(c(
+      "#111111",
+      "#FFFFFF",
+      "#FEE08B",
+      "#F46D43",
+      "#63BDA6"
+    )),
+    c("white", "black", "black", "black", "black")
+  )
+
+  gradient_colors <- clustertree_gradient_colors(
+    values = c(0, 0.5, 1, NA_real_),
+    colors = c("#313695", "#FFFFBF", "#A50026")
+  )
+  expect_length(gradient_colors, 4L)
+  expect_identical(gradient_colors[4L], "grey85")
+  expect_true(all(
+    clustertree_contrast_text(gradient_colors) %in% c("black", "white")
+  ))
+})
+
+test_that("cluster-tree anchored positions retain size-aware spacing", {
+  positions <- clustertree_anchored_positions(
+    sizes = rep(100, 20),
+    size_limits = c(100, 100)
+  )
+
+  expect_equal(min(positions), 0)
+  expect_gt(min(diff(sort(positions))), 1)
+
+  heterogeneous <- clustertree_anchored_positions(
+    sizes = c(100, 100, 10),
+    size_limits = c(10, 100)
+  )
+  expect_gt(
+    heterogeneous[1] - heterogeneous[2],
+    heterogeneous[2] - heterogeneous[3]
+  )
+
+  large_column <- clustertree_anchored_positions(
+    sizes = c(80, 100),
+    size_limits = c(10, 100)
+  )
+  small_column <- clustertree_anchored_positions(
+    sizes = c(10, 20),
+    size_limits = c(10, 100)
+  )
+  expect_gt(diff(range(large_column)), diff(range(small_column)))
+})
+
+test_that("ClusterTreePlot preserves the return_data contract", {
+  srt <- make_cluster_tree_seurat()
+
+  out <- ClusterTreePlot(
+    srt,
+    prefix = "RNA_snn",
+    return_data = TRUE
+  )
+
+  expect_named(
+    out,
+    c("plot", "nodes", "edges", "all_edges", "cluster_info")
+  )
+  expect_s3_class(out$plot, "ggplot")
+  expect_gte(nrow(out$all_edges), nrow(out$edges))
 })
 
 test_that("ClusterTreePlot errors without multi-resolution columns", {


### PR DESCRIPTION
## Summary

- redesign `ClusterTreePlot()` with a bottom-anchored, collision-aware tree that expands from the starting side
- add `direction` support for left-to-right, right-to-left, top-to-bottom, and bottom-to-top trees
- add `label.fg = "auto"` with per-node WCAG contrast selection between black and white labels
- replace the crowded edge legends with a compact two-sample `Cells moved` linewidth guide and an `Incoming share` colour bar
- make `legend.position = "auto"` non-overlapping by construction: horizontal trees place a compact guide row above the panel, aligned to the starting side, while vertical trees place guides on the right
- retain `legend.position = "inside"` only as an explicit force-in-panel option
- make plot text and axes Arial/black by default, remove the redundant default title and panel border, and retain explicit overrides
- preserve multi-feature guide content with patchwork and synchronize the generated Rd documentation
- require ggplot2 >= 3.5.0 for the supported inside-legend API

## Validation

- `Rscript -e 'pkgload::load_all(".", quiet=TRUE, compile=FALSE)'`
- `Rscript -e 'pkgload::load_all(".", quiet=TRUE, compile=FALSE); testthat::test_file("tests/testthat/test-cluster-tree-plot.R", reporter="summary")'`
- ragg PNG visual QA at 720 x 604 for the default single-feature tree
- ragg PNG visual QA for a sparse 2-3 resolution tree, two-feature patchwork output, and all four tree directions
- 2 x 2 direction QA confirms legends remain outside every data panel without covering nodes or edges
- verified multi-feature patchwork grobs retain the shared and feature guide content
- `_R_CHECK_FORCE_SUGGESTS_=false Rscript -e 'rcmdcheck::rcmdcheck(args=c("--no-manual","--as-cran","--no-examples","--no-tests"), error_on="never")'`
  - 0 errors
  - 2 warnings and 4 notes from pre-existing, untouched CellRank/other Rd/DESCRIPTION issues
  - `checking dependencies in R code ... OK`
  - `checking for unstated dependencies in examples ... OK`
  - `checking for unstated dependencies in 'tests' ... OK`

## Notes

- No optional/Remotes backend calls, environment guards, or global options were added.
- CI status is pending after the latest push.
