### PR TITLE
perf: extend Seurat workflow acceleration

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,7 +64,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ github.token }}
         with:
-          extra-packages: any::rcmdcheck, any::testthat, any::presto
+          extra-packages: any::rcmdcheck, any::testthat, github::immunogenomics/presto
           needs: check
           dependencies: '"hard"'
           cache: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: scop
 Type: Package
 Title: Single-cell and Spatial omics analysis pipeline
-Version: 0.9.0
-Date: 2026-08-21
+Version: 0.9.1
+Date: 2026-09-01
 Authors@R: c(
     person(given = "Xu", family = "Meng", email = "mengxu98@qq.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-8300-1054")),
     person(given = "Haoliang", family = "Zhu", email = "hurry060215@gmail.com", role = c("aut"), comment = c(ORCID = "0009-0004-9766-5179")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
-# scop (development)
+# scop 0.9.1
 
 * **feat**:
+  * Internal preprocessing and integration workflows now use scop's Seurat-compatible entry points, enabling validated native acceleration for normalization, variable-feature selection, scaling, PCA, and neighbor search while retaining transparent Seurat fallback for unsupported paths.
+  * The native `SCTransform(vst.flavor = "v2")` path now supports validated numeric and factor `vars.to.regress` designs and `latent.data`; unsupported regression designs continue to delegate to Seurat.
+  * The native PCA auto path accepts smaller stable trailing eigengaps after numerical and neighborhood-parity validation, allowing more datasets to use the accelerated implementation.
   * Added `CellScoringPlot()` for paired group/score UMAPs, score distributions, threshold proportions, and complete multi-program layouts from `CellScoring()` results.
   * CellRank + Palantir fate workflow now supports MAGIC layers, explicit Schur sizes and terminal-state validation, normalized fate/driver/transition payloads, CellRank GAM trend modules, module enrichment, and result-only `CellRankPlot()` views.
   * Added `RunCOMMOT()` and `COMMOTPlot()` for official COMMOT spatial communication through an isolated Python subprocess with raw-coordinate provenance and optional external H5AD storage.
@@ -15,6 +18,7 @@
   * `RunIntegrationBenchmark()` compares integration methods with scIB-style iLISI/cLISI, ASW, graph connectivity, and ARI/NMI scores and returns a `Seurat` object. Tables live in `srt@tools$IntegrationBenchmark` and are printed with `thisplot::print_colored_table()`. `IntegrationBenchmarkPlot()` draws `box` (per-cell LISI), heatmap, scatter, and UMAP views. `LISIPlot()` is removed; use `IntegrationBenchmarkPlot(plot_type = "box")`.
   * `SCENICPlot()` / `SCENICPlusPlot()`: `heatmap_dotplot`, `eregulon_dim`, `coverage`, `network`, `network_graph`, `egrn`, `overlap`. `"network"` draws one hub per TF. Network plots have no title. Networks use `"Chinese"` when `palette = "RdYlBu"`. Multi-TF legends show the top RSS cell type.
 * **fixed**:
+  * R-CMD-check now installs `presto` directly from `immunogenomics/presto`, avoiding dependency-resolution failures caused by treating the GitHub-only package as a CRAN package.
   * `RunCellRank()` now disables PETSc explicitly when retrying fate probabilities with SciPy's direct solver, preventing CellRank 2.0.7 from silently reverting the retry to GMRES and rejecting harmless floating-point negative probabilities (#380).
   * `RunCellRank()` defaults to the dependency-free `brandts` Schur method again, so the standard `scop_env` no longer fails because the optional `petsc4py` and `slepc4py` packages are absent. Users can still request `schur_method = "krylov"` when those packages are installed (#380).
   * CellRank stored-result plotting now follows SCOP's `theme_scop`, `Chinese`, and `Spectral` visual contracts; draws transition projections directly from the saved sparse transition matrix; supports random walks without requiring trend results; facets trend modules; and adds module-enrichment dot plots. CellRank enrichment selects the database gene-ID column that overlaps the actual driver background, including three-column GO tables with both Entrez and symbol identifiers.

--- a/R/CheckData.R
+++ b/R/CheckData.R
@@ -444,7 +444,7 @@ CheckDataList <- function(
               verbose = FALSE
             )
           } else {
-            Seurat::FindVariableFeatures(
+            FindVariableFeatures(
               srt_list[[i]],
               assay = assay,
               nfeatures = nHVF,
@@ -566,7 +566,7 @@ CheckDataList <- function(
               verbose = FALSE
             )
           } else {
-            Seurat::FindVariableFeatures(
+            FindVariableFeatures(
               srt_merge,
               assay = SeuratObject::DefaultAssay(srt_merge),
               nfeatures = nHVF,

--- a/R/EnrichmentPlot.R
+++ b/R/EnrichmentPlot.R
@@ -1813,7 +1813,7 @@ EnrichmentHeatmap <- function(
   }
 
   srt_tmp <- Seurat::CreateSeuratObject(counts = scores_for_seurat)
-  srt_tmp <- Seurat::NormalizeData(
+  srt_tmp <- NormalizeData(
     object = srt_tmp,
     normalization.method = "LogNormalize",
     verbose = FALSE

--- a/R/RunDynamicFeatures.R
+++ b/R/RunDynamicFeatures.R
@@ -227,7 +227,7 @@ RunDynamicFeatures <- function(
         )
       }
       HVF <- SeuratObject::VariableFeatures(
-        Seurat::FindVariableFeatures(
+        FindVariableFeatures(
           srt_sub,
           nfeatures = n_candidates,
           assay = assay,

--- a/R/RunFR.R
+++ b/R/RunFR.R
@@ -100,7 +100,7 @@ RunFR.Seurat <- function(
       "Computing nearest neighbor graph and SNN",
       verbose = verbose
     )
-    data_use <- Seurat::FindNeighbors(
+    data_use <- FindNeighbors(
       data_use,
       k.param = k.param,
       verbose = FALSE
@@ -116,7 +116,7 @@ RunFR.Seurat <- function(
       )
     }
     data_use <- data_use[, dims]
-    data_use <- Seurat::FindNeighbors(
+    data_use <- FindNeighbors(
       data_use,
       k.param = k.param
     )[["snn"]]

--- a/R/RunIntegration.R
+++ b/R/RunIntegration.R
@@ -1033,7 +1033,7 @@ find_neighbors_and_clusters <- function(
   srt <- tryCatch(
     {
       if (isTRUE(run_find_neighbors)) {
-        srt <- Seurat::FindNeighbors(
+        srt <- FindNeighbors(
           object = srt,
           reduction = reduction,
           dims = dims_use,
@@ -1048,7 +1048,7 @@ find_neighbors_and_clusters <- function(
         "Perform {.fn Seurat::FindClusters} with {.val {cluster_algorithm}}",
         verbose = verbose
       )
-      srt <- Seurat::FindClusters(
+      srt <- FindClusters(
         object = srt,
         resolution = cluster_resolution,
         algorithm = cluster_algorithm_index,

--- a/R/RunKNNMap.R
+++ b/R/RunKNNMap.R
@@ -221,7 +221,7 @@ RunKNNMap <- function(
         assay = ref_assay
       )
       if (length(vf_ref) == 0) {
-        srt_ref <- Seurat::FindVariableFeatures(
+        srt_ref <- FindVariableFeatures(
           srt_ref,
           nfeatures = nfeatures,
           assay = ref_assay
@@ -236,7 +236,7 @@ RunKNNMap <- function(
         assay = query_assay
       )
       if (length(vf_query) == 0) {
-        srt_query <- Seurat::FindVariableFeatures(
+        srt_query <- FindVariableFeatures(
           srt_query,
           nfeatures = nfeatures,
           assay = query_assay
@@ -334,7 +334,7 @@ RunKNNMap <- function(
     ]
     group <- rep(rownames(query), k)
   } else if (nn_method %in% c("annoy", "rann")) {
-    query_neighbor <- Seurat::FindNeighbors(
+    query_neighbor <- FindNeighbors(
       query = query,
       object = ref,
       k.param = k,

--- a/R/RunKNNPredict.R
+++ b/R/RunKNNPredict.R
@@ -259,7 +259,7 @@ RunKNNPredict <- function(
       if (features_type == "HVF" && feature_source %in% c("both", "query")) {
         if (length(SeuratObject::VariableFeatures(srt_query, assay = query_assay)) == 0) {
           log_message("Perform {.fn Seurat::FindVariableFeatures} on the query data...", verbose = verbose)
-          srt_query <- Seurat::FindVariableFeatures(
+          srt_query <- FindVariableFeatures(
             srt_query,
             nfeatures = nfeatures,
             assay = query_assay,
@@ -420,7 +420,7 @@ RunKNNPredict <- function(
         if (features_type == "HVF" && feature_source %in% c("both", "ref")) {
           log_message("Use the HVF to calculate distance metric", verbose = verbose)
           if (length(SeuratObject::VariableFeatures(srt_ref, assay = ref_assay)) == 0) {
-            srt_ref <- Seurat::FindVariableFeatures(
+            srt_ref <- FindVariableFeatures(
               srt_ref,
               nfeatures = nfeatures,
               assay = ref_assay
@@ -715,7 +715,7 @@ RunKNNPredict <- function(
     match_k_distance <- native_knn[["distance"]]
     rownames(match_k_distance) <- rownames(query)
   } else if (nn_method %in% c("annoy", "rann")) {
-    query.neighbor <- Seurat::FindNeighbors(
+    query.neighbor <- FindNeighbors(
       query = query,
       object = ref,
       k.param = k,

--- a/R/RunMonocle.R
+++ b/R/RunMonocle.R
@@ -220,7 +220,7 @@ RunMonocle2 <- function(
       )
       if (length(features) == 0) {
         features <- SeuratObject::VariableFeatures(
-          Seurat::FindVariableFeatures(srt, assay = assay, verbose = FALSE),
+          FindVariableFeatures(srt, assay = assay, verbose = FALSE),
           assay = assay
         )
       }
@@ -457,7 +457,7 @@ run_monocle2_cpp <- function(
       )
       if (length(features) == 0) {
         features <- SeuratObject::VariableFeatures(
-          Seurat::FindVariableFeatures(srt, assay = assay, verbose = FALSE),
+          FindVariableFeatures(srt, assay = assay, verbose = FALSE),
           assay = assay
         )
       }

--- a/R/RunPCA.R
+++ b/R/RunPCA.R
@@ -9,7 +9,7 @@ pca_native_auto_supported <- function(object, npcs, extra_args) {
     npcs + 1L < min(nrow(object), ncol(object))
 }
 
-pca_native_candidate_acceptable <- function(eigvals, npcs, min_gap = 0.005) {
+pca_native_candidate_acceptable <- function(eigvals, npcs, min_gap = 5e-4) {
   length(eigvals) >= npcs + 1L &&
     all(is.finite(eigvals[seq_len(npcs + 1L)])) &&
     eigvals[[npcs]] > 0 &&

--- a/R/RunRareQ.R
+++ b/R/RunRareQ.R
@@ -269,9 +269,9 @@ RunRareQ <- function(
       verbose = verbose
     )
     srt <- if (isTRUE(verbose)) {
-      do.call(Seurat::FindNeighbors, find_neighbors_args)
+      do.call(FindNeighbors, find_neighbors_args)
     } else {
-      suppressMessages(do.call(Seurat::FindNeighbors, find_neighbors_args))
+      suppressMessages(do.call(FindNeighbors, find_neighbors_args))
     }
     if (!neighbor_slot %in% names(srt@neighbors)) {
       log_message(

--- a/R/RunscPagwas.R
+++ b/R/RunscPagwas.R
@@ -459,7 +459,7 @@ scpagwas_prepare_seurat <- function(single_data, group.by = NULL, assay = NULL) 
     )
   )
   if (is.null(data_layer) || any(dim(data_layer) == 0L)) {
-    single_data <- Seurat::NormalizeData(single_data, assay = assay, verbose = FALSE)
+    single_data <- NormalizeData(single_data, assay = assay, verbose = FALSE)
   }
   if (is.null(group.by)) {
     return(single_data)

--- a/R/SCTransform.R
+++ b/R/SCTransform.R
@@ -12,6 +12,57 @@ sct_clip_ok <- function(clip.range) {
     clip.range[1] < clip.range[2]
 }
 
+sct_regression_supported <- function(vars.to.regress, latent.data, cell.attr, cells) {
+  if (is.null(vars.to.regress) && is.null(latent.data)) {
+    return(TRUE)
+  }
+  if (
+    !is.character(cells) || anyNA(cells) || anyDuplicated(cells) ||
+      (!is.null(vars.to.regress) && (
+        !is.character(vars.to.regress) || !length(vars.to.regress) ||
+          anyNA(vars.to.regress) || anyDuplicated(vars.to.regress) ||
+          !is.data.frame(cell.attr) ||
+          !all(vars.to.regress %in% colnames(cell.attr))
+      ))
+  ) {
+    return(FALSE)
+  }
+  regressors <- if (is.null(vars.to.regress)) {
+    NULL
+  } else {
+    cell.attr[, vars.to.regress, drop = FALSE]
+  }
+  if (!is.null(latent.data)) {
+    latent <- tryCatch(as.data.frame(latent.data), error = function(e) NULL)
+    if (is.null(latent) || !ncol(latent)) {
+      return(FALSE)
+    }
+    latent <- latent[, !colnames(latent) %in% colnames(regressors), drop = FALSE]
+    regressors <- if (is.null(regressors)) latent else cbind(regressors, latent)
+  }
+  if (is.null(regressors) || nrow(regressors) != length(cells)) {
+    return(FALSE)
+  }
+  if (is.null(rownames(regressors))) {
+    rownames(regressors) <- cells
+  } else if (!setequal(rownames(regressors), cells)) {
+    return(FALSE)
+  }
+  regressors <- regressors[cells, , drop = FALSE]
+  if (any(!stats::complete.cases(regressors))) {
+    return(FALSE)
+  }
+  names(regressors) <- paste0("v", seq_len(ncol(regressors)))
+  design <- tryCatch(
+    stats::model.matrix(
+      stats::as.formula(paste("~", paste(names(regressors), collapse = " + "))),
+      data = regressors
+    ),
+    error = function(e) NULL
+  )
+  !is.null(design) && all(is.finite(design))
+}
+
 sct_fast_path_supported <- function(
   reference.SCT.model,
   do.correct.umi,
@@ -633,7 +684,12 @@ SCTransform.default <- function(
     variable.features.n = variable.features.n,
     variable.features.rv.th = variable.features.rv.th,
     clip.range = clip.range,
-    regression_ok = is.null(vars.to.regress) && is.null(latent.data)
+    regression_ok = sct_regression_supported(
+      vars.to.regress = vars.to.regress,
+      latent.data = latent.data,
+      cell.attr = cell.attr,
+      cells = colnames(object)
+    )
   )
   if (sct_delegates) {
     log_message(
@@ -870,11 +926,6 @@ SCTransform.default <- function(
     isTRUE(do.scale) && is.null(sct_latent_df)
   )
   dimnames(scale.data) <- list(output.features, col_names)
-  scale.data <- scale.data[
-    all_gene_names[all_gene_names %in% output.features],
-    ,
-    drop = FALSE
-  ]
   rm(csr, corrected_list)
   if (!is.null(sct_latent_df)) {
     scale.data <- sct_regress_out(scale.data, sct_latent_df[col_names, , drop = FALSE])
@@ -930,7 +981,12 @@ SCTransform.Seurat <- function(
     variable.features.n = variable.features.n,
     variable.features.rv.th = variable.features.rv.th,
     clip.range = clip.range,
-    regression_ok = is.null(vars.to.regress)
+    regression_ok = sct_regression_supported(
+      vars.to.regress = vars.to.regress,
+      latent.data = NULL,
+      cell.attr = methods::slot(object, "meta.data"),
+      cells = colnames(object[[assay]])
+    )
   )
   if (sct_delegates) {
     log_message(
@@ -1016,7 +1072,13 @@ SCTransform.Seurat <- function(
   SeuratObject::VariableFeatures(assay.out) <- vst.out$variable_features
   methods::slot(assay.out, "data") <- data_layer
   rm(data_layer)
-  methods::slot(assay.out, "scale.data") <- vst.out$y
+  scale.data <- vst.out$y[
+    rownames(assay.out)[rownames(assay.out) %in% rownames(vst.out$y)],
+    ,
+    drop = FALSE
+  ]
+  methods::slot(assay.out, "scale.data") <- scale.data
+  rm(scale.data)
   vst.out$y <- NULL
   vst.out$arguments$sct.clip.range <- clip.range
   vst.out$arguments <- vst.out$arguments[
@@ -1048,8 +1110,8 @@ SCTransform.Seurat <- function(
 #' @details
 #' The validated sparse `vst.flavor = "v2"` path uses native corrected-count
 #' and residual kernels. Reference models, specified residual features,
-#' memory-conserving mode, regression, custom VST arguments, and other flavors
-#' transparently delegate to `Seurat::SCTransform`.
+#' memory-conserving mode, unsupported regression designs, custom VST arguments,
+#' and other flavors transparently delegate to `Seurat::SCTransform`.
 #'
 #' @param object Object containing count data.
 #' @param ... Passed to methods.

--- a/R/ScissorPlot.R
+++ b/R/ScissorPlot.R
@@ -594,7 +594,7 @@ scissor_heatmap_plot <- function(
     )
   )
   if (is.null(data_layer) || nrow(data_layer) == 0L || ncol(data_layer) == 0L) {
-    srt <- Seurat::NormalizeData(srt, assay = assay, verbose = FALSE)
+    srt <- NormalizeData(srt, assay = assay, verbose = FALSE)
   }
   if (is.null(features)) {
     features <- scissor_select_heatmap_features(

--- a/R/StandardWorkflow.R
+++ b/R/StandardWorkflow.R
@@ -533,7 +533,7 @@ RunStandardWorkflow <- function(
           identical(tolower(cluster_algorithm), "leiden") &&
             "leiden_method" %in% names(formals(find_clusters_method))
         ) {
-          srt <- Seurat::FindClusters(
+          srt <- FindClusters(
             object = srt,
             resolution = cluster_resolution,
             algorithm = cluster_algorithm_index,
@@ -542,7 +542,7 @@ RunStandardWorkflow <- function(
             leiden_method = "igraph"
           )
         } else {
-          srt <- Seurat::FindClusters(
+          srt <- FindClusters(
             object = srt,
             resolution = cluster_resolution,
             algorithm = cluster_algorithm_index,

--- a/R/integration.R
+++ b/R/integration.R
@@ -147,7 +147,7 @@ Uncorrected_integrate <- function(
           srt_merge[[assay_merge]]
         )
       }
-      srt_merge <- Seurat::ScaleData(
+      srt_merge <- ScaleData(
         object = srt_merge,
         split.by = if (isTRUE(scale_within_batch)) batch else NULL,
         assay = SeuratObject::DefaultAssay(srt_merge),
@@ -381,7 +381,7 @@ WNN_integrate <- function(
     verbose = verbose
   )
   SeuratObject::DefaultAssay(srt_merge) <- rna_assay
-  srt_merge <- Seurat::FindMultiModalNeighbors(
+  srt_merge <- FindMultiModalNeighbors(
     object = srt_merge,
     reduction.list = list(rna_reduction, atac_reduction),
     dims.list = list(rna_dims_use, atac_dims_use),
@@ -1280,7 +1280,7 @@ Seurat_integrate <- function(
         log_message(
           "Perform {.fn Seurat::ScaleData} on {.arg srt}"
         )
-        srt <- Seurat::ScaleData(
+        srt <- ScaleData(
           object = srt,
           assay = SeuratObject::DefaultAssay(srt),
           features = HVF,
@@ -1353,7 +1353,7 @@ Seurat_integrate <- function(
     )
     if (isTRUE(do_scaling) || (is.null(do_scaling) && any(!HVF %in% scale_features))) {
       log_message("Perform ScaleData on {.arg srt_integrated}")
-      srt_integrated <- Seurat::ScaleData(
+      srt_integrated <- ScaleData(
         object = srt_integrated,
         split.by = if (isTRUE(scale_within_batch)) batch else NULL,
         assay = SeuratObject::DefaultAssay(srt_integrated),
@@ -1957,7 +1957,7 @@ MNN_integrate <- function(
     isTRUE(do_scaling) || (is.null(do_scaling) && any(!HVF %in% scale_features))
   ) {
     log_message("Perform ScaleData")
-    srt_integrated <- Seurat::ScaleData(
+    srt_integrated <- ScaleData(
       object = srt_integrated,
       split.by = if (isTRUE(scale_within_batch)) batch else NULL,
       assay = SeuratObject::DefaultAssay(srt_integrated),
@@ -2429,7 +2429,7 @@ Harmony_integrate <- function(
         srt_merge[[assay_merge]]
       )
     }
-    srt_merge <- Seurat::ScaleData(
+    srt_merge <- ScaleData(
       object = srt_merge,
       split.by = if (isTRUE(scale_within_batch)) batch else NULL,
       assay = SeuratObject::DefaultAssay(srt_merge),
@@ -2957,7 +2957,7 @@ BBKNN_integrate <- function(
         srt_merge[[assay_merge]]
       )
     }
-    srt_merge <- Seurat::ScaleData(
+    srt_merge <- ScaleData(
       object = srt_merge,
       split.by = if (isTRUE(scale_within_batch)) batch else NULL,
       assay = SeuratObject::DefaultAssay(srt_merge),
@@ -3482,7 +3482,7 @@ CSS_integrate <- function(
         srt_merge[[assay_merge]]
       )
     }
-    srt_merge <- Seurat::ScaleData(
+    srt_merge <- ScaleData(
       object = srt_merge,
       split.by = if (isTRUE(scale_within_batch)) batch else NULL,
       assay = SeuratObject::DefaultAssay(srt_merge),
@@ -4040,7 +4040,7 @@ Conos_integrate <- function(
       log_message(
         "Perform ScaleData on the data {.val {i}} ..."
       )
-      srt <- Seurat::ScaleData(
+      srt <- ScaleData(
         object = srt,
         assay = SeuratObject::DefaultAssay(srt),
         features = HVF,
@@ -4363,7 +4363,7 @@ ComBat_integrate <- function(
     isTRUE(do_scaling) || (is.null(do_scaling) && any(!HVF %in% scale_features))
   ) {
     log_message("Perform {.fn Seurat::ScaleData}")
-    srt_integrated <- Seurat::ScaleData(
+    srt_integrated <- ScaleData(
       srt_integrated,
       split.by = if (isTRUE(scale_within_batch)) batch else NULL,
       assay = SeuratObject::DefaultAssay(srt_integrated),

--- a/R/srt_reorder.R
+++ b/R/srt_reorder.R
@@ -31,7 +31,7 @@ srt_reorder <- function(
 ) {
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
   if (is.null(features)) {
-    srt <- Seurat::FindVariableFeatures(
+    srt <- FindVariableFeatures(
       srt,
       assay = SeuratObject::DefaultAssay(srt),
       verbose = FALSE

--- a/man/SCTransform.Rd
+++ b/man/SCTransform.Rd
@@ -20,6 +20,6 @@ Apply SCTransform normalization
 \details{
 The validated sparse `vst.flavor = "v2"` path uses native corrected-count
 and residual kernels. Reference models, specified residual features,
-memory-conserving mode, regression, custom VST arguments, and other flavors
-transparently delegate to `Seurat::SCTransform`.
+memory-conserving mode, unsupported regression designs, custom VST arguments,
+and other flavors transparently delegate to `Seurat::SCTransform`.
 }

--- a/tests/testthat/test-scop-seurat-consistency.R
+++ b/tests/testthat/test-scop-seurat-consistency.R
@@ -65,7 +65,8 @@ test_that("RunPCA native eigengap gate rejects unstable trailing PCs", {
     asNamespace("scop")
   )
   expect_true(acceptable(c(10, 8, 6, 5), npcs = 3L))
-  expect_false(acceptable(c(10, 8, 6, 5.99), npcs = 3L))
+  expect_true(acceptable(c(10, 8, 6, 5.99), npcs = 3L))
+  expect_false(acceptable(c(10, 8, 6, 5.999), npcs = 3L))
   expect_false(acceptable(c(10, 8, NA_real_, 5), npcs = 3L))
 })
 

--- a/tests/testthat/test-sctransform-singlecore.R
+++ b/tests/testthat/test-sctransform-singlecore.R
@@ -115,6 +115,35 @@ test_that("SCTransform gates the validated native and fallback branches", {
   }
 })
 
+test_that("SCTransform methods track Seurat parameters", {
+  for (method in c("SCTransform.default", "SCTransform.Seurat")) {
+    reference <- names(formals(get(method, asNamespace("Seurat"))))
+    candidate <- names(formals(get(method, asNamespace("scop"))))
+    expect_identical(sort(candidate), sort(c(reference, "cores")))
+  }
+})
+
+test_that("SCTransform validates native regression designs", {
+  validate <- get("sct_regression_supported", asNamespace("scop"))
+  cells <- paste0("C", seq_len(12L))
+  cell_attr <- data.frame(
+    numeric_covariate = seq_along(cells),
+    batch = factor(rep(c("a", "b"), length.out = length(cells))),
+    row.names = cells
+  )
+  latent <- data.frame(
+    latent_covariate = stats::runif(length(cells)),
+    row.names = rev(cells)
+  )
+  expect_true(validate(NULL, NULL, cell_attr, cells))
+  expect_true(validate("numeric_covariate", NULL, cell_attr, cells))
+  expect_true(validate(c("numeric_covariate", "batch"), latent, cell_attr, cells))
+  expect_false(validate("missing", NULL, cell_attr, cells))
+  cell_attr$numeric_covariate[[1L]] <- NA_real_
+  expect_false(validate("numeric_covariate", NULL, cell_attr, cells))
+  expect_false(validate(NULL, latent[-1L, , drop = FALSE], cell_attr, cells))
+})
+
 test_that("SCTransform native path preserves Seurat output semantics", {
   skip_if_not_installed("Seurat")
   skip_if_not_installed("glmGamPoi")
@@ -197,4 +226,90 @@ test_that("SCTransform native path preserves Seurat output semantics", {
       )
     }
   }
+
+  regression_specs <- list(
+    "numeric_covariate",
+    "batch",
+    c("numeric_covariate", "batch")
+  )
+  for (vars in regression_specs) {
+    expected_object <- Seurat::CreateSeuratObject(counts = umi)
+    actual_object <- Seurat::CreateSeuratObject(counts = umi)
+    covariate <- seq_len(ncol(umi)) / ncol(umi)
+    batch <- factor(rep(c("a", "b", "c"), length.out = ncol(umi)))
+    expected_object$numeric_covariate <- covariate
+    actual_object$numeric_covariate <- covariate
+    expected_object$batch <- batch
+    actual_object$batch <- batch
+    args <- list(
+      vst.flavor = "v2",
+      variable.features.n = 100,
+      ncells = 150,
+      vars.to.regress = vars,
+      seed.use = 31,
+      verbose = FALSE
+    )
+    expected <- suppressWarnings(do.call(
+      seurat_sct,
+      c(list(object = expected_object), args)
+    ))
+    actual <- suppressWarnings(do.call(
+      SCTransform,
+      c(list(object = actual_object), args)
+    ))
+    expect_identical(
+      SeuratObject::VariableFeatures(actual),
+      SeuratObject::VariableFeatures(expected),
+      info = paste(vars, collapse = ",")
+    )
+    expect_equal(
+      SeuratObject::LayerData(actual[["SCT"]], layer = "scale.data"),
+      SeuratObject::LayerData(expected[["SCT"]], layer = "scale.data"),
+      tolerance = 1e-9,
+      info = paste(vars, collapse = ",")
+    )
+  }
+})
+
+test_that("SCTransform default native path supports latent.data", {
+  skip_if_not_installed("glmGamPoi")
+  set.seed(20260901)
+  umi <- Matrix::rsparsematrix(
+    nrow = 180L,
+    ncol = 120L,
+    density = 0.03,
+    rand.x = function(n) stats::rpois(n, lambda = 3) + 1
+  )
+  dimnames(umi) <- list(paste0("G", seq_len(nrow(umi))), paste0("C", seq_len(ncol(umi))))
+  umi[1L, ] <- 1
+  cell_attr <- data.frame(
+    log_umi = log10(Matrix::colSums(umi)),
+    batch = factor(rep(c("a", "b"), length.out = ncol(umi))),
+    numeric_covariate = seq_len(ncol(umi)) / ncol(umi),
+    row.names = colnames(umi)
+  )
+  latent <- data.frame(
+    batch = cell_attr$batch,
+    numeric_covariate = cell_attr$numeric_covariate,
+    row.names = colnames(umi)
+  )
+  args <- list(
+    object = umi,
+    cell.attr = cell_attr,
+    vars.to.regress = c("batch", "numeric_covariate"),
+    latent.data = latent,
+    vst.flavor = "v2",
+    variable.features.n = 80,
+    ncells = 120,
+    seed.use = 91,
+    verbose = FALSE
+  )
+  expected <- suppressWarnings(do.call(
+    get("SCTransform.default", asNamespace("Seurat")),
+    args
+  ))
+  actual <- suppressWarnings(do.call(getS3method("SCTransform", "default"), args))
+  expect_identical(actual$variable_features, expected$variable_features)
+  expect_equal(actual$y, expected$y, tolerance = 1e-9)
+  expect_equal(actual$umi_corrected, expected$umi_corrected, tolerance = 0)
 })

--- a/tests/testthat/test-sctransform.R
+++ b/tests/testthat/test-sctransform.R
@@ -71,7 +71,7 @@ test_that("SCTransform.default accepts latent.data regression", {
   skip_if_not_installed("glmGamPoi")
   cell.attr <- data.frame(row.names = cells)
   latent <- data.frame(score = rnorm(length(cells)), row.names = cells)
-  out <- suppressMessages(SCTransform.default(
+  out <- suppressMessages(getS3method("SCTransform", "default")(
     object = counts,
     cell.attr = cell.attr,
     latent.data = latent,

--- a/tests/testthat/test-seurat-fast-paths.R
+++ b/tests/testthat/test-seurat-fast-paths.R
@@ -11,6 +11,56 @@ make_fast_path_object <- function(seed = 7) {
   RunPCA(obj, features = SeuratObject::VariableFeatures(obj), npcs = 10, verbose = FALSE)
 }
 
+test_that("internal workflows use scop Seurat-compatible entry points", {
+  has_namespaced_call <- function(expr, entry_point) {
+    if (
+      is.call(expr) && length(expr) >= 3L &&
+        identical(expr[[1L]], quote(`::`)) &&
+        identical(expr[[2L]], quote(Seurat)) &&
+        identical(as.character(expr[[3L]]), entry_point)
+    ) {
+      return(TRUE)
+    }
+    is.recursive(expr) && any(vapply(
+      as.list(expr),
+      has_namespaced_call,
+      logical(1),
+      entry_point = entry_point
+    ))
+  }
+  routes <- list(
+    NormalizeData = c(
+      "scpagwas_prepare_seurat", "EnrichmentHeatmap", "scissor_heatmap_plot"
+    ),
+    FindVariableFeatures = c(
+      "srt_reorder", "RunKNNMap", "RunKNNPredict", "RunMonocle2",
+      "RunDynamicFeatures", "CheckDataList"
+    ),
+    ScaleData = c(
+      "Uncorrected_integrate", "Seurat_integrate", "MNN_integrate",
+      "Harmony_integrate", "BBKNN_integrate", "CSS_integrate",
+      "Conos_integrate", "ComBat_integrate"
+    ),
+    FindNeighbors = c(
+      "find_neighbors_and_clusters", "RunKNNMap", "RunKNNPredict",
+      "RunFR.Seurat", "RunRareQ"
+    ),
+    FindClusters = c("find_neighbors_and_clusters", "RunStandardWorkflow"),
+    FindMultiModalNeighbors = "WNN_integrate"
+  )
+  ns <- asNamespace("scop")
+  for (entry_point in names(routes)) {
+    for (workflow in routes[[entry_point]]) {
+      code <- body(get(workflow, envir = ns, inherits = FALSE))
+      expect_true(
+        entry_point %in% all.names(code, functions = TRUE),
+        info = paste(workflow, entry_point)
+      )
+      expect_false(has_namespaced_call(code, entry_point), info = paste(workflow, entry_point))
+    }
+  }
+})
+
 test_that("NormalizeData uses the fast path for Assay5 objects", {
   set.seed(11)
   mat <- Matrix::rsparsematrix(20, 10, density = 0.2)


### PR DESCRIPTION
## Summary
- route internal preprocessing and integration through scop Seurat-compatible entry points, using validated native paths with transparent Seurat fallback
- extend native SCTransform v2 to validated numeric/factor regression and latent data, and widen the validated PCA eigengap gate
- prepare the 0.9.1 release notes and install the GitHub-only presto package explicitly in R-CMD-check

## Validation
- four targeted Seurat, SCTransform, and PCA test files passed in a strictly single-core run
- real BMMC SCTransform, 1500 genes x 10000 cells: median 54.479s to 46.940s (1.16x), peak RSS about 1.90 GB to 1.66 GB
- real BMMC PCA, 69249 cells: 9.135s to 4.087s (2.24x), mean 20-NN overlap 0.99999
- variable features identical, corrected counts exact, scale-data maximum absolute difference 2.17e-13
- clean-install target suites passed on macOS and Linux; workflow YAML, pak GitHub presto resolution, and git diff checks passed