### PR TITLE
fix: report SpotSweeper artifact status truthfully

### DIFF
--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -633,7 +633,7 @@ spot_sweeper_run_artifacts <- function(
     if (!isTRUE(upstream_subset_ok)) {
       log_message(
         "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: the installed {.pkg SpotSweeper} {.fn localVariance} breaks on {.cls SpatialExperiment} colData (matrix coordinate column breaks {.code DataFrame[i, j]} extraction); only local-outlier QC is stored",
-        message_type = "warning",
+        message_type = "running",
         verbose = verbose
       )
       reason <- "upstream bug in SpotSweeper::localVariance"
@@ -681,7 +681,7 @@ spot_sweeper_run_artifacts <- function(
     if (inherits(spe_sample, "error")) {
       log_message(
         "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: the installed {.pkg SpotSweeper} {.fn findArtifacts} failed ({conditionMessage(spe_sample)}); only local-outlier QC is stored",
-        message_type = "warning",
+        message_type = "running",
         verbose = verbose
       )
       reason <- paste0(
@@ -701,7 +701,7 @@ spot_sweeper_run_artifacts <- function(
       reason <- "SpotSweeper::findArtifacts returned no artifact column"
       log_message(
         "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: {reason}",
-        message_type = "warning",
+        message_type = "running",
         verbose = verbose
       )
       record_sample(
@@ -717,7 +717,7 @@ spot_sweeper_run_artifacts <- function(
       reason <- "SpotSweeper::findArtifacts returned invalid artifact values"
       log_message(
         "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: {reason}",
-        message_type = "warning",
+        message_type = "running",
         verbose = verbose
       )
       record_sample(

--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -38,15 +38,17 @@
 #' @param mito_gene Optional explicit mitochondrial gene vector. When provided,
 #' `mito_pattern` is ignored.
 #' @param mito_percent Metadata column used as mitochondrial percent for
-#' artifact detection. If `NULL`, `percent.mito` is used.
+#' artifact detection. If `NULL`, `percent.mito` is used. The reserved backend
+#' output name `"artifact"` cannot be used when `run_artifact = TRUE`.
 #' @param mito_sum Metadata column used as mitochondrial counts for artifact
-#' detection. If `NULL`, mitochondrial counts are computed.
+#' detection. If `NULL`, mitochondrial counts are computed. The reserved
+#' backend output name `"artifact"` cannot be used when `run_artifact = TRUE`.
 #' @param n_order,shape Parameters passed to `SpotSweeper::findArtifacts()`.
 #' @param prefix Prefix used for metadata columns.
 #' @param tool_name Name used to store detailed results in `srt@tools`.
 #' @param return_filtered Whether to return only spots passing SpotSweeper QC.
-#' A fully filtered object is not returned when requested artifact detection is
-#' incomplete; set `run_artifact = FALSE` to request local-outlier-only filtering.
+#' A fully filtered object is not returned when any requested QC stage is
+#' incomplete.
 #' @param store_results Whether to store detailed results in `srt@tools`.
 #' @param cores Number of workers passed to SpotSweeper local outlier detection.
 #' @param workers Deprecated alias for `cores`.
@@ -58,8 +60,9 @@
 #' `store_results = TRUE`, detailed results and an `artifact_status` table are
 #' stored in `srt@tools[[tool_name]]`. The artifact metadata uses `NA` and
 #' `"NotEvaluated"` when a requested artifact stage did not run; the overall
-#' `*_QC` column uses `"Partial"` for spots that passed local QC but were not
-#' evaluated for artifacts.
+#' `*_local_outlier_qc` uses `"NotEvaluated"` outside the tested coordinate
+#' scope, and the overall `*_QC` column uses `"Partial"` whenever a spot was not
+#' fully evaluated by the requested QC stages.
 #' @export
 #'
 #' @examples
@@ -158,6 +161,24 @@ RunSpotSweeper <- function(
   validate_scalar_flag(run_artifact, "run_artifact")
   validate_scalar_flag(return_filtered, "return_filtered")
   validate_scalar_flag(store_results, "store_results")
+  if (!is.null(mito_percent)) {
+    validate_scalar_string(mito_percent, "mito_percent")
+  }
+  if (!is.null(mito_sum)) {
+    validate_scalar_string(mito_sum, "mito_sum")
+  }
+  if (isTRUE(run_artifact) &&
+    any(vapply(
+      list(mito_percent, mito_sum),
+      identical,
+      logical(1),
+      y = "artifact"
+    ))) {
+    log_message(
+      "Metadata column {.val artifact} is reserved for {.pkg SpotSweeper} artifact output and cannot be used as {.arg mito_percent} or {.arg mito_sum} when {.arg run_artifact = TRUE}",
+      message_type = "error"
+    )
+  }
   n_neighbors <- spot_sweeper_assert_positive_integer(n_neighbors, "n_neighbors")
   n_order <- spot_sweeper_assert_positive_integer(n_order, "n_order")
   cores <- spot_sweeper_assert_positive_integer(cores, "cores")
@@ -191,7 +212,6 @@ RunSpotSweeper <- function(
     mito_sum = mito_sum,
     verbose = verbose
   )
-
   spe <- spot_sweeper_make_spe(
     expr = expr[inputs$features, inputs$spots, drop = FALSE],
     coldata = inputs$coldata,
@@ -245,7 +265,7 @@ RunSpotSweeper <- function(
 
   if (isTRUE(return_filtered) && identical(finalized$status, "partial")) {
     log_message(
-      "Cannot return a fully filtered SpotSweeper object because artifact detection was not completed for every sample; set {.arg return_filtered = FALSE} or disable artifact detection explicitly",
+      "Cannot return a fully filtered SpotSweeper object because QC was not completed for every spot; set {.arg return_filtered = FALSE} and inspect the per-spot status metadata",
       message_type = "error"
     )
   }
@@ -298,6 +318,11 @@ RunSpotSweeper <- function(
 
   failed <- sum(srt[[paste0(prefix, "_QC"), drop = TRUE]] == "Fail", na.rm = TRUE)
   if (identical(finalized$status, "partial")) {
+    local_not_evaluated <- sum(
+      as.character(finalized$metadata[[paste0(prefix, "_local_outlier_qc")]]) ==
+        "NotEvaluated",
+      na.rm = TRUE
+    )
     skipped <- sum(finalized$artifact_status$status == "skipped", na.rm = TRUE)
     failed_artifact <- sum(finalized$artifact_status$status == "failed", na.rm = TRUE)
     not_evaluated <- sum(
@@ -305,11 +330,19 @@ RunSpotSweeper <- function(
         "NotEvaluated",
       na.rm = TRUE
     )
-    log_message(
-      "{.pkg SpotSweeper} completed partially: {.val {failed}} spots failed QC; artifact detection skipped for {.val {skipped}} sample{?s}, failed for {.val {failed_artifact}} sample{?s}, and left {.val {not_evaluated}} spots not evaluated",
-      message_type = "running",
-      verbose = verbose
-    )
+    if (isTRUE(run_artifact)) {
+      log_message(
+        "{.pkg SpotSweeper} completed partially: {.val {failed}} spots failed QC; local-outlier detection left {.val {local_not_evaluated}} spots not evaluated; artifact detection skipped for {.val {skipped}} sample{?s}, failed for {.val {failed_artifact}} sample{?s}, and left {.val {not_evaluated}} spots not evaluated",
+        message_type = "running",
+        verbose = verbose
+      )
+    } else {
+      log_message(
+        "{.pkg SpotSweeper} completed partially: {.val {failed}} spots failed local QC; local-outlier detection left {.val {local_not_evaluated}} spots not evaluated; artifact detection was not requested",
+        message_type = "running",
+        verbose = verbose
+      )
+    }
   } else if (!isTRUE(run_artifact)) {
     log_message(
       "{.pkg SpotSweeper} completed local-outlier QC; artifact detection was not requested; {.val {failed}} spots failed local QC with prefix {.val {prefix}}",
@@ -593,6 +626,10 @@ spot_sweeper_run_artifacts <- function(
     idx <- which(as.character(cdata[[sample_col]]) == sample)
     spe_sample <- spe[, idx]
     sample_coldata <- spot_sweeper_coldata(spe_sample)
+    sample_coldata$artifact <- NULL
+    SummarizedExperiment::colData(spe_sample) <- S4Vectors::DataFrame(
+      sample_coldata
+    )
     artifact_ready <- spot_sweeper_artifact_ready(
       sample_coldata = sample_coldata,
       mito_percent = mito_percent,
@@ -611,8 +648,6 @@ spot_sweeper_run_artifacts <- function(
       )
       next
     }
-    spe_sample <- spe[, idx]
-    sample_coldata <- spot_sweeper_coldata(spe_sample)
     upstream_subset_ok <- tryCatch(
       ncol(subset(spe_sample, , TRUE)) == ncol(spe_sample),
       error = function(e) FALSE
@@ -757,13 +792,14 @@ spot_sweeper_finalize_metadata <- function(
   local_table <- list()
   local_fail <- rep(FALSE, length(all_spots))
   names(local_fail) <- all_spots
+  local_evaluated <- all_spots %in% rownames(cdata)
 
   for (metric in metrics) {
     outlier_raw <- paste0(metric, "_outliers")
     z_raw <- paste0(metric, "_z")
     outlier_col <- spot_sweeper_metadata_col(prefix, metric, "outlier")
     z_col <- spot_sweeper_metadata_col(prefix, metric, "z")
-    metadata[[outlier_col]] <- FALSE
+    metadata[[outlier_col]] <- rep(NA, length(all_spots))
     metadata[[z_col]] <- NA_real_
     outlier <- if (outlier_raw %in% colnames(cdata)) {
       as.logical(cdata[[outlier_raw]])
@@ -839,8 +875,17 @@ spot_sweeper_finalize_metadata <- function(
     levels = c("Pass", "Fail", "NotEvaluated")
   )
 
-  metadata[[paste0(prefix, "_local_outlier_qc")]] <- spot_sweeper_pass_fail(local_fail)
-  partial <- isTRUE(run_artifact) & is.na(artifact_values) & !local_fail
+  local_outlier_qc <- ifelse(
+    local_evaluated,
+    ifelse(local_fail, "Fail", "Pass"),
+    "NotEvaluated"
+  )
+  metadata[[paste0(prefix, "_local_outlier_qc")]] <- factor(
+    local_outlier_qc,
+    levels = c("Pass", "Fail", "NotEvaluated")
+  )
+  partial <- !local_evaluated |
+    (isTRUE(run_artifact) & is.na(artifact_values) & !local_fail)
   overall <- ifelse(
     local_fail | artifact_fail,
     "Fail",
@@ -861,10 +906,17 @@ spot_sweeper_finalize_metadata <- function(
     )
   }
   rownames(artifact_status) <- NULL
-  all_requested_completed <- all(
+  all_artifact_completed <- all(
     !is.na(artifact_status$status) & artifact_status$status == "completed"
-  )
-  overall_status <- if (isTRUE(run_artifact) && !all_requested_completed) {
+  ) &&
+    all(
+      !is.na(artifact_status_values) &
+        artifact_status_values == "completed"
+    ) &&
+    all(!is.na(artifact_values))
+  all_requested_completed <- all(local_evaluated) &&
+    (!isTRUE(run_artifact) || all_artifact_completed)
+  overall_status <- if (!all_requested_completed) {
     "partial"
   } else {
     "completed"

--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -25,6 +25,8 @@
 #' If `NULL`, all spots are treated as one sample.
 #' @param metrics QC metrics used by `SpotSweeper::localOutliers()`. If `NULL`,
 #' `nCount_<assay>`, `nFeature_<assay>`, and `percent.mito` are used.
+#' The corresponding `<metric>_outliers` and `<metric>_z` names are reserved for
+#' backend output and cannot also be requested as input columns.
 #' @param directions Outlier direction for each metric. If `NULL`, count and
 #' feature metrics use `"lower"` and mitochondrial metrics use `"higher"`.
 #' @param n_neighbors Unitless number of nearest spatial neighbors for local
@@ -61,8 +63,9 @@
 #' stored in `srt@tools[[tool_name]]`. The artifact metadata uses `NA` and
 #' `"NotEvaluated"` when a requested artifact stage did not run; the overall
 #' `*_local_outlier_qc` uses `"NotEvaluated"` outside the tested coordinate
-#' scope, and the overall `*_QC` column uses `"Partial"` whenever a spot was not
-#' fully evaluated by the requested QC stages.
+#' scope. In the overall `*_QC` column, `"Fail"` takes precedence when any
+#' evaluated check fails; otherwise `"Partial"` marks spots not fully evaluated
+#' by the requested QC stages.
 #' @export
 #'
 #' @examples
@@ -186,11 +189,6 @@ RunSpotSweeper <- function(
   extra_args <- list(...)
   spot_sweeper_validate_named_list(extra_args, "...")
 
-  check_r(
-    c("MicTott/SpotSweeper", "SpatialExperiment", "SummarizedExperiment", "S4Vectors"),
-    verbose = FALSE
-  )
-
   expr <- GetAssayData5(srt, assay = assay, layer = layer)
   coords <- spatial_analysis_coords(
     srt = srt,
@@ -211,6 +209,30 @@ RunSpotSweeper <- function(
     mito_percent = mito_percent,
     mito_sum = mito_sum,
     verbose = verbose
+  )
+  local_output_columns <- c(
+    paste0(inputs$metrics, "_outliers"),
+    paste0(inputs$metrics, "_z")
+  )
+  required_input_columns <- unique(c(
+    inputs$metrics,
+    inputs$sample_col,
+    if (isTRUE(run_artifact)) c(inputs$mito_percent, inputs$mito_sum)
+  ))
+  local_output_collisions <- intersect(
+    local_output_columns,
+    required_input_columns
+  )
+  if (length(local_output_collisions) > 0L) {
+    log_message(
+      "Requested input column{?s} collide with reserved {.pkg SpotSweeper} local-output names: {.val {local_output_collisions}}",
+      message_type = "error"
+    )
+  }
+
+  check_r(
+    c("MicTott/SpotSweeper", "SpatialExperiment", "SummarizedExperiment", "S4Vectors"),
+    verbose = FALSE
   )
   spe <- spot_sweeper_make_spe(
     expr = expr[inputs$features, inputs$spots, drop = FALSE],
@@ -566,6 +588,13 @@ spot_sweeper_run_local_outliers <- function(
       "Run {.pkg SpotSweeper} local outlier detection for {.val {metric}}",
       verbose = verbose
     )
+    outlier_col <- paste0(metric, "_outliers")
+    z_col <- paste0(metric, "_z")
+    input_spots <- colnames(spe)
+    input_coldata <- spot_sweeper_coldata(spe)
+    input_coldata[[outlier_col]] <- NULL
+    input_coldata[[z_col]] <- NULL
+    SummarizedExperiment::colData(spe) <- S4Vectors::DataFrame(input_coldata)
     args <- c(
       list(
         spe = spe,
@@ -580,6 +609,12 @@ spot_sweeper_run_local_outliers <- function(
       spot_sweeper_filter_args(local_fun, extra_args)
     )
     spe <- do.call(local_fun, args)
+    if (!identical(colnames(spe), input_spots)) {
+      log_message(
+        "{.pkg SpotSweeper} {.fn localOutliers} changed spot identities or order for metric {.val {metric}}",
+        message_type = "error"
+      )
+    }
     result[[metric]] <- spot_sweeper_coldata(spe)
   }
   list(spe = spe, result = result)
@@ -747,8 +782,12 @@ spot_sweeper_run_artifacts <- function(
       )
       next
     }
-    artifact_values <- as.logical(sample_coldata$artifact)
-    if (length(artifact_values) != nrow(sample_coldata) || anyNA(artifact_values)) {
+    artifact_values <- spot_sweeper_binary_values(
+      sample_coldata$artifact,
+      expected_length = nrow(sample_coldata),
+      allow_na = FALSE
+    )
+    if (is.null(artifact_values)) {
       reason <- "SpotSweeper::findArtifacts returned invalid artifact values"
       log_message(
         "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: {reason}",
@@ -793,6 +832,7 @@ spot_sweeper_finalize_metadata <- function(
   local_fail <- rep(FALSE, length(all_spots))
   names(local_fail) <- all_spots
   local_evaluated <- all_spots %in% rownames(cdata)
+  names(local_evaluated) <- all_spots
 
   for (metric in metrics) {
     outlier_raw <- paste0(metric, "_outliers")
@@ -802,9 +842,16 @@ spot_sweeper_finalize_metadata <- function(
     metadata[[outlier_col]] <- rep(NA, length(all_spots))
     metadata[[z_col]] <- NA_real_
     outlier <- if (outlier_raw %in% colnames(cdata)) {
-      as.logical(cdata[[outlier_raw]])
+      spot_sweeper_binary_values(
+        cdata[[outlier_raw]],
+        expected_length = nrow(cdata),
+        allow_na = TRUE
+      )
     } else {
-      rep(FALSE, nrow(cdata))
+      NULL
+    }
+    if (is.null(outlier)) {
+      outlier <- rep(NA, nrow(cdata))
     }
     z <- if (z_raw %in% colnames(cdata)) {
       suppressWarnings(as.numeric(cdata[[z_raw]]))
@@ -813,7 +860,10 @@ spot_sweeper_finalize_metadata <- function(
     }
     metadata[rownames(cdata), outlier_col] <- outlier
     metadata[rownames(cdata), z_col] <- z
-    local_fail[rownames(cdata)] <- local_fail[rownames(cdata)] | outlier
+    local_evaluated[rownames(cdata)] <-
+      local_evaluated[rownames(cdata)] & !is.na(outlier)
+    local_fail[rownames(cdata)] <-
+      local_fail[rownames(cdata)] | (!is.na(outlier) & outlier)
     local_table[[metric]] <- data.frame(
       spot = rownames(cdata),
       metric = metric,
@@ -876,9 +926,9 @@ spot_sweeper_finalize_metadata <- function(
   )
 
   local_outlier_qc <- ifelse(
-    local_evaluated,
-    ifelse(local_fail, "Fail", "Pass"),
-    "NotEvaluated"
+    local_fail,
+    "Fail",
+    ifelse(local_evaluated, "Pass", "NotEvaluated")
   )
   metadata[[paste0(prefix, "_local_outlier_qc")]] <- factor(
     local_outlier_qc,
@@ -1066,6 +1116,31 @@ spot_sweeper_coldata <- function(spe) {
   out <- as.data.frame(SummarizedExperiment::colData(spe), stringsAsFactors = FALSE)
   rownames(out) <- colnames(spe)
   out
+}
+
+spot_sweeper_binary_values <- function(
+  values,
+  expected_length,
+  allow_na = FALSE
+) {
+  if (length(values) != expected_length) {
+    return(NULL)
+  }
+  if (is.logical(values)) {
+    out <- values
+  } else if (is.numeric(values)) {
+    observed <- values[!is.na(values)]
+    if (!all(observed %in% c(0, 1))) {
+      return(NULL)
+    }
+    out <- as.logical(values)
+  } else {
+    return(NULL)
+  }
+  if (!isTRUE(allow_na) && anyNA(out)) {
+    return(NULL)
+  }
+  unname(out)
 }
 
 spot_sweeper_metadata_col <- function(prefix, metric, suffix) {

--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -4,8 +4,10 @@
 #' Run `SpotSweeper` spatially aware spot-level quality control on a spatial
 #' `Seurat` object. The wrapper computes standard spot QC metrics, runs local
 #' outlier detection for each metric, optionally runs regional artifact
-#' detection per sample, and writes standardized pass/fail metadata that can be
-#' visualized with [SpatialSpotPlot()].
+#' detection per sample, and writes standardized QC status metadata that can be
+#' visualized with [SpatialSpotPlot()]. Artifact detection is reported as
+#' completed, skipped, failed, or not requested; an artifact that was not
+#' evaluated is never reported as a negative artifact call.
 #'
 #' @md
 #' @param srt A `Seurat` object.
@@ -30,6 +32,8 @@
 #' @param cutoff Modified z-score cutoff passed to local outlier detection.
 #' @param log Whether SpotSweeper should log1p-transform local outlier metrics.
 #' @param run_artifact Whether to run `SpotSweeper::findArtifacts()` per sample.
+#' If the requested artifact stage is skipped or fails for any sample, the
+#' returned metadata and stored result are marked as partial.
 #' @param mito_pattern Regex prefixes used to identify mitochondrial genes.
 #' @param mito_gene Optional explicit mitochondrial gene vector. When provided,
 #' `mito_pattern` is ignored.
@@ -41,16 +45,21 @@
 #' @param prefix Prefix used for metadata columns.
 #' @param tool_name Name used to store detailed results in `srt@tools`.
 #' @param return_filtered Whether to return only spots passing SpotSweeper QC.
+#' A fully filtered object is not returned when requested artifact detection is
+#' incomplete; set `run_artifact = FALSE` to request local-outlier-only filtering.
 #' @param store_results Whether to store detailed results in `srt@tools`.
 #' @param cores Number of workers passed to SpotSweeper local outlier detection.
 #' @param workers Deprecated alias for `cores`.
-#' @param verbose Whether to print progress messages.
+#' @param verbose Whether to print progress and completion status messages.
 #' @param ... Additional named arguments passed to matching SpotSweeper backend
 #' functions when those arguments are supported by the installed version.
 #'
 #' @return A `Seurat` object with SpotSweeper QC metadata. When
-#' `store_results = TRUE`, detailed results are stored in
-#' `srt@tools[[tool_name]]`.
+#' `store_results = TRUE`, detailed results and an `artifact_status` table are
+#' stored in `srt@tools[[tool_name]]`. The artifact metadata uses `NA` and
+#' `"NotEvaluated"` when a requested artifact stage did not run; the overall
+#' `*_QC` column uses `"Partial"` for spots that passed local QC but were not
+#' evaluated for artifacts.
 #' @export
 #'
 #' @examples
@@ -204,6 +213,10 @@ RunSpotSweeper <- function(
   spe <- local_out$spe
 
   artifact_out <- NULL
+  artifact_status <- spot_sweeper_artifact_status_not_requested(
+    coldata = inputs$coldata,
+    sample_col = inputs$sample_col
+  )
   if (isTRUE(run_artifact)) {
     artifact_out <- spot_sweeper_run_artifacts(
       spe = spe,
@@ -217,6 +230,7 @@ RunSpotSweeper <- function(
       verbose = verbose
     )
     spe <- artifact_out$spe
+    artifact_status <- artifact_out$status
   }
 
   finalized <- spot_sweeper_finalize_metadata(
@@ -225,12 +239,23 @@ RunSpotSweeper <- function(
     prefix = prefix,
     metrics = inputs$metrics,
     metric_columns = inputs$metric_columns,
-    run_artifact = run_artifact
+    run_artifact = run_artifact,
+    artifact_status = artifact_status
   )
+
+  if (isTRUE(return_filtered) && identical(finalized$status, "partial")) {
+    log_message(
+      "Cannot return a fully filtered SpotSweeper object because artifact detection was not completed for every sample; set {.arg return_filtered = FALSE} or disable artifact detection explicitly",
+      message_type = "error"
+    )
+  }
+
   srt <- Seurat::AddMetaData(srt, metadata = finalized$metadata)
 
   if (isTRUE(store_results)) {
     srt@tools[[tool_name]] <- list(
+      status = finalized$status,
+      artifact_status = finalized$artifact_status,
       local_outliers = finalized$local_outliers,
       artifacts = finalized$artifacts,
       colData = finalized$coldata,
@@ -272,11 +297,32 @@ RunSpotSweeper <- function(
   }
 
   failed <- sum(srt[[paste0(prefix, "_QC"), drop = TRUE]] == "Fail", na.rm = TRUE)
-  log_message(
-    "{.pkg SpotSweeper} flagged {.val {failed}} spots with prefix {.val {prefix}}",
-    message_type = "success",
-    verbose = verbose
-  )
+  if (identical(finalized$status, "partial")) {
+    skipped <- sum(finalized$artifact_status$status == "skipped", na.rm = TRUE)
+    failed_artifact <- sum(finalized$artifact_status$status == "failed", na.rm = TRUE)
+    not_evaluated <- sum(
+      as.character(finalized$metadata[[paste0(prefix, "_artifact_qc")]]) ==
+        "NotEvaluated",
+      na.rm = TRUE
+    )
+    log_message(
+      "{.pkg SpotSweeper} completed partially: {.val {failed}} spots failed QC; artifact detection skipped for {.val {skipped}} sample{?s}, failed for {.val {failed_artifact}} sample{?s}, and left {.val {not_evaluated}} spots not evaluated",
+      message_type = "warning",
+      verbose = verbose
+    )
+  } else if (!isTRUE(run_artifact)) {
+    log_message(
+      "{.pkg SpotSweeper} completed local-outlier QC; artifact detection was not requested; {.val {failed}} spots failed local QC with prefix {.val {prefix}}",
+      message_type = "success",
+      verbose = verbose
+    )
+  } else {
+    log_message(
+      "{.pkg SpotSweeper} flagged {.val {failed}} spots with prefix {.val {prefix}}",
+      message_type = "success",
+      verbose = verbose
+    )
+  }
 
   if (isTRUE(return_filtered)) {
     srt <- srt[, srt[[paste0(prefix, "_QC"), drop = TRUE]] == "Pass"]
@@ -521,9 +567,28 @@ spot_sweeper_run_artifacts <- function(
   cdata <- spot_sweeper_coldata(spe)
   samples <- unique(as.character(cdata[[sample_col]]))
   combined <- cdata
-  combined$artifact <- FALSE
+  combined$artifact <- NA
   combined$.SpotSweeper_artifact_skip_reason <- NA_character_
+  combined$.SpotSweeper_artifact_status <- "skipped"
   result <- list()
+  status_rows <- vector("list", length(samples))
+  names(status_rows) <- samples
+  record_sample <- function(sample, sample_coldata, status, reason = NA_character_) {
+    if (!identical(status, "completed")) {
+      sample_coldata$artifact <- NA
+    }
+    sample_coldata$.SpotSweeper_artifact_skip_reason <- reason
+    sample_coldata$.SpotSweeper_artifact_status <- status
+    combined <<- spot_sweeper_merge_coldata(combined, sample_coldata)
+    result[[sample]] <<- sample_coldata
+    status_rows[[sample]] <<- spot_sweeper_artifact_status_row(
+      sample = sample,
+      sample_coldata = sample_coldata,
+      status = status,
+      reason = reason
+    )
+    invisible(NULL)
+  }
   for (sample in samples) {
     idx <- which(as.character(cdata[[sample_col]]) == sample)
     spe_sample <- spe[, idx]
@@ -538,10 +603,12 @@ spot_sweeper_run_artifacts <- function(
         "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: {artifact_ready$reason}",
         verbose = verbose
       )
-      sample_coldata$artifact <- FALSE
-      sample_coldata$.SpotSweeper_artifact_skip_reason <- artifact_ready$reason
-      combined <- spot_sweeper_merge_coldata(combined, sample_coldata)
-      result[[sample]] <- sample_coldata
+      record_sample(
+        sample = sample,
+        sample_coldata = sample_coldata,
+        status = "skipped",
+        reason = artifact_ready$reason
+      )
       next
     }
     spe_sample <- spe[, idx]
@@ -566,12 +633,16 @@ spot_sweeper_run_artifacts <- function(
     if (!isTRUE(upstream_subset_ok)) {
       log_message(
         "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: the installed {.pkg SpotSweeper} {.fn localVariance} breaks on {.cls SpatialExperiment} colData (matrix coordinate column breaks {.code DataFrame[i, j]} extraction); only local-outlier QC is stored",
-        message_type = "warning"
+        message_type = "warning",
+        verbose = verbose
       )
-      sample_coldata$artifact <- FALSE
-      sample_coldata$.SpotSweeper_artifact_skip_reason <- "upstream bug in SpotSweeper::localVariance"
-      combined <- spot_sweeper_merge_coldata(combined, sample_coldata)
-      result[[sample]] <- sample_coldata
+      reason <- "upstream bug in SpotSweeper::localVariance"
+      record_sample(
+        sample = sample,
+        sample_coldata = sample_coldata,
+        status = "skipped",
+        reason = reason
+      )
       next
     }
     log_message(
@@ -610,24 +681,65 @@ spot_sweeper_run_artifacts <- function(
     if (inherits(spe_sample, "error")) {
       log_message(
         "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: the installed {.pkg SpotSweeper} {.fn findArtifacts} failed ({conditionMessage(spe_sample)}); only local-outlier QC is stored",
-        message_type = "warning"
+        message_type = "warning",
+        verbose = verbose
       )
-      sample_coldata$artifact <- FALSE
-      sample_coldata$.SpotSweeper_artifact_skip_reason <- paste0(
+      reason <- paste0(
         "upstream failure in SpotSweeper::findArtifacts: ",
         conditionMessage(spe_sample)
       )
-      combined <- spot_sweeper_merge_coldata(combined, sample_coldata)
-      result[[sample]] <- sample_coldata
+      record_sample(
+        sample = sample,
+        sample_coldata = sample_coldata,
+        status = "failed",
+        reason = reason
+      )
       next
     }
     sample_coldata <- spot_sweeper_coldata(spe_sample)
-    sample_coldata$.SpotSweeper_artifact_skip_reason <- NA_character_
-    combined <- spot_sweeper_merge_coldata(combined, sample_coldata)
-    result[[sample]] <- sample_coldata
+    if (!"artifact" %in% colnames(sample_coldata)) {
+      reason <- "SpotSweeper::findArtifacts returned no artifact column"
+      log_message(
+        "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: {reason}",
+        message_type = "warning",
+        verbose = verbose
+      )
+      record_sample(
+        sample = sample,
+        sample_coldata = sample_coldata,
+        status = "failed",
+        reason = reason
+      )
+      next
+    }
+    artifact_values <- as.logical(sample_coldata$artifact)
+    if (length(artifact_values) != nrow(sample_coldata) || anyNA(artifact_values)) {
+      reason <- "SpotSweeper::findArtifacts returned invalid artifact values"
+      log_message(
+        "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: {reason}",
+        message_type = "warning",
+        verbose = verbose
+      )
+      record_sample(
+        sample = sample,
+        sample_coldata = sample_coldata,
+        status = "failed",
+        reason = reason
+      )
+      next
+    }
+    sample_coldata$artifact <- artifact_values
+    record_sample(
+      sample = sample,
+      sample_coldata = sample_coldata,
+      status = "completed",
+      reason = NA_character_
+    )
   }
   SummarizedExperiment::colData(spe) <- S4Vectors::DataFrame(combined[colnames(spe), , drop = FALSE])
-  list(spe = spe, result = result)
+  status <- do.call(rbind, status_rows)
+  rownames(status) <- NULL
+  list(spe = spe, result = result, status = status)
 }
 
 spot_sweeper_finalize_metadata <- function(
@@ -636,6 +748,7 @@ spot_sweeper_finalize_metadata <- function(
   prefix,
   metrics,
   metric_columns,
+  artifact_status,
   run_artifact = TRUE
 ) {
   cdata <- spot_sweeper_coldata(spe)
@@ -676,17 +789,37 @@ spot_sweeper_finalize_metadata <- function(
   local_table <- do.call(rbind, local_table)
   rownames(local_table) <- NULL
 
+  artifact_values <- rep(NA, length(all_spots))
+  names(artifact_values) <- all_spots
+  artifact_status_values <- rep("not_requested", length(all_spots))
+  names(artifact_status_values) <- all_spots
+  artifact_qc_values <- rep("NotEvaluated", length(all_spots))
+  names(artifact_qc_values) <- all_spots
+  if (isTRUE(run_artifact)) {
+    artifact_status_values[] <- "skipped"
+    if (".SpotSweeper_artifact_status" %in% colnames(cdata)) {
+      artifact_status_values[rownames(cdata)] <- as.character(
+        cdata$.SpotSweeper_artifact_status
+      )
+    }
+  }
+
   artifact_fail <- rep(FALSE, length(all_spots))
   names(artifact_fail) <- all_spots
   artifact_table <- NULL
   if (isTRUE(run_artifact) && "artifact" %in% colnames(cdata)) {
     artifact <- as.logical(cdata[["artifact"]])
-    metadata[[paste0(prefix, "_artifact")]] <- FALSE
-    metadata[rownames(cdata), paste0(prefix, "_artifact")] <- artifact
-    artifact_fail[rownames(cdata)] <- artifact
+    artifact_values[rownames(cdata)] <- artifact
+    artifact_qc_values[rownames(cdata)] <- ifelse(
+      is.na(artifact),
+      "NotEvaluated",
+      ifelse(artifact, "Fail", "Pass")
+    )
+    artifact_fail[rownames(cdata)] <- !is.na(artifact) & artifact
     artifact_table <- data.frame(
       spot = rownames(cdata),
       artifact = artifact,
+      artifact_status = unname(artifact_status_values[rownames(cdata)]),
       stringsAsFactors = FALSE
     )
     var_cols <- grep("^k[0-9]+$", colnames(cdata), value = TRUE)
@@ -699,16 +832,52 @@ spot_sweeper_finalize_metadata <- function(
     }
   }
 
+  metadata[[paste0(prefix, "_artifact")]] <- artifact_values
+  metadata[[paste0(prefix, "_artifact_status")]] <- artifact_status_values
+  metadata[[paste0(prefix, "_artifact_qc")]] <- factor(
+    artifact_qc_values,
+    levels = c("Pass", "Fail", "NotEvaluated")
+  )
+
   metadata[[paste0(prefix, "_local_outlier_qc")]] <- spot_sweeper_pass_fail(local_fail)
-  metadata[[paste0(prefix, "_artifact_qc")]] <- spot_sweeper_pass_fail(artifact_fail)
-  metadata[[paste0(prefix, "_QC")]] <- spot_sweeper_pass_fail(local_fail | artifact_fail)
+  partial <- isTRUE(run_artifact) & is.na(artifact_values) & !local_fail
+  overall <- ifelse(
+    local_fail | artifact_fail,
+    "Fail",
+    ifelse(partial, "Partial", "Pass")
+  )
+  metadata[[paste0(prefix, "_QC")]] <- factor(
+    overall,
+    levels = c("Pass", "Fail", "Partial")
+  )
+
+  required_status_columns <- c("sample", "status", "reason", "n_spots", "n_artifacts")
+  if (!is.data.frame(artifact_status) ||
+    nrow(artifact_status) == 0L ||
+    !all(required_status_columns %in% colnames(artifact_status))) {
+    log_message(
+      "Internal SpotSweeper artifact status is missing required sample-level fields",
+      message_type = "error"
+    )
+  }
+  rownames(artifact_status) <- NULL
+  all_requested_completed <- all(
+    !is.na(artifact_status$status) & artifact_status$status == "completed"
+  )
+  overall_status <- if (isTRUE(run_artifact) && !all_requested_completed) {
+    "partial"
+  } else {
+    "completed"
+  }
 
   list(
     metadata = metadata,
     local_outliers = local_table,
     artifacts = artifact_table,
     coldata = cdata,
-    metric_columns = metric_columns
+    metric_columns = metric_columns,
+    artifact_status = artifact_status,
+    status = overall_status
   )
 }
 
@@ -724,6 +893,43 @@ spot_sweeper_merge_coldata <- function(combined, sample_coldata) {
   sample_coldata <- sample_coldata[, colnames(combined), drop = FALSE]
   combined[rownames(sample_coldata), ] <- sample_coldata
   combined
+}
+
+spot_sweeper_artifact_status_row <- function(
+  sample,
+  sample_coldata,
+  status,
+  reason = NA_character_
+) {
+  artifact_count <- if (identical(status, "completed") && "artifact" %in% colnames(sample_coldata)) {
+    sum(as.logical(sample_coldata$artifact), na.rm = TRUE)
+  } else {
+    NA_integer_
+  }
+  data.frame(
+    sample = as.character(sample),
+    status = as.character(status),
+    reason = if (length(reason) == 0L || is.null(reason)) NA_character_ else as.character(reason),
+    n_spots = as.integer(nrow(sample_coldata)),
+    n_artifacts = as.integer(artifact_count),
+    stringsAsFactors = FALSE
+  )
+}
+
+spot_sweeper_artifact_status_not_requested <- function(coldata, sample_col) {
+  samples <- unique(as.character(coldata[[sample_col]]))
+  rows <- lapply(samples, function(sample) {
+    sample_coldata <- coldata[as.character(coldata[[sample_col]]) == sample, , drop = FALSE]
+    spot_sweeper_artifact_status_row(
+      sample = sample,
+      sample_coldata = sample_coldata,
+      status = "not_requested",
+      reason = NA_character_
+    )
+  })
+  out <- do.call(rbind, rows)
+  rownames(out) <- NULL
+  out
 }
 
 spot_sweeper_artifact_ready <- function(sample_coldata, mito_percent, mito_sum) {

--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -22,7 +22,9 @@
 #' explicit compatibility option. Neighbor counts are unitless, while any
 #' backend distance calculation uses the selected coordinate units.
 #' @param sample.by Optional metadata column identifying samples or images.
-#' If `NULL`, all spots are treated as one sample.
+#' If `NULL`, all spots are treated as one sample. The selected column must not
+#' contain missing values. The reserved backend output name `"artifact"` cannot
+#' be used when `run_artifact = TRUE`.
 #' @param metrics QC metrics used by `SpotSweeper::localOutliers()`. If `NULL`,
 #' `nCount_<assay>`, `nFeature_<assay>`, and `percent.mito` are used.
 #' The corresponding `<metric>_outliers` and `<metric>_z` names are reserved for
@@ -164,6 +166,9 @@ RunSpotSweeper <- function(
   validate_scalar_flag(run_artifact, "run_artifact")
   validate_scalar_flag(return_filtered, "return_filtered")
   validate_scalar_flag(store_results, "store_results")
+  if (!is.null(sample.by)) {
+    validate_scalar_string(sample.by, "sample.by")
+  }
   if (!is.null(mito_percent)) {
     validate_scalar_string(mito_percent, "mito_percent")
   }
@@ -172,13 +177,13 @@ RunSpotSweeper <- function(
   }
   if (isTRUE(run_artifact) &&
     any(vapply(
-      list(mito_percent, mito_sum),
+      list(sample.by, mito_percent, mito_sum),
       identical,
       logical(1),
       y = "artifact"
     ))) {
     log_message(
-      "Metadata column {.val artifact} is reserved for {.pkg SpotSweeper} artifact output and cannot be used as {.arg mito_percent} or {.arg mito_sum} when {.arg run_artifact = TRUE}",
+      "Metadata column {.val artifact} is reserved for {.pkg SpotSweeper} artifact output and cannot be used as {.arg sample.by}, {.arg mito_percent}, or {.arg mito_sum} when {.arg run_artifact = TRUE}",
       message_type = "error"
     )
   }
@@ -731,6 +736,8 @@ spot_sweeper_run_artifacts <- function(
         nrow(SummarizedExperiment::colData(spe_sample))
       )
     }
+    input_spots <- colnames(spe_sample)
+    input_sample_coldata <- spot_sweeper_coldata(spe_sample)
     args <- c(
       list(
         spe = spe_sample,
@@ -744,29 +751,45 @@ spot_sweeper_run_artifacts <- function(
       ),
       spot_sweeper_filter_args(artifact_fun, extra_args)
     )
-    spe_sample <- tryCatch(
+    artifact_spe <- tryCatch(
       do.call(artifact_fun, args),
       error = function(e) e
     )
-    if (inherits(spe_sample, "error")) {
+    if (inherits(artifact_spe, "error")) {
       log_message(
-        "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: the installed {.pkg SpotSweeper} {.fn findArtifacts} failed ({conditionMessage(spe_sample)}); only local-outlier QC is stored",
+        "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: the installed {.pkg SpotSweeper} {.fn findArtifacts} failed ({conditionMessage(artifact_spe)}); only local-outlier QC is stored",
         message_type = "running",
         verbose = verbose
       )
       reason <- paste0(
         "upstream failure in SpotSweeper::findArtifacts: ",
-        conditionMessage(spe_sample)
+        conditionMessage(artifact_spe)
       )
       record_sample(
         sample = sample,
-        sample_coldata = sample_coldata,
+        sample_coldata = input_sample_coldata,
         status = "failed",
         reason = reason
       )
       next
     }
-    sample_coldata <- spot_sweeper_coldata(spe_sample)
+    output_spots <- tryCatch(colnames(artifact_spe), error = function(e) NULL)
+    if (!identical(output_spots, input_spots)) {
+      reason <- "SpotSweeper::findArtifacts changed spot count, identities, or order"
+      log_message(
+        "Skip {.pkg SpotSweeper} artifact detection for sample {.val {sample}}: {reason}",
+        message_type = "running",
+        verbose = verbose
+      )
+      record_sample(
+        sample = sample,
+        sample_coldata = input_sample_coldata,
+        status = "failed",
+        reason = reason
+      )
+      next
+    }
+    sample_coldata <- spot_sweeper_coldata(artifact_spe)
     if (!"artifact" %in% colnames(sample_coldata)) {
       reason <- "SpotSweeper::findArtifacts returned no artifact column"
       log_message(
@@ -1063,6 +1086,12 @@ spot_sweeper_resolve_sample_col <- function(coldata, sample.by = NULL) {
   if (!sample.by %in% colnames(coldata)) {
     log_message(
       "{.arg sample.by} {.val {sample.by}} is not present in metadata",
+      message_type = "error"
+    )
+  }
+  if (anyNA(coldata[[sample.by]])) {
+    log_message(
+      "{.arg sample.by} {.val {sample.by}} contains missing values; every spot must have a sample label",
       message_type = "error"
     )
   }

--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -307,7 +307,7 @@ RunSpotSweeper <- function(
     )
     log_message(
       "{.pkg SpotSweeper} completed partially: {.val {failed}} spots failed QC; artifact detection skipped for {.val {skipped}} sample{?s}, failed for {.val {failed_artifact}} sample{?s}, and left {.val {not_evaluated}} spots not evaluated",
-      message_type = "warning",
+      message_type = "running",
       verbose = verbose
     )
   } else if (!isTRUE(run_artifact)) {

--- a/man/RunSpotSweeper.Rd
+++ b/man/RunSpotSweeper.Rd
@@ -73,10 +73,12 @@ returned metadata and stored result are marked as partial.}
 \code{mito_pattern} is ignored.}
 
 \item{mito_percent}{Metadata column used as mitochondrial percent for
-artifact detection. If \code{NULL}, \code{percent.mito} is used.}
+artifact detection. If \code{NULL}, \code{percent.mito} is used. The reserved
+backend output name \code{"artifact"} cannot be used when \code{run_artifact = TRUE}.}
 
 \item{mito_sum}{Metadata column used as mitochondrial counts for artifact
-detection. If \code{NULL}, mitochondrial counts are computed.}
+detection. If \code{NULL}, mitochondrial counts are computed. The reserved
+backend output name \code{"artifact"} cannot be used when \code{run_artifact = TRUE}.}
 
 \item{n_order, shape}{Parameters passed to \code{SpotSweeper::findArtifacts()}.}
 
@@ -85,8 +87,8 @@ detection. If \code{NULL}, mitochondrial counts are computed.}
 \item{tool_name}{Name used to store detailed results in \code{srt@tools}.}
 
 \item{return_filtered}{Whether to return only spots passing SpotSweeper QC.
-A fully filtered object is not returned when requested artifact detection is
-incomplete; set \code{run_artifact = FALSE} to request local-outlier-only filtering.}
+A fully filtered object is not returned when any requested QC stage is
+incomplete.}
 
 \item{store_results}{Whether to store detailed results in \code{srt@tools}.}
 
@@ -109,8 +111,9 @@ A \code{Seurat} object with SpotSweeper QC metadata. When
 \code{store_results = TRUE}, detailed results and an \code{artifact_status}
 table are stored in \code{srt@tools[[tool_name]]}. The artifact metadata uses
 \code{NA} and \code{"NotEvaluated"} when a requested artifact stage did not
-run; the overall \code{*_QC} column uses \code{"Partial"} for spots that
-passed local QC but were not evaluated for artifacts.
+run; \code{*_local_outlier_qc} uses \code{"NotEvaluated"} outside the tested
+coordinate scope, and the overall \code{*_QC} column uses \code{"Partial"}
+whenever a spot was not fully evaluated by the requested QC stages.
 }
 \description{
 Run \code{SpotSweeper} spatially aware spot-level quality control on a spatial

--- a/man/RunSpotSweeper.Rd
+++ b/man/RunSpotSweeper.Rd
@@ -48,7 +48,9 @@ available.}
 are present; a single image is selected automatically when \code{NULL}.}
 
 \item{sample.by}{Optional metadata column identifying samples or images.
-If \code{NULL}, all spots are treated as one sample.}
+If \code{NULL}, all spots are treated as one sample. The selected column must not
+contain missing values. The reserved backend output name \code{"artifact"} cannot
+be used when \code{run_artifact = TRUE}.}
 
 \item{metrics}{QC metrics used by \code{SpotSweeper::localOutliers()}. If \code{NULL},
 \verb{nCount_<assay>}, \verb{nFeature_<assay>}, and \code{percent.mito} are used.

--- a/man/RunSpotSweeper.Rd
+++ b/man/RunSpotSweeper.Rd
@@ -51,7 +51,9 @@ are present; a single image is selected automatically when \code{NULL}.}
 If \code{NULL}, all spots are treated as one sample.}
 
 \item{metrics}{QC metrics used by \code{SpotSweeper::localOutliers()}. If \code{NULL},
-\verb{nCount_<assay>}, \verb{nFeature_<assay>}, and \code{percent.mito} are used.}
+\verb{nCount_<assay>}, \verb{nFeature_<assay>}, and \code{percent.mito} are used.
+The corresponding \verb{<metric>_outliers} and \verb{<metric>_z} names are reserved for
+backend output and cannot also be requested as input columns.}
 
 \item{directions}{Outlier direction for each metric. If \code{NULL}, count and
 feature metrics use \code{"lower"} and mitochondrial metrics use \code{"higher"}.}
@@ -112,8 +114,9 @@ A \code{Seurat} object with SpotSweeper QC metadata. When
 table are stored in \code{srt@tools[[tool_name]]}. The artifact metadata uses
 \code{NA} and \code{"NotEvaluated"} when a requested artifact stage did not
 run; \code{*_local_outlier_qc} uses \code{"NotEvaluated"} outside the tested
-coordinate scope, and the overall \code{*_QC} column uses \code{"Partial"}
-whenever a spot was not fully evaluated by the requested QC stages.
+coordinate scope. In the overall \code{*_QC} column, \code{"Fail"} takes
+precedence when any evaluated check fails; otherwise \code{"Partial"} marks
+spots not fully evaluated by the requested QC stages.
 }
 \description{
 Run \code{SpotSweeper} spatially aware spot-level quality control on a spatial

--- a/man/RunSpotSweeper.Rd
+++ b/man/RunSpotSweeper.Rd
@@ -63,7 +63,9 @@ outlier detection.}
 
 \item{log}{Whether SpotSweeper should log1p-transform local outlier metrics.}
 
-\item{run_artifact}{Whether to run \code{SpotSweeper::findArtifacts()} per sample.}
+\item{run_artifact}{Whether to run \code{SpotSweeper::findArtifacts()} per sample.
+If the requested artifact stage is skipped or fails for any sample, the
+returned metadata and stored result are marked as partial.}
 
 \item{mito_pattern}{Regex prefixes used to identify mitochondrial genes.}
 
@@ -82,7 +84,9 @@ detection. If \code{NULL}, mitochondrial counts are computed.}
 
 \item{tool_name}{Name used to store detailed results in \code{srt@tools}.}
 
-\item{return_filtered}{Whether to return only spots passing SpotSweeper QC.}
+\item{return_filtered}{Whether to return only spots passing SpotSweeper QC.
+A fully filtered object is not returned when requested artifact detection is
+incomplete; set \code{run_artifact = FALSE} to request local-outlier-only filtering.}
 
 \item{store_results}{Whether to store detailed results in \code{srt@tools}.}
 
@@ -90,7 +94,7 @@ detection. If \code{NULL}, mitochondrial counts are computed.}
 
 \item{workers}{Deprecated alias for \code{cores}.}
 
-\item{verbose}{Whether to print progress messages.}
+\item{verbose}{Whether to print progress and completion status messages.}
 
 \item{coordinate_space}{Coordinate system used for spatial neighborhoods.
 The default is raw acquisition coordinates; \code{"legacy_display"} remains an
@@ -102,15 +106,20 @@ functions when those arguments are supported by the installed version.}
 }
 \value{
 A \code{Seurat} object with SpotSweeper QC metadata. When
-\code{store_results = TRUE}, detailed results are stored in
-\code{srt@tools[[tool_name]]}.
+\code{store_results = TRUE}, detailed results and an \code{artifact_status}
+table are stored in \code{srt@tools[[tool_name]]}. The artifact metadata uses
+\code{NA} and \code{"NotEvaluated"} when a requested artifact stage did not
+run; the overall \code{*_QC} column uses \code{"Partial"} for spots that
+passed local QC but were not evaluated for artifacts.
 }
 \description{
 Run \code{SpotSweeper} spatially aware spot-level quality control on a spatial
 \code{Seurat} object. The wrapper computes standard spot QC metrics, runs local
 outlier detection for each metric, optionally runs regional artifact
-detection per sample, and writes standardized pass/fail metadata that can be
-visualized with \code{\link[=SpatialSpotPlot]{SpatialSpotPlot()}}.
+detection per sample, and writes standardized QC status metadata that can be
+visualized with \code{\link[=SpatialSpotPlot]{SpatialSpotPlot()}}. Artifact
+detection is reported as completed, skipped, failed, or not requested; an
+artifact that was not evaluated is never reported as a negative artifact call.
 }
 \examples{
 data(visium_human_pancreas_sub)

--- a/tests/testthat/test-run-spotsweeper.R
+++ b/tests/testthat/test-run-spotsweeper.R
@@ -29,7 +29,11 @@ skip_if_no_spotsweeper_infra <- function() {
   testthat::skip_if_not_installed("S4Vectors")
 }
 
-with_mock_spotsweeper <- function(code) {
+with_mock_spotsweeper <- function(
+  code,
+  artifact_mode = c("success", "error", "missing", "invalid")
+) {
+  artifact_mode <- match.arg(artifact_mode)
   fake_local <- function(
     spe,
     metric,
@@ -78,6 +82,24 @@ with_mock_spotsweeper <- function(code) {
     SummarizedExperiment::colData(spe) <- S4Vectors::DataFrame(cdata)
     spe
   }
+  failing_artifact <- function(...) {
+    stop("mock artifact failure")
+  }
+  missing_artifact <- function(spe, ...) {
+    spe
+  }
+  invalid_artifact <- function(spe, ...) {
+    cdata <- as.data.frame(SummarizedExperiment::colData(spe))
+    cdata$artifact <- rep(NA, nrow(cdata))
+    SummarizedExperiment::colData(spe) <- S4Vectors::DataFrame(cdata)
+    spe
+  }
+  selected_artifact <- switch(artifact_mode,
+    success = fake_artifact,
+    error = failing_artifact,
+    missing = missing_artifact,
+    invalid = invalid_artifact
+  )
   testthat::local_mocked_bindings(
     .package = "scop",
     check_r = function(packages, ...) {
@@ -96,7 +118,7 @@ with_mock_spotsweeper <- function(code) {
       if (identical(package, "SpotSweeper")) {
         return(switch(name,
           localOutliers = fake_local,
-          findArtifacts = fake_artifact,
+          findArtifacts = selected_artifact,
           stop("unexpected SpotSweeper function")
         ))
       }
@@ -104,6 +126,37 @@ with_mock_spotsweeper <- function(code) {
     }
   )
   force(code)
+}
+
+capture_spotsweeper_logs <- function(code) {
+  events <- list()
+  testthat::local_mocked_bindings(
+    .package = "scop",
+    log_message = function(
+      ...,
+      verbose = NULL,
+      message_type = c("info", "success", "warning", "error", "running", "ask")
+    ) {
+      message_type <- match.arg(message_type)
+      text <- paste(vapply(
+        list(...),
+        function(x) paste(as.character(x), collapse = " "),
+        character(1)
+      ), collapse = " ")
+      if (identical(message_type, "error")) {
+        stop(text, call. = FALSE)
+      }
+      if (!isFALSE(verbose)) {
+        events[[length(events) + 1L]] <<- list(
+          type = message_type,
+          text = text
+        )
+      }
+      invisible(NULL)
+    }
+  )
+  force(code)
+  events
 }
 
 test_that("RunSpotSweeper validates Seurat input before backend work", {
@@ -144,6 +197,10 @@ test_that("RunSpotSweeper stores local outlier and artifact metadata", {
   expect_true(out$SpotSweeper_percent.mito_outlier[2])
   expect_true(out$SpotSweeper_artifact[4])
   expect_true("SpotSweeper" %in% names(out@tools))
+  expect_identical(out@tools$SpotSweeper$status, "completed")
+  expect_true(all(out@tools$SpotSweeper$artifact_status$status == "completed"))
+  expect_true(all(as.character(out$SpotSweeper_artifact_qc) %in% c("Pass", "Fail")))
+  expect_true(all(as.character(out$SpotSweeper_QC) %in% c("Pass", "Fail")))
   expect_identical(out@tools$SpotSweeper$parameters$coordinate_space, "raw")
   expect_equal(out@tools$SpotSweeper$metrics, c("nCount_RNA", "nFeature_RNA", "percent.mito"))
   expect_equal(out@tools$SpotSweeper$directions[["percent.mito"]], "higher")
@@ -166,10 +223,248 @@ test_that("RunSpotSweeper skips artifact detection when mitochondrial signal is 
   })
 
   expect_true("SpotSweeper_artifact" %in% colnames(out@meta.data))
-  expect_false(any(out$SpotSweeper_artifact))
-  expect_true(all(out$SpotSweeper_artifact_qc == "Pass"))
+  expect_true(all(is.na(out$SpotSweeper_artifact)))
+  expect_true(all(as.character(out$SpotSweeper_artifact_qc) == "NotEvaluated"))
+  expect_equal(as.character(out$SpotSweeper_QC[1:2]), c("Fail", "Fail"))
+  expect_true(all(as.character(out$SpotSweeper_QC[3:6]) == "Partial"))
+  expect_identical(out@tools$SpotSweeper$status, "partial")
+  expect_true(all(out@tools$SpotSweeper$artifact_status$status == "skipped"))
   expect_true("skip_reason" %in% colnames(out@tools$SpotSweeper$artifacts))
   expect_true(all(!is.na(out@tools$SpotSweeper$artifacts$skip_reason)))
+})
+
+test_that("RunSpotSweeper marks artifact backend failures as partial", {
+  skip_if_no_spotsweeper_infra()
+  srt <- make_spotsweeper_seurat()
+  out <- suppressWarnings(with_mock_spotsweeper({
+    RunSpotSweeper(
+      srt,
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      sample.by = "sample",
+      n_neighbors = 2,
+      n_order = 2,
+      verbose = FALSE
+    )
+  }, artifact_mode = "error"))
+
+  expect_identical(out@tools$SpotSweeper$status, "partial")
+  expect_true(all(out@tools$SpotSweeper$artifact_status$status == "failed"))
+  expect_true(all(is.na(out$SpotSweeper_artifact)))
+  expect_true(all(as.character(out$SpotSweeper_artifact_qc) == "NotEvaluated"))
+  expect_true(all(as.character(out$SpotSweeper_QC[3:6]) == "Partial"))
+  expect_true(all(grepl("mock artifact failure", out@tools$SpotSweeper$artifact_status$reason)))
+})
+
+test_that("RunSpotSweeper rejects missing or invalid artifact backend output truthfully", {
+  skip_if_no_spotsweeper_infra()
+  expected_reason <- c(
+    missing = "returned no artifact column",
+    invalid = "returned invalid artifact values"
+  )
+  for (artifact_mode in names(expected_reason)) {
+    srt <- make_spotsweeper_seurat()
+    out <- suppressWarnings(with_mock_spotsweeper({
+      RunSpotSweeper(
+        srt,
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        n_order = 2,
+        verbose = FALSE
+      )
+    }, artifact_mode = artifact_mode))
+
+    status <- out@tools$SpotSweeper$artifact_status
+    expect_identical(out@tools$SpotSweeper$status, "partial")
+    expect_true(all(status$status == "failed"))
+    expect_true(all(grepl(expected_reason[[artifact_mode]], status$reason)))
+    expect_true(all(is.na(out$SpotSweeper_artifact)))
+    expect_true(all(as.character(out$SpotSweeper_artifact_qc) == "NotEvaluated"))
+    expect_true(all(as.character(out$SpotSweeper_QC[3:6]) == "Partial"))
+  }
+})
+
+test_that("RunSpotSweeper preserves mixed per-sample artifact statuses", {
+  skip_if_no_spotsweeper_infra()
+  srt <- make_spotsweeper_seurat()
+  srt$artifact_mito_percent <- c(1, 2, 3, 1, 1, 1)
+  srt$artifact_mito_sum <- c(1, 2, 3, 1, 1, 1)
+  out <- suppressWarnings(with_mock_spotsweeper({
+    RunSpotSweeper(
+      srt,
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      sample.by = "sample",
+      mito_percent = "artifact_mito_percent",
+      mito_sum = "artifact_mito_sum",
+      n_neighbors = 2,
+      n_order = 2,
+      verbose = FALSE
+    )
+  }))
+
+  status <- out@tools$SpotSweeper$artifact_status
+  expect_equal(status$sample, c("S1", "S2"))
+  expect_equal(status$status, c("completed", "skipped"))
+  expect_equal(status$n_spots, c(3L, 3L))
+  expect_equal(status$n_artifacts, c(0L, NA_integer_))
+  expect_identical(out@tools$SpotSweeper$status, "partial")
+  expect_true(all(!is.na(out$SpotSweeper_artifact[1:3])))
+  expect_true(all(is.na(out$SpotSweeper_artifact[4:6])))
+  expect_true(all(as.character(out$SpotSweeper_artifact_qc[1:3]) == "Pass"))
+  expect_true(all(as.character(out$SpotSweeper_artifact_qc[4:6]) == "NotEvaluated"))
+  expect_equal(
+    as.character(out$SpotSweeper_QC),
+    c("Fail", "Pass", "Pass", "Partial", "Partial", "Partial")
+  )
+})
+
+test_that("RunSpotSweeper preserves custom sample order when artifacts are not requested", {
+  skip_if_no_spotsweeper_infra()
+  srt <- make_spotsweeper_seurat()
+  srt$sample <- rep(c("S2", "S1"), each = 3)
+  out <- with_mock_spotsweeper({
+    RunSpotSweeper(
+      srt,
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      sample.by = "sample",
+      n_neighbors = 2,
+      run_artifact = FALSE,
+      store_results = TRUE,
+      verbose = FALSE
+    )
+  })
+
+  status <- out@tools$SpotSweeper$artifact_status
+  expect_identical(out@tools$SpotSweeper$status, "completed")
+  expect_equal(status$sample, c("S2", "S1"))
+  expect_true(all(status$status == "not_requested"))
+  expect_equal(status$n_spots, c(3L, 3L))
+  expect_true(all(is.na(status$n_artifacts)))
+  expect_true(all(out$SpotSweeper_artifact_status == "not_requested"))
+  expect_true(all(is.na(out$SpotSweeper_artifact)))
+  expect_true(all(as.character(out$SpotSweeper_artifact_qc) == "NotEvaluated"))
+})
+
+test_that("RunSpotSweeper refuses filtered output when artifact detection is partial", {
+  skip_if_no_spotsweeper_infra()
+  srt <- make_spotsweeper_seurat()
+  before <- list(
+    meta.data = srt@meta.data,
+    assays = srt@assays,
+    reductions = srt@reductions,
+    graphs = srt@graphs,
+    tools = srt@tools
+  )
+  condition <- tryCatch(
+    suppressWarnings(with_mock_spotsweeper({
+      RunSpotSweeper(
+        srt,
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        n_order = 2,
+        return_filtered = TRUE,
+        verbose = FALSE
+      )
+    }, artifact_mode = "error")),
+    error = identity
+  )
+  expect_s3_class(condition, "error")
+  expect_match(conditionMessage(condition), "fully filtered SpotSweeper object")
+  expect_identical(srt@meta.data, before$meta.data)
+  expect_identical(srt@assays, before$assays)
+  expect_identical(srt@reductions, before$reductions)
+  expect_identical(srt@graphs, before$graphs)
+  expect_identical(srt@tools, before$tools)
+})
+
+test_that("RunSpotSweeper keeps partial metadata when detailed storage is disabled", {
+  skip_if_no_spotsweeper_infra()
+  srt <- make_spotsweeper_seurat(include_mito = FALSE)
+  out <- with_mock_spotsweeper({
+    RunSpotSweeper(
+      srt,
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      sample.by = "sample",
+      n_neighbors = 2,
+      n_order = 2,
+      store_results = FALSE,
+      verbose = FALSE
+    )
+  })
+
+  expect_false("SpotSweeper" %in% names(out@tools))
+  expect_true(all(out$SpotSweeper_artifact_status == "skipped"))
+  expect_true(all(is.na(out$SpotSweeper_artifact)))
+  expect_true(all(as.character(out$SpotSweeper_artifact_qc) == "NotEvaluated"))
+  expect_equal(
+    as.character(out$SpotSweeper_QC),
+    c("Fail", "Fail", "Partial", "Partial", "Partial", "Partial")
+  )
+})
+
+test_that("RunSpotSweeper console status is truthful and respects verbose", {
+  skip_if_no_spotsweeper_infra()
+
+  partial_events <- capture_spotsweeper_logs(with_mock_spotsweeper({
+    RunSpotSweeper(
+      make_spotsweeper_seurat(include_mito = FALSE),
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      sample.by = "sample",
+      n_neighbors = 2,
+      verbose = TRUE
+    )
+  }))
+  expect_true(any(vapply(
+    partial_events,
+    function(x) identical(x$type, "warning") && grepl("completed partially", x$text),
+    logical(1)
+  )))
+  expect_false(any(vapply(
+    partial_events,
+    function(x) identical(x$type, "success"),
+    logical(1)
+  )))
+
+  local_only_events <- capture_spotsweeper_logs(with_mock_spotsweeper({
+    RunSpotSweeper(
+      make_spotsweeper_seurat(),
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      sample.by = "sample",
+      n_neighbors = 2,
+      run_artifact = FALSE,
+      verbose = TRUE
+    )
+  }))
+  expect_true(any(vapply(
+    local_only_events,
+    function(x) {
+      identical(x$type, "success") &&
+        grepl("local-outlier QC", x$text) &&
+        grepl("not requested", x$text)
+    },
+    logical(1)
+  )))
+
+  silent_events <- capture_spotsweeper_logs(with_mock_spotsweeper({
+    RunSpotSweeper(
+      make_spotsweeper_seurat(),
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      sample.by = "sample",
+      n_neighbors = 2,
+      verbose = FALSE
+    )
+  }, artifact_mode = "error"))
+  expect_length(silent_events, 0L)
 })
 
 test_that("RunSpotSweeper supports return_filtered and store_results = FALSE", {
@@ -192,6 +487,9 @@ test_that("RunSpotSweeper supports return_filtered and store_results = FALSE", {
   expect_s4_class(out, "Seurat")
   expect_equal(colnames(out), c("Spot3", "Spot4", "Spot5", "Spot6"))
   expect_false("SpotSweeper" %in% names(out@tools))
+  expect_true(all(is.na(out$SpotSweeper_artifact)))
+  expect_true(all(as.character(out$SpotSweeper_artifact_qc) == "NotEvaluated"))
+  expect_true(all(out$SpotSweeper_artifact_status == "not_requested"))
   expect_true(all(out$SpotSweeper_QC == "Pass"))
 })
 

--- a/tests/testthat/test-run-spotsweeper.R
+++ b/tests/testthat/test-run-spotsweeper.R
@@ -31,7 +31,10 @@ skip_if_no_spotsweeper_infra <- function() {
 
 with_mock_spotsweeper <- function(
   code,
-  artifact_mode = c("success", "error", "missing", "invalid", "nonbinary"),
+  artifact_mode = c(
+    "success", "error", "missing", "invalid", "nonbinary",
+    "drop", "rename", "reorder"
+  ),
   local_mode = c("success", "missing", "partial", "invalid")
 ) {
   artifact_mode <- match.arg(artifact_mode)
@@ -94,6 +97,15 @@ with_mock_spotsweeper <- function(
     cdata$artifact <- colnames(spe) %in% c("Spot4", "Spot6")
     cdata$k18 <- seq_len(nrow(cdata))
     SummarizedExperiment::colData(spe) <- S4Vectors::DataFrame(cdata)
+    if (identical(artifact_mode, "drop")) {
+      spe <- spe[, seq_len(ncol(spe) - 1L)]
+    } else if (identical(artifact_mode, "rename")) {
+      spot_names <- colnames(spe)
+      spot_names[[1]] <- paste0(spot_names[[1]], "_renamed")
+      colnames(spe) <- spot_names
+    } else if (identical(artifact_mode, "reorder")) {
+      spe <- spe[, rev(seq_len(ncol(spe)))]
+    }
     spe
   }
   failing_artifact <- function(...) {
@@ -119,7 +131,10 @@ with_mock_spotsweeper <- function(
     error = failing_artifact,
     missing = missing_artifact,
     invalid = invalid_artifact,
-    nonbinary = nonbinary_artifact
+    nonbinary = nonbinary_artifact,
+    drop = fake_artifact,
+    rename = fake_artifact,
+    reorder = fake_artifact
   )
   testthat::local_mocked_bindings(
     .package = "scop",
@@ -308,6 +323,37 @@ test_that("RunSpotSweeper rejects missing or invalid artifact backend output tru
   }
 })
 
+test_that("RunSpotSweeper rejects artifact output with changed spot alignment", {
+  skip_if_no_spotsweeper_infra()
+  for (artifact_mode in c("drop", "rename", "reorder")) {
+    out <- suppressWarnings(with_mock_spotsweeper({
+      RunSpotSweeper(
+        make_spotsweeper_seurat(),
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        n_order = 2,
+        verbose = FALSE
+      )
+    }, artifact_mode = artifact_mode))
+
+    status <- out@tools$SpotSweeper$artifact_status
+    expect_identical(out@tools$SpotSweeper$status, "partial", info = artifact_mode)
+    expect_true(all(status$status == "failed"), info = artifact_mode)
+    expect_equal(status$n_spots, c(3L, 3L), info = artifact_mode)
+    expect_true(all(grepl(
+      "changed spot count, identities, or order",
+      status$reason,
+      fixed = TRUE
+    )), info = artifact_mode)
+    expect_true(all(is.na(out$SpotSweeper_artifact)), info = artifact_mode)
+    expect_true(all(
+      as.character(out$SpotSweeper_artifact_qc) == "NotEvaluated"
+    ), info = artifact_mode)
+  }
+})
+
 test_that("RunSpotSweeper marks incomplete local-outlier output partial", {
   skip_if_no_spotsweeper_infra()
   for (local_mode in c("missing", "partial", "invalid")) {
@@ -430,13 +476,12 @@ test_that("RunSpotSweeper does not reuse a stale artifact metadata column", {
 })
 
 test_that("RunSpotSweeper rejects reserved artifact input columns atomically", {
-  skip_if_no_spotsweeper_infra()
   srt <- make_spotsweeper_seurat()
   srt$artifact <- seq_len(ncol(srt))
   metadata_before <- srt@meta.data
   tools_before <- srt@tools
 
-  for (input_arg in c("mito_percent", "mito_sum")) {
+  for (input_arg in c("sample.by", "mito_percent", "mito_sum")) {
     check_called <- FALSE
     args <- list(
       srt = srt,
@@ -461,6 +506,36 @@ test_that("RunSpotSweeper rejects reserved artifact input columns atomically", {
     )
     expect_false(check_called, info = input_arg)
   }
+  expect_identical(srt@meta.data, metadata_before)
+  expect_identical(srt@tools, tools_before)
+})
+
+test_that("RunSpotSweeper rejects missing sample labels before backend checks", {
+  srt <- make_spotsweeper_seurat()
+  srt$sample[[2]] <- NA_character_
+  metadata_before <- srt@meta.data
+  tools_before <- srt@tools
+  check_called <- FALSE
+
+  expect_error(
+    testthat::with_mocked_bindings(
+      RunSpotSweeper(
+        srt,
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        verbose = FALSE
+      ),
+      check_r = function(...) {
+        check_called <<- TRUE
+        stop("backend check should not run", call. = FALSE)
+      },
+      .package = "scop"
+    ),
+    "contains missing values"
+  )
+  expect_false(check_called)
   expect_identical(srt@meta.data, metadata_before)
   expect_identical(srt@tools, tools_before)
 })

--- a/tests/testthat/test-run-spotsweeper.R
+++ b/tests/testthat/test-run-spotsweeper.R
@@ -31,9 +31,11 @@ skip_if_no_spotsweeper_infra <- function() {
 
 with_mock_spotsweeper <- function(
   code,
-  artifact_mode = c("success", "error", "missing", "invalid")
+  artifact_mode = c("success", "error", "missing", "invalid", "nonbinary"),
+  local_mode = c("success", "missing", "partial", "invalid")
 ) {
   artifact_mode <- match.arg(artifact_mode)
+  local_mode <- match.arg(local_mode)
   fake_local <- function(
     spe,
     metric,
@@ -57,8 +59,20 @@ with_mock_spotsweeper <- function(
     if (identical(metric, "percent.mito")) {
       outlier["Spot2"] <- TRUE
     }
+    if (identical(local_mode, "missing")) {
+      return(spe)
+    }
+    if (identical(local_mode, "partial")) {
+      outlier[[3]] <- NA
+    } else if (identical(local_mode, "invalid")) {
+      outlier <- rep(2, length(outlier))
+    }
     cdata[[paste0(metric, "_outliers")]] <- outlier
-    cdata[[paste0(metric, "_z")]] <- ifelse(outlier, cutoff + 1, 0)
+    cdata[[paste0(metric, "_z")]] <- ifelse(
+      is.na(outlier),
+      NA_real_,
+      ifelse(outlier == 1, cutoff + 1, 0)
+    )
     SummarizedExperiment::colData(spe) <- S4Vectors::DataFrame(cdata)
     spe
   }
@@ -94,11 +108,18 @@ with_mock_spotsweeper <- function(
     SummarizedExperiment::colData(spe) <- S4Vectors::DataFrame(cdata)
     spe
   }
+  nonbinary_artifact <- function(spe, ...) {
+    cdata <- as.data.frame(SummarizedExperiment::colData(spe))
+    cdata$artifact <- rep(c(0, 1, 2), length.out = nrow(cdata))
+    SummarizedExperiment::colData(spe) <- S4Vectors::DataFrame(cdata)
+    spe
+  }
   selected_artifact <- switch(artifact_mode,
     success = fake_artifact,
     error = failing_artifact,
     missing = missing_artifact,
-    invalid = invalid_artifact
+    invalid = invalid_artifact,
+    nonbinary = nonbinary_artifact
   )
   testthat::local_mocked_bindings(
     .package = "scop",
@@ -260,7 +281,8 @@ test_that("RunSpotSweeper rejects missing or invalid artifact backend output tru
   skip_if_no_spotsweeper_infra()
   expected_reason <- c(
     missing = "returned no artifact column",
-    invalid = "returned invalid artifact values"
+    invalid = "returned invalid artifact values",
+    nonbinary = "returned invalid artifact values"
   )
   for (artifact_mode in names(expected_reason)) {
     srt <- make_spotsweeper_seurat()
@@ -284,6 +306,103 @@ test_that("RunSpotSweeper rejects missing or invalid artifact backend output tru
     expect_true(all(as.character(out$SpotSweeper_artifact_qc) == "NotEvaluated"))
     expect_true(all(as.character(out$SpotSweeper_QC[3:6]) == "Partial"))
   }
+})
+
+test_that("RunSpotSweeper marks incomplete local-outlier output partial", {
+  skip_if_no_spotsweeper_infra()
+  for (local_mode in c("missing", "partial", "invalid")) {
+    out <- suppressMessages(with_mock_spotsweeper({
+      RunSpotSweeper(
+        make_spotsweeper_seurat(),
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        run_artifact = FALSE,
+        verbose = TRUE
+      )
+    }, local_mode = local_mode))
+
+    expect_identical(out@tools$SpotSweeper$status, "partial", info = local_mode)
+    expect_true(any(
+      as.character(out$SpotSweeper_local_outlier_qc) == "NotEvaluated"
+    ), info = local_mode)
+    expect_true(any(as.character(out$SpotSweeper_QC) == "Partial"), info = local_mode)
+  }
+
+  expect_error(
+    with_mock_spotsweeper({
+      RunSpotSweeper(
+        make_spotsweeper_seurat(),
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        run_artifact = FALSE,
+        return_filtered = TRUE,
+        verbose = FALSE
+      )
+    }, local_mode = "missing"),
+    "completed for every spot"
+  )
+})
+
+test_that("RunSpotSweeper does not reuse stale local-outlier metadata", {
+  skip_if_no_spotsweeper_infra()
+  srt <- make_spotsweeper_seurat()
+  metrics <- c("nCount_RNA", "nFeature_RNA", "percent.mito")
+  for (metric in metrics) {
+    srt[[paste0(metric, "_outliers")]] <- FALSE
+    srt[[paste0(metric, "_z")]] <- 0
+  }
+
+  out <- suppressMessages(with_mock_spotsweeper({
+    RunSpotSweeper(
+      srt,
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      sample.by = "sample",
+      n_neighbors = 2,
+      run_artifact = FALSE,
+      verbose = TRUE
+    )
+  }, local_mode = "missing"))
+
+  expect_identical(out@tools$SpotSweeper$status, "partial")
+  expect_true(all(as.character(out$SpotSweeper_local_outlier_qc) == "NotEvaluated"))
+  expect_true(all(as.character(out$SpotSweeper_QC) == "Partial"))
+  for (metric in metrics) {
+    output_col <- spot_sweeper_metadata_col("SpotSweeper", metric, "outlier")
+    expect_true(all(is.na(out[[output_col, drop = TRUE]])), info = metric)
+  }
+})
+
+test_that("RunSpotSweeper rejects local-output input collisions before backend checks", {
+  srt <- make_spotsweeper_seurat()
+  srt$nCount_RNA_outliers <- seq_len(ncol(srt))
+  check_called <- FALSE
+
+  expect_error(
+    testthat::with_mocked_bindings(
+      RunSpotSweeper(
+        srt,
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        metrics = c("nCount_RNA", "nCount_RNA_outliers"),
+        n_neighbors = 2,
+        run_artifact = FALSE,
+        verbose = FALSE
+      ),
+      check_r = function(...) {
+        check_called <<- TRUE
+        stop("backend check should not run", call. = FALSE)
+      },
+      .package = "scop"
+    ),
+    "collide with reserved.*local-output"
+  )
+  expect_false(check_called)
 })
 
 test_that("RunSpotSweeper does not reuse a stale artifact metadata column", {
@@ -651,7 +770,12 @@ test_that("RunSpotSweeper partial completion survives warning escalation", {
     readiness = list(include_mito = FALSE, artifact_mode = "success", status = "skipped"),
     backend_error = list(include_mito = TRUE, artifact_mode = "error", status = "failed"),
     missing_output = list(include_mito = TRUE, artifact_mode = "missing", status = "failed"),
-    invalid_output = list(include_mito = TRUE, artifact_mode = "invalid", status = "failed")
+    invalid_output = list(include_mito = TRUE, artifact_mode = "invalid", status = "failed"),
+    nonbinary_output = list(
+      include_mito = TRUE,
+      artifact_mode = "nonbinary",
+      status = "failed"
+    )
   )
   for (case_name in names(cases)) {
     case <- cases[[case_name]]

--- a/tests/testthat/test-run-spotsweeper.R
+++ b/tests/testthat/test-run-spotsweeper.R
@@ -472,21 +472,35 @@ test_that("RunSpotSweeper partial completion survives warning escalation", {
   old_options <- options(warn = 2)
   on.exit(options(old_options), add = TRUE)
 
-  out <- NULL
-  expect_no_error(
-    out <- suppressMessages(with_mock_spotsweeper({
-      RunSpotSweeper(
-        make_spotsweeper_seurat(include_mito = FALSE),
-        layer = "counts",
-        coord.cols = c("x", "y"),
-        sample.by = "sample",
-        n_neighbors = 2,
-        verbose = TRUE
-      )
-    }))
+  cases <- list(
+    readiness = list(include_mito = FALSE, artifact_mode = "success", status = "skipped"),
+    backend_error = list(include_mito = TRUE, artifact_mode = "error", status = "failed"),
+    missing_output = list(include_mito = TRUE, artifact_mode = "missing", status = "failed"),
+    invalid_output = list(include_mito = TRUE, artifact_mode = "invalid", status = "failed")
   )
-  expect_s4_class(out, "Seurat")
-  expect_identical(out@tools$SpotSweeper$status, "partial")
+  for (case_name in names(cases)) {
+    case <- cases[[case_name]]
+    out <- NULL
+    expect_no_error(
+      out <- suppressMessages(with_mock_spotsweeper({
+        RunSpotSweeper(
+          make_spotsweeper_seurat(include_mito = case$include_mito),
+          layer = "counts",
+          coord.cols = c("x", "y"),
+          sample.by = "sample",
+          n_neighbors = 2,
+          verbose = TRUE
+        )
+      }, artifact_mode = case$artifact_mode)),
+      message = case_name
+    )
+    expect_s4_class(out, "Seurat")
+    expect_identical(out@tools$SpotSweeper$status, "partial", info = case_name)
+    expect_true(
+      all(out@tools$SpotSweeper$artifact_status$status == case$status),
+      info = case_name
+    )
+  }
 })
 
 test_that("RunSpotSweeper supports return_filtered and store_results = FALSE", {

--- a/tests/testthat/test-run-spotsweeper.R
+++ b/tests/testthat/test-run-spotsweeper.R
@@ -286,6 +286,181 @@ test_that("RunSpotSweeper rejects missing or invalid artifact backend output tru
   }
 })
 
+test_that("RunSpotSweeper does not reuse a stale artifact metadata column", {
+  skip_if_no_spotsweeper_infra()
+  srt <- make_spotsweeper_seurat()
+  srt$artifact <- rep(c(TRUE, FALSE), length.out = ncol(srt))
+  artifact_before <- srt$artifact
+
+  out <- suppressMessages(with_mock_spotsweeper({
+    RunSpotSweeper(
+      srt,
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      sample.by = "sample",
+      n_neighbors = 2,
+      verbose = TRUE
+    )
+  }, artifact_mode = "missing"))
+
+  expect_identical(out@tools$SpotSweeper$status, "partial")
+  expect_true(all(out@tools$SpotSweeper$artifact_status$status == "failed"))
+  expect_true(all(is.na(out$SpotSweeper_artifact)))
+  expect_true(all(as.character(out$SpotSweeper_artifact_qc) == "NotEvaluated"))
+  expect_identical(out$artifact, artifact_before)
+})
+
+test_that("RunSpotSweeper rejects reserved artifact input columns atomically", {
+  skip_if_no_spotsweeper_infra()
+  srt <- make_spotsweeper_seurat()
+  srt$artifact <- seq_len(ncol(srt))
+  metadata_before <- srt@meta.data
+  tools_before <- srt@tools
+
+  for (input_arg in c("mito_percent", "mito_sum")) {
+    check_called <- FALSE
+    args <- list(
+      srt = srt,
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      sample.by = "sample",
+      n_neighbors = 2,
+      verbose = FALSE
+    )
+    args[[input_arg]] <- "artifact"
+    expect_error(
+      testthat::with_mocked_bindings(
+        do.call(RunSpotSweeper, args),
+        check_r = function(...) {
+          check_called <<- TRUE
+          stop("backend check should not run", call. = FALSE)
+        },
+        .package = "scop"
+      ),
+      "reserved.*artifact output",
+      info = input_arg
+    )
+    expect_false(check_called, info = input_arg)
+  }
+  expect_identical(srt@meta.data, metadata_before)
+  expect_identical(srt@tools, tools_before)
+})
+
+test_that("RunSpotSweeper includes untested coordinate spots in overall status", {
+  skip_if_no_spotsweeper_infra()
+  srt <- make_spotsweeper_seurat()
+  coords <- data.frame(
+    x = srt$x[seq_len(5)],
+    y = srt$y[seq_len(5)],
+    row.names = colnames(srt)[seq_len(5)]
+  )
+
+  out <- testthat::with_mocked_bindings(
+    suppressMessages(with_mock_spotsweeper({
+      RunSpotSweeper(
+        srt,
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        verbose = TRUE
+      )
+    })),
+    spatial_analysis_coords = function(...) list(data = coords),
+    .package = "scop"
+  )
+
+  expect_identical(out@tools$SpotSweeper$status, "partial")
+  expect_false("Spot6" %in% out@tools$SpotSweeper$tested_spots)
+  expect_identical(
+    as.character(out$SpotSweeper_local_outlier_qc[[6]]),
+    "NotEvaluated"
+  )
+  metric_outlier_cols <- grep(
+    "^SpotSweeper_.*_outlier$",
+    colnames(out[[]]),
+    value = TRUE
+  )
+  expect_true(all(vapply(
+    metric_outlier_cols,
+    function(column) is.na(out[[column, drop = TRUE]][[6]]),
+    logical(1)
+  )))
+  expect_identical(out$SpotSweeper_artifact_status[[6]], "skipped")
+  expect_true(is.na(out$SpotSweeper_artifact[[6]]))
+  expect_identical(as.character(out$SpotSweeper_artifact_qc[[6]]), "NotEvaluated")
+  expect_identical(as.character(out$SpotSweeper_QC[[6]]), "Partial")
+})
+
+test_that("RunSpotSweeper marks incomplete local-only coordinate scope partial", {
+  skip_if_no_spotsweeper_infra()
+  srt <- make_spotsweeper_seurat()
+  coords <- data.frame(
+    x = srt$x[seq_len(5)],
+    y = srt$y[seq_len(5)],
+    row.names = colnames(srt)[seq_len(5)]
+  )
+
+  out <- NULL
+  events <- testthat::with_mocked_bindings(
+    capture_spotsweeper_logs(with_mock_spotsweeper({
+      out <- RunSpotSweeper(
+        srt,
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        run_artifact = FALSE,
+        verbose = TRUE
+      )
+    })),
+    spatial_analysis_coords = function(...) list(data = coords),
+    .package = "scop"
+  )
+
+  expect_identical(out@tools$SpotSweeper$status, "partial")
+  expect_identical(
+    as.character(out$SpotSweeper_local_outlier_qc[[6]]),
+    "NotEvaluated"
+  )
+  expect_identical(out$SpotSweeper_artifact_status[[6]], "not_requested")
+  expect_identical(as.character(out$SpotSweeper_QC[[6]]), "Partial")
+  expect_true(any(vapply(
+    events,
+    function(x) {
+      identical(x$type, "running") &&
+        grepl("completed partially", x$text) &&
+        grepl("artifact detection was not requested", x$text)
+    },
+    logical(1)
+  )))
+  expect_false(any(vapply(
+    events,
+    function(x) identical(x$type, "success"),
+    logical(1)
+  )))
+
+  expect_error(
+    testthat::with_mocked_bindings(
+      with_mock_spotsweeper({
+        RunSpotSweeper(
+          srt,
+          layer = "counts",
+          coord.cols = c("x", "y"),
+          sample.by = "sample",
+          n_neighbors = 2,
+          run_artifact = FALSE,
+          return_filtered = TRUE,
+          verbose = FALSE
+        )
+      }),
+      spatial_analysis_coords = function(...) list(data = coords),
+      .package = "scop"
+    ),
+    "completed for every spot"
+  )
+})
+
 test_that("RunSpotSweeper preserves mixed per-sample artifact statuses", {
   skip_if_no_spotsweeper_infra()
   srt <- make_spotsweeper_seurat()

--- a/tests/testthat/test-run-spotsweeper.R
+++ b/tests/testthat/test-run-spotsweeper.R
@@ -424,7 +424,7 @@ test_that("RunSpotSweeper console status is truthful and respects verbose", {
   }))
   expect_true(any(vapply(
     partial_events,
-    function(x) identical(x$type, "warning") && grepl("completed partially", x$text),
+    function(x) identical(x$type, "running") && grepl("completed partially", x$text),
     logical(1)
   )))
   expect_false(any(vapply(
@@ -465,6 +465,28 @@ test_that("RunSpotSweeper console status is truthful and respects verbose", {
     )
   }, artifact_mode = "error"))
   expect_length(silent_events, 0L)
+})
+
+test_that("RunSpotSweeper partial completion survives warning escalation", {
+  skip_if_no_spotsweeper_infra()
+  old_options <- options(warn = 2)
+  on.exit(options(old_options), add = TRUE)
+
+  out <- NULL
+  expect_no_error(
+    out <- suppressMessages(with_mock_spotsweeper({
+      RunSpotSweeper(
+        make_spotsweeper_seurat(include_mito = FALSE),
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        verbose = TRUE
+      )
+    }))
+  )
+  expect_s4_class(out, "Seurat")
+  expect_identical(out@tools$SpotSweeper$status, "partial")
 })
 
 test_that("RunSpotSweeper supports return_filtered and store_results = FALSE", {


### PR DESCRIPTION
## Summary

- distinguish per-sample SpotSweeper artifact states as completed, skipped, failed, or not_requested
- use NA and NotEvaluated for artifact or local-outlier output that was not actually produced
- mark the overall run partial whenever any requested spot/stage remains unevaluated, while preserving known Fail precedence
- validate fresh binary artifact and local-outlier producer outputs instead of accepting stale or non-binary metadata
- require findArtifacts() to retain every input spot identity and order; shortened, renamed, or reordered output fails that sample truthfully
- reject missing sample labels and producer-owned name collisions before optional-backend checks
- preserve sample.by encounter order and original sample spot counts in stored diagnostics
- reject return_filtered = TRUE whenever requested QC is incomplete, before mutating the returned object
- keep all recoverable partial paths returnable under options(warn = 2) through a non-success, non-warning console channel

## Validation

- PASS: latest-head macOS, Ubuntu, and Windows R-CMD-check
- PASS: latest-head pkgdown and changes jobs
- PASS: latest Codex review found no major issues; all eight review threads are resolved
- PASS: full test-run-spotsweeper.R targeted file, including missing/partial/invalid/stale output, non-binary flags, dropped/renamed/reordered spots, missing sample labels, reserved names, and return-filtered atomicity
- PASS: parameterized warning-escalation coverage under options(warn = 2)
- PASS: focused real SpotSweeper 1.5.0 run on 120 bundled Visium spots; the upstream-incompatible artifact stage returned a truthful partial result with 120 NotEvaluated calls
- PASS: pkgload::load_all('.', quiet = TRUE, compile = FALSE)
- PASS: prescribed local rcmdcheck on the final implementation: 0 errors, 2 inherited warnings, 5 notes
- PASS: checking for unstated dependencies in examples and tests
- PASS: R/Rd parse and git diff --check

The two local check warnings are inherited from upstream main: lifecycle / glmGamPoi / sctransform namespace declarations and pre-existing Rd usage mismatches. This PR does not modify those dependency or Rd topics.