### PR TITLE
feat: add concise spatial run receipts

### DIFF
--- a/R/RunBayesSpace.R
+++ b/R/RunBayesSpace.R
@@ -225,9 +225,37 @@ RunBayesSpace <- function(
   }
   srt@tools[["BayesSpace"]] <- spatial_tag_coordinate_contract(tool)
 
-  log_message(
-    "{.pkg BayesSpace} clusters stored in metadata column {.val {cluster_colname}}",
-    verbose = verbose
+  domain_summary <- spatial_domain_summary(cluster_df[[cluster_colname]])
+  n_spots <- nrow(cluster_df)
+  n_domains <- nrow(domain_summary)
+  domain_size_min <- if (n_domains > 0L) min(domain_summary$count) else 0L
+  domain_size_max <- if (n_domains > 0L) max(domain_summary$count) else 0L
+  image_use <- coordinate_input$source$image
+  has_image <- length(image_use) == 1L && !is.na(image_use) && nzchar(image_use)
+  scope <- if (!isTRUE(has_image)) {
+    "assay {.val {assay}}, raw coordinates"
+  } else {
+    "assay {.val {assay}}, image {.val {image_use}}, raw coordinates"
+  }
+  plot_call <- paste0(
+    "SpatialSpotPlot(srt, group.by = ",
+    spatial_run_receipt_quote(cluster_colname, "cluster_colname"),
+    ")"
+  )
+  spatial_run_receipt(
+    done = paste0(
+      "{.pkg BayesSpace} completed: {.val {n_spots}} spots, ",
+      "{.val {n_domains}} domains, domain size ",
+      "{.val {domain_size_min}}-{.val {domain_size_max}}"
+    ),
+    scope = scope,
+    saved = paste0(
+      "metadata column {.var {cluster_colname}} and ",
+      "{.code srt@tools[['BayesSpace']]}"
+    ),
+    plot = plot_call,
+    verbose = verbose,
+    .envir = environment()
   )
   srt
 }

--- a/R/RunBayesSpace.R
+++ b/R/RunBayesSpace.R
@@ -237,18 +237,34 @@ RunBayesSpace <- function(
   } else {
     "assay {.val {assay}}, image {.val {image_use}}, raw coordinates"
   }
+  display_scale <- if (
+    isTRUE(has_image) && isTRUE(thisutils::get_verbose(verbose))
+  ) {
+    spatial_run_receipt_display_scale(srt, image_use)
+  } else {
+    NULL
+  }
   plot_args <- c(
     paste0(
       "group.by = ",
       spatial_run_receipt_quote(cluster_colname, "cluster_colname")
     )
   )
-  if (isTRUE(has_image)) {
+  if (isTRUE(has_image) && !is.null(display_scale)) {
     plot_args <- c(
       plot_args,
       paste0("image = ", spatial_run_receipt_quote(image_use, "image"))
     )
-  } else {
+    if (identical(display_scale, "hires")) {
+      plot_args <- c(
+        plot_args,
+        paste0(
+          "image.scale = ",
+          spatial_run_receipt_quote(display_scale, "image.scale")
+        )
+      )
+    }
+  } else if (!isTRUE(has_image)) {
     plot_args <- c(
       plot_args,
       paste0(
@@ -260,11 +276,24 @@ RunBayesSpace <- function(
       )
     )
   }
-  plot_call <- paste0(
-    "SpatialSpotPlot(<returned_object>, ",
-    paste(plot_args, collapse = ", "),
-    ")"
-  )
+  plot_call <- if (!isTRUE(has_image) || !is.null(display_scale)) {
+    paste0(
+      "SpatialSpotPlot(<returned_object>, ",
+      paste(plot_args, collapse = ", "),
+      ")"
+    )
+  } else {
+    NULL
+  }
+  inspect_call <- if (isTRUE(has_image) && is.null(display_scale)) {
+    paste0(
+      "<returned_object>[[]][, ",
+      spatial_run_receipt_quote(cluster_colname, "cluster_colname"),
+      ", drop = FALSE]"
+    )
+  } else {
+    NULL
+  }
   spatial_run_receipt(
     done = paste0(
       "{.pkg BayesSpace} completed: {.val {n_spots}} spots, ",
@@ -277,6 +306,7 @@ RunBayesSpace <- function(
       "returned object tool bundle {.var BayesSpace}"
     ),
     plot = plot_call,
+    inspect = inspect_call,
     verbose = verbose,
     .envir = environment()
   )

--- a/R/RunBayesSpace.R
+++ b/R/RunBayesSpace.R
@@ -238,7 +238,7 @@ RunBayesSpace <- function(
     "assay {.val {assay}}, image {.val {image_use}}, raw coordinates"
   }
   plot_call <- paste0(
-    "SpatialSpotPlot(srt, group.by = ",
+    "SpatialSpotPlot(<returned_object>, group.by = ",
     spatial_run_receipt_quote(cluster_colname, "cluster_colname"),
     ")"
   )
@@ -251,7 +251,7 @@ RunBayesSpace <- function(
     scope = scope,
     saved = paste0(
       "metadata column {.var {cluster_colname}} and ",
-      "{.code srt@tools[['BayesSpace']]}"
+      "returned object tool bundle {.var BayesSpace}"
     ),
     plot = plot_call,
     verbose = verbose,

--- a/R/RunBayesSpace.R
+++ b/R/RunBayesSpace.R
@@ -237,9 +237,32 @@ RunBayesSpace <- function(
   } else {
     "assay {.val {assay}}, image {.val {image_use}}, raw coordinates"
   }
+  plot_args <- c(
+    paste0(
+      "group.by = ",
+      spatial_run_receipt_quote(cluster_colname, "cluster_colname")
+    )
+  )
+  if (isTRUE(has_image)) {
+    plot_args <- c(
+      plot_args,
+      paste0("image = ", spatial_run_receipt_quote(image_use, "image"))
+    )
+  } else {
+    plot_args <- c(
+      plot_args,
+      paste0(
+        "coord.cols = ",
+        deparse1(
+          unname(as.character(coordinate_input$source$coord.cols)),
+          width.cutoff = 500L
+        )
+      )
+    )
+  }
   plot_call <- paste0(
-    "SpatialSpotPlot(<returned_object>, group.by = ",
-    spatial_run_receipt_quote(cluster_colname, "cluster_colname"),
+    "SpatialSpotPlot(<returned_object>, ",
+    paste(plot_args, collapse = ", "),
     ")"
   )
   spatial_run_receipt(

--- a/R/RunSpatialNetwork.R
+++ b/R/RunSpatialNetwork.R
@@ -166,7 +166,7 @@ RunSpatialNetwork <- function(
   }
   scope <- paste0(scope, "; {.val {nrow(nodes)}} observations")
   plot_call <- paste0(
-    "SpatialNetworkPlot(srt, graph.name = ",
+    "SpatialNetworkPlot(<returned_object>, graph.name = ",
     spatial_run_receipt_quote(graph.name, "graph.name"),
     ")"
   )
@@ -174,8 +174,8 @@ RunSpatialNetwork <- function(
     done = done,
     scope = scope,
     saved = paste0(
-      "graph {.val {graph.name}} in ",
-      "{.code srt@tools[['SpatialNetwork']]$graphs}"
+      "graph {.val {graph.name}} in returned object tool bundle ",
+      "{.var SpatialNetwork}, field {.var graphs}"
     ),
     plot = plot_call,
     replaced = isTRUE(existing_graph) && isTRUE(overwrite),

--- a/R/RunSpatialNetwork.R
+++ b/R/RunSpatialNetwork.R
@@ -125,6 +125,7 @@ RunSpatialNetwork <- function(
     graphs = list()
   )
   store$graphs <- store$graphs %||% list()
+  existing_graph <- !is.null(store$graphs[[graph.name]])
   if (!is.null(store$graphs[[graph.name]]) && !isTRUE(overwrite)) {
     log_message(
       "Spatial graph {.val {graph.name}} already exists; set {.arg overwrite = TRUE} to replace it",
@@ -147,10 +148,39 @@ RunSpatialNetwork <- function(
     n_edges = nrow(edges)
   )
   srt@tools[["SpatialNetwork"]] <- store
-  log_message(
-    "Stored spatial graph {.val {graph.name}} with {.val {nrow(nodes)}} nodes and {.val {nrow(edges)}} edges",
-    message_type = "success",
-    verbose = verbose
+  done <- if (identical(method, "knn")) {
+    paste0(
+      "Spatial graph completed: {.val {method}}, {.arg k} = {.val {k}}, ",
+      "{.val {nrow(nodes)}} nodes, {.val {nrow(edges)}} edges"
+    )
+  } else {
+    paste0(
+      "Spatial graph completed: {.val {method}}, {.arg radius} = {.val {radius}}, ",
+      "{.val {nrow(nodes)}} nodes, {.val {nrow(edges)}} edges"
+    )
+  }
+  scope <- if (is.null(selected_image)) {
+    "raw coordinates"
+  } else {
+    "image {.val {selected_image}}, raw coordinates"
+  }
+  scope <- paste0(scope, "; {.val {nrow(nodes)}} observations")
+  plot_call <- paste0(
+    "SpatialNetworkPlot(srt, graph.name = ",
+    spatial_run_receipt_quote(graph.name, "graph.name"),
+    ")"
+  )
+  spatial_run_receipt(
+    done = done,
+    scope = scope,
+    saved = paste0(
+      "graph {.val {graph.name}} in ",
+      "{.code srt@tools[['SpatialNetwork']]$graphs}"
+    ),
+    plot = plot_call,
+    replaced = isTRUE(existing_graph) && isTRUE(overwrite),
+    verbose = verbose,
+    .envir = environment()
   )
   srt
 }

--- a/R/RunSpatialNetwork.R
+++ b/R/RunSpatialNetwork.R
@@ -165,11 +165,40 @@ RunSpatialNetwork <- function(
     "image {.val {selected_image}}, raw coordinates"
   }
   scope <- paste0(scope, "; {.val {nrow(nodes)}} observations")
-  plot_call <- paste0(
-    "SpatialNetworkPlot(<returned_object>, graph.name = ",
-    spatial_run_receipt_quote(graph.name, "graph.name"),
-    ")"
-  )
+  display_scale <- if (isTRUE(thisutils::get_verbose(verbose))) {
+    spatial_run_receipt_display_scale(srt, selected_image)
+  } else {
+    NULL
+  }
+  plot_call <- if (is.null(selected_image) || !is.null(display_scale)) {
+    plot_args <- c(
+      paste0(
+        "graph.name = ",
+        spatial_run_receipt_quote(graph.name, "graph.name")
+      )
+    )
+    if (identical(display_scale, "hires")) {
+      plot_args <- c(
+        plot_args,
+        paste0(
+          "image.scale = ",
+          spatial_run_receipt_quote(display_scale, "image.scale")
+        )
+      )
+    }
+    paste0(
+      "SpatialNetworkPlot(<returned_object>, ",
+      paste(plot_args, collapse = ", "),
+      ")"
+    )
+  } else {
+    paste0(
+      "SpatialNetworkPlot(res = <returned_object>@tools[[\"SpatialNetwork\"]], ",
+      "graph.name = ",
+      spatial_run_receipt_quote(graph.name, "graph.name"),
+      ")"
+    )
+  }
   spatial_run_receipt(
     done = done,
     scope = scope,

--- a/R/RunSpatialVariableFeatures.R
+++ b/R/RunSpatialVariableFeatures.R
@@ -308,24 +308,51 @@ RunSpatialVariableFeatures <- function(
   has_plot_image <- is.character(plot_image) && length(plot_image) == 1L &&
     !is.na(plot_image) && nzchar(plot_image)
   plot_coord_cols <- coordinate_input$source$coord.cols %||% coord.cols
+  display_scale <- if (
+    isTRUE(store_results) &&
+      isTRUE(has_plot_image) &&
+      isTRUE(thisutils::get_verbose(verbose))
+  ) {
+    spatial_run_receipt_display_scale(srt, plot_image)
+  } else {
+    NULL
+  }
   plot_call <- if (isTRUE(store_results)) {
     plot_args <- c(
-      "plot_type = \"combined\"",
+      paste0(
+        "plot_type = ",
+        if (isTRUE(has_plot_image) && is.null(display_scale)) {
+          "\"summary\""
+        } else {
+          "\"combined\""
+        }
+      ),
       paste0("assay = ", spatial_run_receipt_quote(assay, "assay"))
     )
-    if (isTRUE(has_plot_image)) {
+    if (isTRUE(has_plot_image) && !is.null(display_scale)) {
       plot_args <- c(
         plot_args,
         paste0("image = ", spatial_run_receipt_quote(plot_image, "image"))
       )
+      if (identical(display_scale, "hires")) {
+        plot_args <- c(
+          plot_args,
+          paste0(
+            "image.scale = ",
+            spatial_run_receipt_quote(display_scale, "image.scale")
+          )
+        )
+      }
     }
-    plot_args <- c(
-      plot_args,
-      paste0(
-        "coord.cols = ",
-        deparse1(unname(as.character(plot_coord_cols)), width.cutoff = 500L)
+    if (!isTRUE(has_plot_image) || !is.null(display_scale)) {
+      plot_args <- c(
+        plot_args,
+        paste0(
+          "coord.cols = ",
+          deparse1(unname(as.character(plot_coord_cols)), width.cutoff = 500L)
+        )
       )
-    )
+    }
     paste0(
       "SpatialVariableFeaturePlot(<returned_object>, ",
       paste(plot_args, collapse = ", "),

--- a/R/RunSpatialVariableFeatures.R
+++ b/R/RunSpatialVariableFeatures.R
@@ -274,10 +274,54 @@ RunSpatialVariableFeatures <- function(
       srt@tools[["SpatialVariableFeatures"]]
     )
   }
-  log_message(
-    "Stored {.val {length(top_features)}} spatial variable features",
-    message_type = "success",
-    verbose = verbose
+  n_top <- length(top_features)
+  variable_features_set <- isTRUE(set_variable_features) && n_top > 0L
+  saved <- character()
+  if (isTRUE(variable_features_set)) {
+    saved <- c(
+      saved,
+      "{.val {n_top}} top features as assay {.var VariableFeatures}"
+    )
+  }
+  if (isTRUE(store_results)) {
+    saved <- c(
+      saved,
+      "full result in returned object tool bundle {.var SpatialVariableFeatures}"
+    )
+  }
+  done <- paste0(
+    "Spatial variable features completed: {.val {nrow(result)}} tested, ",
+    "{.val {n_top}} ranked in the top set"
+  )
+  if (length(saved) == 0L) {
+    done <- paste0(done, "; results not retained")
+  }
+  plot_call <- if (isTRUE(store_results)) {
+    "SpatialVariableFeaturePlot(<returned_object>, plot_type = \"combined\")"
+  } else {
+    NULL
+  }
+  inspect_call <- if (!isTRUE(store_results) && isTRUE(variable_features_set)) {
+    paste0(
+      "SeuratObject::VariableFeatures(<returned_object>, assay = ",
+      spatial_run_receipt_quote(assay, "assay"),
+      ")"
+    )
+  } else {
+    NULL
+  }
+  spatial_run_receipt(
+    done = done,
+    scope = paste0(
+      "method {.val {method}} ({.val {backend}} backend); ",
+      "assay {.val {assay}}, layer {.val {layer}}; ",
+      "{.val {length(spots)}} spots; coordinates {.val {coordinate_space}}"
+    ),
+    saved = if (length(saved) > 0L) paste(saved, collapse = "; ") else NULL,
+    plot = plot_call,
+    inspect = inspect_call,
+    verbose = verbose,
+    .envir = environment()
   )
   srt
 }

--- a/R/RunSpatialVariableFeatures.R
+++ b/R/RunSpatialVariableFeatures.R
@@ -308,28 +308,30 @@ RunSpatialVariableFeatures <- function(
   has_plot_image <- is.character(plot_image) && length(plot_image) == 1L &&
     !is.na(plot_image) && nzchar(plot_image)
   plot_coord_cols <- coordinate_input$source$coord.cols %||% coord.cols
+  receipt_verbose <- thisutils::get_verbose(verbose)
   display_scale <- if (
     isTRUE(store_results) &&
       isTRUE(has_plot_image) &&
-      isTRUE(thisutils::get_verbose(verbose))
+      isTRUE(receipt_verbose)
   ) {
     spatial_run_receipt_display_scale(srt, plot_image)
   } else {
     NULL
   }
+  can_plot_spatially <- !isTRUE(has_plot_image) || !is.null(display_scale)
+  can_combine <- isTRUE(store_results) &&
+    isTRUE(receipt_verbose) &&
+    isTRUE(can_plot_spatially) &&
+    spatial_run_receipt_package_available("patchwork")
   plot_call <- if (isTRUE(store_results)) {
     plot_args <- c(
       paste0(
         "plot_type = ",
-        if (isTRUE(has_plot_image) && is.null(display_scale)) {
-          "\"summary\""
-        } else {
-          "\"combined\""
-        }
+        if (isTRUE(can_combine)) "\"combined\"" else "\"summary\""
       ),
       paste0("assay = ", spatial_run_receipt_quote(assay, "assay"))
     )
-    if (isTRUE(has_plot_image) && !is.null(display_scale)) {
+    if (isTRUE(can_combine) && isTRUE(has_plot_image)) {
       plot_args <- c(
         plot_args,
         paste0("image = ", spatial_run_receipt_quote(plot_image, "image"))
@@ -344,7 +346,7 @@ RunSpatialVariableFeatures <- function(
         )
       }
     }
-    if (!isTRUE(has_plot_image) || !is.null(display_scale)) {
+    if (isTRUE(can_combine)) {
       plot_args <- c(
         plot_args,
         paste0(

--- a/R/RunSpatialVariableFeatures.R
+++ b/R/RunSpatialVariableFeatures.R
@@ -106,6 +106,13 @@ RunSpatialVariableFeatures <- function(
   method <- match.arg(method)
   backend <- match.arg(backend)
   native_method <- method %in% c("moran", "geary")
+  backend_name <- if (isTRUE(native_method)) {
+    backend
+  } else if (identical(method, "SPARKX")) {
+    "SPARK"
+  } else {
+    "nnSVG"
+  }
   if (!is.numeric(k) || length(k) != 1L || is.na(k) || k < 1) {
     log_message(
       "{.arg k} must be a positive number",
@@ -145,12 +152,13 @@ RunSpatialVariableFeatures <- function(
   }
   set.seed(seed)
 
-  coords <- spatial_analysis_coords(
+  coordinate_input <- spatial_analysis_coords(
     srt = srt,
     image = image,
     coord.cols = coord.cols,
     coordinate_space = coordinate_space
-  )$data
+  )
+  coords <- coordinate_input$data
   spots <- intersect(colnames(srt), rownames(coords))
   if (length(spots) == 0L) {
     log_message(
@@ -266,7 +274,7 @@ RunSpatialVariableFeatures <- function(
         min_spots = min_spots,
         nperm = nperm,
         seed = seed,
-        backend = backend,
+        backend = backend_name,
         set_variable_features = set_variable_features
       )
     )
@@ -296,8 +304,33 @@ RunSpatialVariableFeatures <- function(
   if (length(saved) == 0L) {
     done <- paste0(done, "; results not retained")
   }
+  plot_image <- coordinate_input$source$image
+  has_plot_image <- is.character(plot_image) && length(plot_image) == 1L &&
+    !is.na(plot_image) && nzchar(plot_image)
+  plot_coord_cols <- coordinate_input$source$coord.cols %||% coord.cols
   plot_call <- if (isTRUE(store_results)) {
-    "SpatialVariableFeaturePlot(<returned_object>, plot_type = \"combined\")"
+    plot_args <- c(
+      "plot_type = \"combined\"",
+      paste0("assay = ", spatial_run_receipt_quote(assay, "assay"))
+    )
+    if (isTRUE(has_plot_image)) {
+      plot_args <- c(
+        plot_args,
+        paste0("image = ", spatial_run_receipt_quote(plot_image, "image"))
+      )
+    }
+    plot_args <- c(
+      plot_args,
+      paste0(
+        "coord.cols = ",
+        deparse1(unname(as.character(plot_coord_cols)), width.cutoff = 500L)
+      )
+    )
+    paste0(
+      "SpatialVariableFeaturePlot(<returned_object>, ",
+      paste(plot_args, collapse = ", "),
+      ")"
+    )
   } else {
     NULL
   }
@@ -313,7 +346,7 @@ RunSpatialVariableFeatures <- function(
   spatial_run_receipt(
     done = done,
     scope = paste0(
-      "method {.val {method}} ({.val {backend}} backend); ",
+      "method {.val {method}} ({.val {backend_name}} backend); ",
       "assay {.val {assay}}, layer {.val {layer}}; ",
       "{.val {length(spots)}} spots; coordinates {.val {coordinate_space}}"
     ),

--- a/R/RunSpotQC.R
+++ b/R/RunSpotQC.R
@@ -84,6 +84,7 @@ RunSpotQC <- function(
   }
 
   counts <- GetAssayData5(srt, assay = assay, layer = "counts")
+  n_evaluated <- ncol(counts)
   nCount <- Matrix::colSums(counts)
   nFeature <- Matrix::colSums(counts > 0)
   srt[[paste0("nCount_", assay)]] <- nCount
@@ -176,15 +177,40 @@ RunSpotQC <- function(
     srt[[qc]] <- factor(srt[[qc, drop = TRUE]], levels = c("Pass", "Fail"))
   }
 
-  log_message(
-    "{.val {ncol(srt) - length(SpotQC)}} spots passed QC and {.val {length(SpotQC)}} spots failed QC",
-    message_type = "success",
-    verbose = verbose
-  )
-
+  n_failed <- length(SpotQC)
+  n_passed <- n_evaluated - n_failed
   if (isTRUE(return_filtered)) {
     srt <- srt[, srt$SpotQC == "Pass"]
   }
+
+  n_returned <- ncol(srt)
+  done <- paste0(
+    "Spot QC completed: {.val {n_evaluated}} evaluated, ",
+    "{.val {n_passed}} Pass, {.val {n_failed}} Fail"
+  )
+  if (isTRUE(return_filtered)) {
+    done <- paste0(done, "; {.val {n_returned}} returned")
+  }
+  image_names <- tryCatch(
+    SeuratObject::Images(srt),
+    error = function(e) character()
+  )
+  plot_call <- if (length(image_names) > 1L) {
+    paste0(
+      "lapply(SeuratObject::Images(srt), function(image) ",
+      "SpatialSpotPlot(srt, group.by = \"SpotQC\", image = image))"
+    )
+  } else {
+    "SpatialSpotPlot(srt, group.by = \"SpotQC\")"
+  }
+  spatial_run_receipt(
+    done = done,
+    scope = "assay {.val {assay}}, layer {.val counts}",
+    saved = "metadata column {.var SpotQC}",
+    plot = if (isTRUE(return_filtered)) NULL else plot_call,
+    verbose = verbose,
+    .envir = environment()
+  )
   srt
 }
 

--- a/R/RunSpotQC.R
+++ b/R/RunSpotQC.R
@@ -15,7 +15,9 @@
 #' @param outlier_threshold Character vector specifying outlier thresholds as
 #' `"metric:direction:nmads"`. Available default metrics are
 #' `"log10_nCount"`, `"log10_nFeature"`, and `"spot_featurecount_dist"`.
-#' @param outlier_n Minimum number of outlier metrics required to fail a spot.
+#' @param outlier_n Positive integer giving the minimum number of outlier rules
+#' required to fail a spot. It cannot exceed the number of
+#' `outlier_threshold` rules.
 #' @param UMI_threshold Minimum UMI count required to pass `"umi"` QC.
 #' @param gene_threshold Minimum detected gene count required to pass `"gene"`
 #' QC.
@@ -27,7 +29,9 @@
 #' @param seed Random seed for reproducibility.
 #'
 #' @return A `Seurat` object with spot QC metadata columns. Cells that are not
-#' present in the selected assay receive `NA` QC labels and are excluded when
+#' present in the selected assay receive `NA` QC labels. A selected-assay cell
+#' also receives `NA` when at least one requested QC is unresolved and no
+#' requested QC has a known failure. Only cells labelled `Pass` are retained when
 #' `return_filtered = TRUE`.
 #' @export
 #'
@@ -62,8 +66,6 @@ RunSpotQC <- function(
     message_type = "running",
     verbose = verbose
   )
-  set.seed(seed)
-
   if (!inherits(srt, "Seurat")) {
     log_message(
       "{.arg srt} must be a {.cls Seurat} object",
@@ -84,6 +86,66 @@ RunSpotQC <- function(
       message_type = "error"
     )
   }
+  validate_scalar_flag(return_filtered, "return_filtered")
+  if ("umi" %in% qc_metrics) {
+    UMI_threshold <- spot_qc_validate_cutoff(
+      UMI_threshold,
+      arg = "UMI_threshold",
+      minimum = 0
+    )
+  }
+  if ("gene" %in% qc_metrics) {
+    gene_threshold <- spot_qc_validate_cutoff(
+      gene_threshold,
+      arg = "gene_threshold",
+      minimum = 0
+    )
+  }
+  if ("mito" %in% qc_metrics) {
+    mito_threshold <- spot_qc_validate_cutoff(
+      mito_threshold,
+      arg = "mito_threshold"
+    )
+  }
+  if ("outlier" %in% qc_metrics) {
+    valid_outlier_threshold <- is.character(outlier_threshold) &&
+      length(outlier_threshold) > 0L &&
+      !anyNA(outlier_threshold) &&
+      all(nzchar(outlier_threshold))
+    if (!isTRUE(valid_outlier_threshold)) {
+      log_message(
+        paste0(
+          "{.arg outlier_threshold} must be a non-empty character vector ",
+          "of {.val metric:direction:nmads} rules"
+        ),
+        message_type = "error"
+      )
+    }
+    outlier_n_valid <- is.numeric(outlier_n) &&
+      length(outlier_n) == 1L &&
+      !is.na(outlier_n) &&
+      is.finite(outlier_n) &&
+      outlier_n >= 1 &&
+      outlier_n == floor(outlier_n)
+    if (!isTRUE(outlier_n_valid)) {
+      log_message(
+        "{.arg outlier_n} must be a finite positive integer",
+        message_type = "error"
+      )
+    }
+    n_outlier_rules <- length(outlier_threshold)
+    if (outlier_n > n_outlier_rules) {
+      log_message(
+        paste0(
+          "{.arg outlier_n} cannot exceed the number of ",
+          "{.arg outlier_threshold} rules ({.val {n_outlier_rules}})"
+        ),
+        message_type = "error"
+      )
+    }
+    outlier_n <- as.integer(outlier_n)
+  }
+  set.seed(seed)
 
   counts <- GetAssayData5(srt, assay = assay, layer = "counts")
   evaluated_spots <- colnames(counts)
@@ -130,7 +192,7 @@ RunSpotQC <- function(
     spot_mito_qc <- evaluated_spots[which(percent_mito > mito_threshold)]
   }
   if ("outlier" %in% qc_metrics) {
-    outlier <- lapply(
+    outlier_flags <- lapply(
       strsplit(outlier_threshold, ":", fixed = TRUE),
       function(rule) {
         if (length(rule) != 3L) {
@@ -148,53 +210,97 @@ RunSpotQC <- function(
           log10_nFeature = log10_nFeature,
           spot_featurecount_dist = spot_featurecount_dist
         )
-        evaluated_spots[spot_qc_is_outlier(
+        nmads <- suppressWarnings(as.numeric(rule[[3L]]))
+        spot_qc_is_outlier(
           metric,
-          nmads = as.numeric(rule[[3L]]),
+          nmads = nmads,
           type = rule[[2L]]
-        )]
+        )
       }
     )
-    names(outlier) <- outlier_threshold
-    outlier_tb <- table(unlist(outlier))
-    spot_outlier_qc <- names(outlier_tb)[outlier_tb >= outlier_n]
-    for (nm in names(outlier)) {
+    names(outlier_flags) <- outlier_threshold
+    outlier_matrix <- do.call(cbind, unname(outlier_flags))
+    rownames(outlier_matrix) <- evaluated_spots
+    colnames(outlier_matrix) <- outlier_threshold
+    known_fail <- rowSums(outlier_matrix == TRUE, na.rm = TRUE)
+    missing_rules <- rowSums(is.na(outlier_matrix))
+    spot_outlier_status <- rep(NA_character_, n_evaluated)
+    names(spot_outlier_status) <- evaluated_spots
+    spot_outlier_status[known_fail >= outlier_n] <- "Fail"
+    spot_outlier_status[
+      is.na(spot_outlier_status) &
+        known_fail + missing_rules < outlier_n
+    ] <- "Pass"
+    spot_outlier_qc <- evaluated_spots[which(spot_outlier_status == "Fail")]
+    for (i in seq_along(outlier_flags)) {
+      nm <- names(outlier_flags)[[i]]
       outlier_flag <- rep(NA, ncol(srt))
       names(outlier_flag) <- colnames(srt)
-      outlier_flag[evaluated_spots] <- evaluated_spots %in% outlier[[nm]]
+      outlier_flag[evaluated_spots] <- outlier_flags[[i]]
       srt[[make.names(paste0("spot_", nm))]] <- outlier_flag
     }
+  } else {
+    spot_outlier_status <- setNames(
+      rep("Pass", n_evaluated),
+      evaluated_spots
+    )
   }
 
-  SpotQC <- unique(c(
-    spot_umi_qc,
-    spot_gene_qc,
-    spot_mito_qc,
-    spot_outlier_qc
-  ))
-  qc_map <- list(
-    spot_umi_qc = spot_umi_qc,
-    spot_gene_qc = spot_gene_qc,
-    spot_mito_qc = spot_mito_qc,
-    spot_outlier_qc = spot_outlier_qc,
-    SpotQC = SpotQC
+  pass_fail_status <- function(failed_spots) {
+    out <- ifelse(evaluated_spots %in% failed_spots, "Fail", "Pass")
+    names(out) <- evaluated_spots
+    out
+  }
+  qc_status_map <- list(
+    spot_umi_qc = pass_fail_status(spot_umi_qc),
+    spot_gene_qc = pass_fail_status(spot_gene_qc),
+    spot_mito_qc = pass_fail_status(spot_mito_qc),
+    spot_outlier_qc = spot_outlier_status
   )
-  for (qc in names(qc_map)) {
+  requested_status_names <- paste0("spot_", qc_metrics, "_qc")
+  if (length(requested_status_names) == 0L) {
+    overall_status <- setNames(rep("Pass", n_evaluated), evaluated_spots)
+  } else {
+    requested_status <- do.call(
+      cbind,
+      unname(qc_status_map[requested_status_names])
+    )
+    known_fail <- rowSums(requested_status == "Fail", na.rm = TRUE) > 0L
+    not_evaluated <- rowSums(is.na(requested_status)) > 0L
+    overall_status <- ifelse(
+      known_fail,
+      "Fail",
+      ifelse(not_evaluated, NA_character_, "Pass")
+    )
+    names(overall_status) <- evaluated_spots
+  }
+  qc_status_map$SpotQC <- overall_status
+  for (qc in names(qc_status_map)) {
     qc_status <- rep(NA_character_, ncol(srt))
     names(qc_status) <- colnames(srt)
-    qc_status[evaluated_spots] <- ifelse(
-      evaluated_spots %in% qc_map[[qc]],
-      "Fail",
-      "Pass"
-    )
+    qc_status[evaluated_spots] <- qc_status_map[[qc]]
     srt[[qc]] <- qc_status
     srt[[qc]] <- factor(srt[[qc, drop = TRUE]], levels = c("Pass", "Fail"))
   }
 
-  n_failed <- length(SpotQC)
-  n_passed <- n_evaluated - n_failed
+  selected_labels <- as.character(
+    srt@meta.data[evaluated_spots, "SpotQC", drop = TRUE]
+  )
+  n_passed <- sum(selected_labels == "Pass", na.rm = TRUE)
+  n_failed <- sum(selected_labels == "Fail", na.rm = TRUE)
+  n_not_evaluated <- sum(is.na(selected_labels))
+  n_evaluated <- n_passed + n_failed
   if (isTRUE(return_filtered)) {
     keep <- !is.na(srt$SpotQC) & srt$SpotQC == "Pass"
+    if (!any(keep)) {
+      log_message(
+        paste0(
+          "No spots passed QC; set {.arg return_filtered = FALSE} ",
+          "to inspect the unfiltered result"
+        ),
+        message_type = "error"
+      )
+    }
     srt <- srt[, keep]
   }
 
@@ -203,6 +309,12 @@ RunSpotQC <- function(
     "Spot QC completed: {.val {n_evaluated}} evaluated, ",
     "{.val {n_passed}} Pass, {.val {n_failed}} Fail"
   )
+  if (n_not_evaluated > 0L) {
+    done <- paste0(
+      done,
+      "; {.val {n_not_evaluated}} NotEvaluated"
+    )
+  }
   if (isTRUE(return_filtered)) {
     done <- paste0(done, "; {.val {n_returned}} returned")
   }
@@ -235,6 +347,7 @@ RunSpotQC <- function(
     saved = "metadata column {.var SpotQC}",
     plot = plot_call,
     inspect = inspect_call,
+    status = if (n_not_evaluated > 0L) "partial" else "completed",
     verbose = verbose,
     .envir = environment()
   )
@@ -321,10 +434,24 @@ spot_qc_metric <- function(
   }
   assay_metric <- paste0(metric, "_", assay)
   if (assay_metric %in% colnames(srt@meta.data)) {
-    return(srt@meta.data[evaluated_spots, assay_metric, drop = TRUE])
+    metric_values <- srt@meta.data[
+      evaluated_spots,
+      assay_metric,
+      drop = TRUE
+    ]
+    return(spot_qc_validate_metric(
+      metric_values,
+      metric = assay_metric,
+      n_expected = length(evaluated_spots)
+    ))
   }
   if (metric %in% colnames(srt@meta.data)) {
-    return(srt@meta.data[evaluated_spots, metric, drop = TRUE])
+    metric_values <- srt@meta.data[evaluated_spots, metric, drop = TRUE]
+    return(spot_qc_validate_metric(
+      metric_values,
+      metric = metric,
+      n_expected = length(evaluated_spots)
+    ))
   }
   log_message(
     "{.arg outlier_threshold} metric {.val {metric}} was not found",
@@ -332,16 +459,54 @@ spot_qc_metric <- function(
   )
 }
 
+spot_qc_validate_metric <- function(x, metric, n_expected) {
+  if (!is.numeric(x) || length(x) != n_expected) {
+    log_message(
+      paste0(
+        "{.arg outlier_threshold} metric {.val {metric}} must be a numeric ",
+        "vector with one value per selected-assay spot"
+      ),
+      message_type = "error"
+    )
+  }
+  x
+}
+
+spot_qc_validate_cutoff <- function(x, arg, minimum = -Inf) {
+  if (
+    !is.numeric(x) ||
+      length(x) != 1L ||
+      is.na(x) ||
+      !is.finite(x) ||
+      x < minimum
+  ) {
+    qualifier <- if (is.finite(minimum)) "non-negative " else ""
+    log_message(
+      paste0("{.arg {arg}} must be a finite ", qualifier, "number"),
+      message_type = "error"
+    )
+  }
+  as.numeric(x)
+}
+
 spot_qc_is_outlier <- function(x, nmads = 3, type = c("lower", "higher")) {
   type <- match.arg(type)
-  if (!is.numeric(nmads) || length(nmads) != 1L || is.na(nmads) || nmads < 0) {
+  if (
+    !is.numeric(nmads) ||
+      length(nmads) != 1L ||
+      is.na(nmads) ||
+      !is.finite(nmads) ||
+      nmads < 0
+  ) {
     log_message(
       "{.arg nmads} must be a non-negative number",
       message_type = "error"
     )
   }
   keep <- is.finite(x)
-  out <- rep(FALSE, length(x))
+  out <- rep(NA, length(x))
+  names(out) <- names(x)
+  out[keep] <- FALSE
   if (sum(keep) == 0L) {
     return(out)
   }

--- a/R/RunSpotQC.R
+++ b/R/RunSpotQC.R
@@ -143,6 +143,7 @@ RunSpotQC <- function(
           metric = rule[[1L]],
           srt = srt,
           assay = assay,
+          evaluated_spots = evaluated_spots,
           log10_nCount = log10_nCount,
           log10_nFeature = log10_nFeature,
           spot_featurecount_dist = spot_featurecount_dist
@@ -304,6 +305,7 @@ spot_qc_metric <- function(
   metric,
   srt,
   assay,
+  evaluated_spots,
   log10_nCount,
   log10_nFeature,
   spot_featurecount_dist
@@ -319,10 +321,10 @@ spot_qc_metric <- function(
   }
   assay_metric <- paste0(metric, "_", assay)
   if (assay_metric %in% colnames(srt@meta.data)) {
-    return(srt[[assay_metric, drop = TRUE]])
+    return(srt@meta.data[evaluated_spots, assay_metric, drop = TRUE])
   }
   if (metric %in% colnames(srt@meta.data)) {
-    return(srt[[metric, drop = TRUE]])
+    return(srt@meta.data[evaluated_spots, metric, drop = TRUE])
   }
   log_message(
     "{.arg outlier_threshold} metric {.val {metric}} was not found",

--- a/R/RunSpotQC.R
+++ b/R/RunSpotQC.R
@@ -26,7 +26,9 @@
 #' `mito_pattern` is ignored.
 #' @param seed Random seed for reproducibility.
 #'
-#' @return A `Seurat` object with spot QC metadata columns.
+#' @return A `Seurat` object with spot QC metadata columns. Cells that are not
+#' present in the selected assay receive `NA` QC labels and are excluded when
+#' `return_filtered = TRUE`.
 #' @export
 #'
 #' @examples
@@ -84,6 +86,7 @@ RunSpotQC <- function(
   }
 
   counts <- GetAssayData5(srt, assay = assay, layer = "counts")
+  evaluated_spots <- colnames(counts)
   n_evaluated <- ncol(counts)
   nCount <- Matrix::colSums(counts)
   nFeature <- Matrix::colSums(counts > 0)
@@ -118,13 +121,13 @@ RunSpotQC <- function(
 
   spot_umi_qc <- spot_gene_qc <- spot_mito_qc <- spot_outlier_qc <- character()
   if ("umi" %in% qc_metrics) {
-    spot_umi_qc <- colnames(srt)[which(nCount < UMI_threshold)]
+    spot_umi_qc <- evaluated_spots[which(nCount < UMI_threshold)]
   }
   if ("gene" %in% qc_metrics) {
-    spot_gene_qc <- colnames(srt)[which(nFeature < gene_threshold)]
+    spot_gene_qc <- evaluated_spots[which(nFeature < gene_threshold)]
   }
   if ("mito" %in% qc_metrics) {
-    spot_mito_qc <- colnames(srt)[which(percent_mito > mito_threshold)]
+    spot_mito_qc <- evaluated_spots[which(percent_mito > mito_threshold)]
   }
   if ("outlier" %in% qc_metrics) {
     outlier <- lapply(
@@ -144,7 +147,7 @@ RunSpotQC <- function(
           log10_nFeature = log10_nFeature,
           spot_featurecount_dist = spot_featurecount_dist
         )
-        colnames(srt)[spot_qc_is_outlier(
+        evaluated_spots[spot_qc_is_outlier(
           metric,
           nmads = as.numeric(rule[[3L]]),
           type = rule[[2L]]
@@ -155,7 +158,10 @@ RunSpotQC <- function(
     outlier_tb <- table(unlist(outlier))
     spot_outlier_qc <- names(outlier_tb)[outlier_tb >= outlier_n]
     for (nm in names(outlier)) {
-      srt[[make.names(paste0("spot_", nm))]] <- colnames(srt) %in% outlier[[nm]]
+      outlier_flag <- rep(NA, ncol(srt))
+      names(outlier_flag) <- colnames(srt)
+      outlier_flag[evaluated_spots] <- evaluated_spots %in% outlier[[nm]]
+      srt[[make.names(paste0("spot_", nm))]] <- outlier_flag
     }
   }
 
@@ -173,14 +179,22 @@ RunSpotQC <- function(
     SpotQC = SpotQC
   )
   for (qc in names(qc_map)) {
-    srt[[qc]] <- ifelse(colnames(srt) %in% qc_map[[qc]], "Fail", "Pass")
+    qc_status <- rep(NA_character_, ncol(srt))
+    names(qc_status) <- colnames(srt)
+    qc_status[evaluated_spots] <- ifelse(
+      evaluated_spots %in% qc_map[[qc]],
+      "Fail",
+      "Pass"
+    )
+    srt[[qc]] <- qc_status
     srt[[qc]] <- factor(srt[[qc, drop = TRUE]], levels = c("Pass", "Fail"))
   }
 
   n_failed <- length(SpotQC)
   n_passed <- n_evaluated - n_failed
   if (isTRUE(return_filtered)) {
-    srt <- srt[, srt$SpotQC == "Pass"]
+    keep <- !is.na(srt$SpotQC) & srt$SpotQC == "Pass"
+    srt <- srt[, keep]
   }
 
   n_returned <- ncol(srt)

--- a/R/RunSpotQC.R
+++ b/R/RunSpotQC.R
@@ -197,11 +197,11 @@ RunSpotQC <- function(
   )
   plot_call <- if (length(image_names) > 1L) {
     paste0(
-      "lapply(SeuratObject::Images(srt), function(image) ",
-      "SpatialSpotPlot(srt, group.by = \"SpotQC\", image = image))"
+      "lapply(SeuratObject::Images(<returned_object>), function(image) ",
+      "SpatialSpotPlot(<returned_object>, group.by = \"SpotQC\", image = image))"
     )
   } else {
-    "SpatialSpotPlot(srt, group.by = \"SpotQC\")"
+    "SpatialSpotPlot(<returned_object>, group.by = \"SpotQC\")"
   }
   spatial_run_receipt(
     done = done,

--- a/R/RunSpotQC.R
+++ b/R/RunSpotQC.R
@@ -195,23 +195,65 @@ RunSpotQC <- function(
     SeuratObject::Images(srt),
     error = function(e) character()
   )
-  plot_call <- if (length(image_names) > 1L) {
+  can_plot <- !isTRUE(return_filtered) && spot_qc_has_plottable_coordinates(
+    srt = srt,
+    image_names = image_names
+  )
+  plot_call <- if (isTRUE(can_plot) && length(image_names) > 1L) {
     paste0(
       "lapply(SeuratObject::Images(<returned_object>), function(image) ",
       "SpatialSpotPlot(<returned_object>, group.by = \"SpotQC\", image = image))"
     )
-  } else {
+  } else if (isTRUE(can_plot)) {
     "SpatialSpotPlot(<returned_object>, group.by = \"SpotQC\")"
+  } else {
+    NULL
+  }
+  inspect_call <- if (!isTRUE(return_filtered) && !isTRUE(can_plot)) {
+    "table(<returned_object>[[\"SpotQC\", drop = TRUE]], useNA = \"ifany\")"
+  } else {
+    NULL
   }
   spatial_run_receipt(
     done = done,
     scope = "assay {.val {assay}}, layer {.val counts}",
     saved = "metadata column {.var SpotQC}",
-    plot = if (isTRUE(return_filtered)) NULL else plot_call,
+    plot = plot_call,
+    inspect = inspect_call,
     verbose = verbose,
     .envir = environment()
   )
   srt
+}
+
+spot_qc_has_plottable_coordinates <- function(srt, image_names = NULL) {
+  if (is.null(image_names)) {
+    image_names <- tryCatch(
+      SeuratObject::Images(srt),
+      error = function(e) character()
+    )
+  }
+  targets <- if (length(image_names) > 0L) as.list(image_names) else list(NULL)
+  all(vapply(
+    targets,
+    function(image) {
+      tryCatch(
+        {
+          coords <- spatial_coords_raw(
+            srt = srt,
+            image = image,
+            coord.cols = c("col", "row"),
+            image.scale = "lowres",
+            require_scale = TRUE,
+            image_policy = "strict"
+          )$data
+          nrow(coords) > 0L
+        },
+        error = function(e) FALSE
+      )
+    },
+    logical(1)
+  ))
 }
 
 spot_qc_mito_features <- function(features, mito_pattern, mito_gene = NULL) {

--- a/R/RunSpotQC.R
+++ b/R/RunSpotQC.R
@@ -318,28 +318,32 @@ RunSpotQC <- function(
   if (isTRUE(return_filtered)) {
     done <- paste0(done, "; {.val {n_returned}} returned")
   }
-  image_names <- tryCatch(
-    SeuratObject::Images(srt),
-    error = function(e) character()
-  )
-  can_plot <- !isTRUE(return_filtered) && spot_qc_has_plottable_coordinates(
-    srt = srt,
-    image_names = image_names
-  )
-  plot_call <- if (isTRUE(can_plot) && length(image_names) > 1L) {
-    paste0(
-      "lapply(SeuratObject::Images(<returned_object>), function(image) ",
-      "SpatialSpotPlot(<returned_object>, group.by = \"SpotQC\", image = image))"
+  receipt_verbose <- thisutils::get_verbose(verbose)
+  plot_call <- inspect_call <- NULL
+  if (isTRUE(receipt_verbose)) {
+    image_names <- tryCatch(
+      SeuratObject::Images(srt),
+      error = function(e) character()
     )
-  } else if (isTRUE(can_plot)) {
-    "SpatialSpotPlot(<returned_object>, group.by = \"SpotQC\")"
-  } else {
-    NULL
-  }
-  inspect_call <- if (!isTRUE(return_filtered) && !isTRUE(can_plot)) {
-    "table(<returned_object>[[\"SpotQC\", drop = TRUE]], useNA = \"ifany\")"
-  } else {
-    NULL
+    can_plot <- !isTRUE(return_filtered) && spot_qc_has_plottable_coordinates(
+      srt = srt,
+      image_names = image_names
+    )
+    plot_call <- if (isTRUE(can_plot) && length(image_names) > 1L) {
+      paste0(
+        "lapply(SeuratObject::Images(<returned_object>), function(image) ",
+        "SpatialSpotPlot(<returned_object>, group.by = \"SpotQC\", image = image))"
+      )
+    } else if (isTRUE(can_plot)) {
+      "SpatialSpotPlot(<returned_object>, group.by = \"SpotQC\")"
+    } else {
+      NULL
+    }
+    inspect_call <- if (!isTRUE(return_filtered) && !isTRUE(can_plot)) {
+      "table(<returned_object>[[\"SpotQC\", drop = TRUE]], useNA = \"ifany\")"
+    } else {
+      NULL
+    }
   }
   spatial_run_receipt(
     done = done,
@@ -348,7 +352,7 @@ RunSpotQC <- function(
     plot = plot_call,
     inspect = inspect_call,
     status = if (n_not_evaluated > 0L) "partial" else "completed",
-    verbose = verbose,
+    verbose = receipt_verbose,
     .envir = environment()
   )
   srt

--- a/R/SpatialRunReceipt.R
+++ b/R/SpatialRunReceipt.R
@@ -21,6 +21,36 @@ spatial_run_receipt_quote <- function(x, name) {
   deparse1(x, width.cutoff = 500L)
 }
 
+spatial_run_receipt_display_scale <- function(srt, image) {
+  if (is.null(image)) {
+    return(NULL)
+  }
+  tryCatch({
+    resolved_image <- spatial_image_resolve(
+      srt = srt,
+      image = image,
+      image_policy = "strict"
+    )$image
+    if (is.null(resolved_image)) {
+      return(NULL)
+    }
+    spatial_image <- srt[[resolved_image]]
+    candidates <- c("lowres", "hires")
+    usable <- vapply(candidates, function(candidate) {
+      scale <- spatial_image_scale_info(
+        spatial_image,
+        image.scale = candidate,
+        required = FALSE
+      )$scale
+      length(scale) == 1L && is.finite(scale) && scale > 0
+    }, logical(1))
+    if (!any(usable)) {
+      return(NULL)
+    }
+    candidates[[which(usable)[[1L]]]]
+  }, error = function(e) NULL)
+}
+
 spatial_run_receipt <- function(
   done,
   scope = NULL,

--- a/R/SpatialRunReceipt.R
+++ b/R/SpatialRunReceipt.R
@@ -1,0 +1,98 @@
+# Internal spatial run receipt renderer --------------------------------------
+
+spatial_run_receipt_lines <- function(x, name) {
+  if (is.null(x)) {
+    return(character())
+  }
+  if (!is.character(x)) {
+    stop(sprintf("%s must be NULL or a character vector", name), call. = FALSE)
+  }
+  x <- x[!is.na(x) & nzchar(x)]
+  if (length(x) == 0L) {
+    return(character())
+  }
+  as.character(x)
+}
+
+spatial_run_receipt_quote <- function(x, name) {
+  if (!is.character(x) || length(x) != 1L || is.na(x) || !nzchar(x)) {
+    stop(sprintf("%s must be one non-empty character string", name), call. = FALSE)
+  }
+  deparse1(x, width.cutoff = 500L)
+}
+
+spatial_run_receipt <- function(
+  done,
+  scope = NULL,
+  saved = NULL,
+  plot = NULL,
+  inspect = NULL,
+  status = c("completed", "partial"),
+  replaced = FALSE,
+  verbose = TRUE,
+  .envir = parent.frame()
+) {
+  verbose <- thisutils::get_verbose(verbose)
+  if (!isTRUE(verbose)) {
+    return(invisible(NULL))
+  }
+
+  status <- match.arg(status)
+  if (!is.character(done) || length(done) != 1L || is.na(done) || !nzchar(done)) {
+    stop("done must be one non-empty character string", call. = FALSE)
+  }
+  scope <- spatial_run_receipt_lines(scope, "scope")
+  saved <- spatial_run_receipt_lines(saved, "saved")
+  plot <- spatial_run_receipt_lines(plot, "plot")
+  inspect <- spatial_run_receipt_lines(inspect, "inspect")
+  if (!is.logical(replaced) || length(replaced) != 1L || is.na(replaced)) {
+    stop("replaced must be one non-missing logical value", call. = FALSE)
+  }
+  if (!is.environment(.envir)) {
+    stop(".envir must be an environment", call. = FALSE)
+  }
+
+  message_type <- if (identical(status, "completed")) "success" else "running"
+  log_message(
+    done,
+    message_type = message_type,
+    verbose = TRUE,
+    .envir = .envir
+  )
+
+  if (length(scope) > 0L) {
+    log_message(
+      paste(c("{.field Scope}", scope), collapse = " "),
+      level = 2,
+      timestamp = FALSE,
+      verbose = TRUE,
+      .envir = .envir
+    )
+  }
+
+  if (length(saved) > 0L) {
+    saved_label <- if (isTRUE(replaced)) "{.field Replaced}" else "{.field Saved}"
+    log_message(
+      paste(c(saved_label, saved), collapse = " "),
+      level = 2,
+      timestamp = FALSE,
+      verbose = TRUE,
+      .envir = .envir
+    )
+  }
+
+  next_lines <- if (length(plot) > 0L) plot else inspect
+  next_label <- if (length(plot) > 0L) "{.field Plot}" else "{.field Inspect}"
+  if (length(next_lines) > 0L) {
+    next_call <- next_lines[[1L]]
+    log_message(
+      paste(next_label, "{.code {next_call}}"),
+      level = 2,
+      timestamp = FALSE,
+      verbose = TRUE,
+      .envir = environment()
+    )
+  }
+
+  invisible(NULL)
+}

--- a/R/SpatialRunReceipt.R
+++ b/R/SpatialRunReceipt.R
@@ -21,6 +21,14 @@ spatial_run_receipt_quote <- function(x, name) {
   deparse1(x, width.cutoff = 500L)
 }
 
+spatial_run_receipt_package_available <- function(package) {
+  is.character(package) &&
+    length(package) == 1L &&
+    !is.na(package) &&
+    nzchar(package) &&
+    nzchar(system.file(package = package))
+}
+
 spatial_run_receipt_display_scale <- function(srt, image) {
   if (is.null(image)) {
     return(NULL)

--- a/R/SpatialRunReceipt.R
+++ b/R/SpatialRunReceipt.R
@@ -45,6 +45,12 @@ spatial_run_receipt <- function(
   saved <- spatial_run_receipt_lines(saved, "saved")
   plot <- spatial_run_receipt_lines(plot, "plot")
   inspect <- spatial_run_receipt_lines(inspect, "inspect")
+  if (length(plot) > 1L) {
+    stop("plot must contain at most one non-empty string", call. = FALSE)
+  }
+  if (length(inspect) > 1L) {
+    stop("inspect must contain at most one non-empty string", call. = FALSE)
+  }
   if (!is.logical(replaced) || length(replaced) != 1L || is.na(replaced)) {
     stop("replaced must be one non-missing logical value", call. = FALSE)
   }
@@ -82,7 +88,11 @@ spatial_run_receipt <- function(
   }
 
   next_lines <- if (length(plot) > 0L) plot else inspect
-  next_label <- if (length(plot) > 0L) "{.field Plot}" else "{.field Inspect}"
+  next_label <- if (length(plot) > 0L) {
+    "{.field Plot returned object}"
+  } else {
+    "{.field Inspect returned object}"
+  }
   if (length(next_lines) > 0L) {
     next_call <- next_lines[[1L]]
     log_message(

--- a/man/RunSpotQC.Rd
+++ b/man/RunSpotQC.Rd
@@ -36,7 +36,9 @@ Seurat object.}
 \code{"metric:direction:nmads"}. Available default metrics are
 \code{"log10_nCount"}, \code{"log10_nFeature"}, and \code{"spot_featurecount_dist"}.}
 
-\item{outlier_n}{Minimum number of outlier metrics required to fail a spot.}
+\item{outlier_n}{Positive integer giving the minimum number of outlier rules
+required to fail a spot. It cannot exceed the number of
+\code{outlier_threshold} rules.}
 
 \item{UMI_threshold}{Minimum UMI count required to pass \code{"umi"} QC.}
 
@@ -58,7 +60,9 @@ Default is \code{TRUE}.}
 }
 \value{
 A \code{Seurat} object with spot QC metadata columns. Cells that are not
-present in the selected assay receive \code{NA} QC labels and are excluded when
+present in the selected assay receive \code{NA} QC labels. A selected-assay cell
+also receives \code{NA} when at least one requested QC is unresolved and no
+requested QC has a known failure. Only cells labelled \code{Pass} are retained when
 \code{return_filtered = TRUE}.
 }
 \description{

--- a/man/RunSpotQC.Rd
+++ b/man/RunSpotQC.Rd
@@ -57,7 +57,9 @@ Default is \code{TRUE}.}
 \item{seed}{Random seed for reproducibility.}
 }
 \value{
-A \code{Seurat} object with spot QC metadata columns.
+A \code{Seurat} object with spot QC metadata columns. Cells that are not
+present in the selected assay receive \code{NA} QC labels and are excluded when
+\code{return_filtered = TRUE}.
 }
 \description{
 Calculate common spot-level QC metrics for spatial transcriptomics data and

--- a/tests/testthat/test-bayesspace.R
+++ b/tests/testthat/test-bayesspace.R
@@ -88,6 +88,23 @@ mock_bayesspace_complete <- function(sce, ...) {
   sce
 }
 
+bayesspace_receipt_plain <- function(messages) {
+  cli::ansi_strip(paste(messages, collapse = "\n"))
+}
+
+bayesspace_expect_receipt_plot <- function(messages, expected_call, srt) {
+  plain <- bayesspace_receipt_plain(messages)
+  expect_true(grepl(paste0("Plot `", expected_call, "`"), plain, fixed = TRUE))
+  expect_error(parse(text = expected_call), NA)
+  plot <- suppressWarnings(eval(
+    parse(text = expected_call),
+    envir = list(srt = srt),
+    enclos = parent.frame()
+  ))
+  expect_s3_class(plot, "ggplot")
+  invisible(plain)
+}
+
 test_that("RunBayesSpace stores raw coordinate provenance and aligned cells", {
   skip_if_not_installed("SingleCellExperiment")
   srt <- make_bayesspace_object()
@@ -110,6 +127,83 @@ test_that("RunBayesSpace stores raw coordinate provenance and aligned cells", {
   expect_identical(rownames(result$colData), colnames(out))
   expect_false("sce" %in% names(result))
   expect_false(anyNA(out$BayesSpace_cluster))
+})
+
+test_that("RunBayesSpace emits an exact receipt and safely quotes its Plot key", {
+  skip_if_not_installed("SingleCellExperiment")
+  srt <- make_bayesspace_object()
+  cluster_colname <- 'Bayes "quoted"\\domain'
+  out <- NULL
+  messages <- suppressWarnings(testthat::capture_messages(
+    out <- with_mock_bayesspace(mock_bayesspace_complete, {
+      RunBayesSpace(
+        srt,
+        q = 2,
+        preprocess = FALSE,
+        cluster_colname = cluster_colname,
+        store_sce = FALSE,
+        verbose = TRUE
+      )
+    })
+  ))
+  plain <- bayesspace_receipt_plain(messages)
+  expect_true(grepl(
+    "BayesSpace completed: 4 spots, 2 domains, domain size 2-2",
+    plain,
+    fixed = TRUE
+  ))
+  expect_true(grepl("Scope assay", plain, fixed = TRUE))
+  expect_true(grepl("raw coordinates", plain, fixed = TRUE))
+  expect_true(grepl("Saved metadata column", plain, fixed = TRUE))
+  expect_true(grepl(cluster_colname, plain, fixed = TRUE))
+  expect_true(grepl("srt@tools[['BayesSpace']]", plain, fixed = TRUE))
+  expect_true(cluster_colname %in% colnames(out[[]]))
+  plot_call <- paste0(
+    "SpatialSpotPlot(srt, group.by = ",
+    deparse1(cluster_colname, width.cutoff = 500L),
+    ")"
+  )
+  bayesspace_expect_receipt_plot(messages, plot_call, out)
+})
+
+test_that("RunBayesSpace is silent on request and failure has no receipt", {
+  skip_if_not_installed("SingleCellExperiment")
+  srt <- make_bayesspace_object()
+  quiet <- NULL
+  quiet_messages <- suppressWarnings(testthat::capture_messages(
+    quiet <- with_mock_bayesspace(mock_bayesspace_complete, {
+      RunBayesSpace(
+        srt,
+        q = 2,
+        preprocess = FALSE,
+        store_sce = FALSE,
+        verbose = FALSE
+      )
+    })
+  ))
+  expect_length(quiet_messages, 0L)
+  expect_s4_class(quiet, "Seurat")
+
+  missing_cluster <- function(sce, ...) sce
+  failure_messages <- suppressWarnings(testthat::capture_messages(
+    with_mock_bayesspace(missing_cluster, {
+      expect_error(
+        RunBayesSpace(
+          srt,
+          q = 2,
+          preprocess = FALSE,
+          store_sce = FALSE,
+          verbose = TRUE
+        ),
+        "did not return"
+      )
+    })
+  ))
+  expect_false(grepl(
+    "BayesSpace completed",
+    bayesspace_receipt_plain(failure_messages),
+    fixed = TRUE
+  ))
 })
 
 test_that("BayesSpace preserves exact Visium array indices separately from raw pixels", {

--- a/tests/testthat/test-bayesspace.R
+++ b/tests/testthat/test-bayesspace.R
@@ -92,16 +92,15 @@ bayesspace_receipt_plain <- function(messages) {
   cli::ansi_strip(paste(messages, collapse = "\n"))
 }
 
-bayesspace_expect_receipt_plot <- function(messages, expected_call, srt) {
+bayesspace_expect_receipt_plot_hint <- function(messages, expected_call) {
   plain <- bayesspace_receipt_plain(messages)
-  expect_true(grepl(paste0("Plot `", expected_call, "`"), plain, fixed = TRUE))
-  expect_error(parse(text = expected_call), NA)
-  plot <- suppressWarnings(eval(
-    parse(text = expected_call),
-    envir = list(srt = srt),
-    enclos = parent.frame()
+  expect_true(grepl(
+    paste0("Plot returned object `", expected_call, "`"),
+    plain,
+    fixed = TRUE
   ))
-  expect_s3_class(plot, "ggplot")
+  expect_true(grepl("<returned_object>", expected_call, fixed = TRUE))
+  expect_false(grepl("srt", expected_call, fixed = TRUE))
   invisible(plain)
 }
 
@@ -129,7 +128,7 @@ test_that("RunBayesSpace stores raw coordinate provenance and aligned cells", {
   expect_false(anyNA(out$BayesSpace_cluster))
 })
 
-test_that("RunBayesSpace emits an exact receipt and safely quotes its Plot key", {
+test_that("RunBayesSpace emits an exact receipt and safely quotes its Plot hint", {
   skip_if_not_installed("SingleCellExperiment")
   srt <- make_bayesspace_object()
   cluster_colname <- 'Bayes "quoted"\\domain'
@@ -156,14 +155,15 @@ test_that("RunBayesSpace emits an exact receipt and safely quotes its Plot key",
   expect_true(grepl("raw coordinates", plain, fixed = TRUE))
   expect_true(grepl("Saved metadata column", plain, fixed = TRUE))
   expect_true(grepl(cluster_colname, plain, fixed = TRUE))
-  expect_true(grepl("srt@tools[['BayesSpace']]", plain, fixed = TRUE))
+  expect_true(grepl("returned object tool bundle `BayesSpace`", plain, fixed = TRUE))
   expect_true(cluster_colname %in% colnames(out[[]]))
   plot_call <- paste0(
-    "SpatialSpotPlot(srt, group.by = ",
+    "SpatialSpotPlot(<returned_object>, group.by = ",
     deparse1(cluster_colname, width.cutoff = 500L),
     ")"
   )
-  bayesspace_expect_receipt_plot(messages, plot_call, out)
+  bayesspace_expect_receipt_plot_hint(messages, plot_call)
+  expect_false(grepl("srt", plain, fixed = TRUE))
 })
 
 test_that("RunBayesSpace is silent on request and failure has no receipt", {

--- a/tests/testthat/test-bayesspace.R
+++ b/tests/testthat/test-bayesspace.R
@@ -184,6 +184,77 @@ test_that("RunBayesSpace emits an exact receipt and safely quotes its Plot hint"
   expect_false(grepl("srt", plain, fixed = TRUE))
 })
 
+test_that("RunBayesSpace receipt uses a valid image scale or metadata inspection", {
+  skip_if_not_installed("SingleCellExperiment")
+  fixture <- make_bayesspace_visium_v1_object()
+  fixture$object[["slice"]]@scale.factors$lowres <- NA_real_
+
+  hires_messages <- testthat::capture_messages(
+    hires_out <- with_mock_bayesspace(mock_bayesspace_complete, {
+      RunBayesSpace(
+        fixture$object,
+        q = 2,
+        image = "slice",
+        preprocess = FALSE,
+        store_sce = FALSE,
+        verbose = TRUE
+      )
+    })
+  )
+  hires_call <- paste0(
+    "SpatialSpotPlot(<returned_object>, group.by = \"BayesSpace_cluster\", ",
+    "image = \"slice\", image.scale = \"hires\")"
+  )
+  bayesspace_expect_receipt_plot_hint(hires_messages, hires_call)
+  hires_plot <- NULL
+  expect_no_error(
+    hires_plot <- eval(parse(text = sub(
+      "<returned_object>",
+      "hires_out",
+      hires_call,
+      fixed = TRUE
+    )))
+  )
+  expect_s3_class(hires_plot, "ggplot")
+
+  no_scale <- make_bayesspace_visium_v1_object()$object
+  no_scale[["slice"]]@scale.factors$lowres <- NA_real_
+  no_scale[["slice"]]@scale.factors$hires <- NA_real_
+  inspect_messages <- testthat::capture_messages(
+    inspect_out <- with_mock_bayesspace(mock_bayesspace_complete, {
+      RunBayesSpace(
+        no_scale,
+        q = 2,
+        image = "slice",
+        preprocess = FALSE,
+        store_sce = FALSE,
+        verbose = TRUE
+      )
+    })
+  )
+  inspect_plain <- bayesspace_receipt_plain(inspect_messages)
+  inspect_call <- paste0(
+    "<returned_object>[[]][, \"BayesSpace_cluster\", drop = FALSE]"
+  )
+  expect_true(grepl(
+    paste0("Inspect returned object `", inspect_call, "`"),
+    inspect_plain,
+    fixed = TRUE
+  ))
+  expect_false(grepl("Plot returned object", inspect_plain, fixed = TRUE))
+  inspected <- NULL
+  expect_no_error(
+    inspected <- eval(parse(text = sub(
+      "<returned_object>",
+      "inspect_out",
+      inspect_call,
+      fixed = TRUE
+    )))
+  )
+  expect_identical(colnames(inspected), "BayesSpace_cluster")
+  expect_identical(rownames(inspected), colnames(inspect_out))
+})
+
 test_that("RunBayesSpace is silent on request and failure has no receipt", {
   skip_if_not_installed("SingleCellExperiment")
   srt <- make_bayesspace_object()

--- a/tests/testthat/test-bayesspace.R
+++ b/tests/testthat/test-bayesspace.R
@@ -132,6 +132,15 @@ test_that("RunBayesSpace emits an exact receipt and safely quotes its Plot hint"
   skip_if_not_installed("SingleCellExperiment")
   srt <- make_bayesspace_object()
   cluster_colname <- 'Bayes "quoted"\\domain'
+  coord_cols <- c('x "quoted"', "y\\path")
+  custom_coords <- data.frame(
+    x = c(10, 20, 10, 20),
+    y = c(30, 30, 40, 40),
+    row.names = colnames(srt),
+    check.names = FALSE
+  )
+  colnames(custom_coords) <- coord_cols
+  srt <- SeuratObject::AddMetaData(srt, metadata = custom_coords)
   out <- NULL
   messages <- suppressWarnings(testthat::capture_messages(
     out <- with_mock_bayesspace(mock_bayesspace_complete, {
@@ -140,6 +149,7 @@ test_that("RunBayesSpace emits an exact receipt and safely quotes its Plot hint"
         q = 2,
         preprocess = FALSE,
         cluster_colname = cluster_colname,
+        coord.cols = coord_cols,
         store_sce = FALSE,
         verbose = TRUE
       )
@@ -160,9 +170,17 @@ test_that("RunBayesSpace emits an exact receipt and safely quotes its Plot hint"
   plot_call <- paste0(
     "SpatialSpotPlot(<returned_object>, group.by = ",
     deparse1(cluster_colname, width.cutoff = 500L),
+    ", coord.cols = ",
+    deparse1(coord_cols, width.cutoff = 500L),
     ")"
   )
   bayesspace_expect_receipt_plot_hint(messages, plot_call)
+  expect_identical(
+    out@tools[["BayesSpace"]]$parameters$coord.cols,
+    coord_cols
+  )
+  executable_call <- sub("<returned_object>", "out", plot_call, fixed = TRUE)
+  expect_no_error(eval(parse(text = executable_call)))
   expect_false(grepl("srt", plain, fixed = TRUE))
 })
 

--- a/tests/testthat/test-spatial-network-receipt.R
+++ b/tests/testthat/test-spatial-network-receipt.R
@@ -1,0 +1,85 @@
+make_spatial_network_receipt_image <- function(
+  lowres = NA_real_,
+  hires = 0.5
+) {
+  counts <- matrix(
+    seq_len(12),
+    nrow = 3,
+    dimnames = list(paste0("Gene", 1:3), paste0("Spot", 1:4))
+  )
+  srt <- suppressWarnings(SeuratObject::CreateSeuratObject(counts))
+  scale_factors <- structure(
+    list(spot = 1, fiducial = 1, hires = hires, lowres = lowres),
+    class = "scalefactors"
+  )
+  coordinates <- data.frame(
+    imagerow = c(4, 8, 12, 16),
+    imagecol = c(5, 10, 15, 20),
+    row.names = colnames(srt)
+  )
+  srt[["slice"]] <- methods::new(
+    "VisiumV1",
+    image = array(1, dim = c(20, 30, 3)),
+    scale.factors = scale_factors,
+    coordinates = coordinates,
+    spot.radius = 0.1,
+    assay = SeuratObject::DefaultAssay(srt),
+    key = "network_"
+  )
+  srt
+}
+
+test_that("RunSpatialNetwork receipt selects a usable display scale or the raw graph", {
+  skip_if_not_installed("BiocNeighbors")
+
+  hires_messages <- testthat::capture_messages(
+    hires_out <- RunSpatialNetwork(
+      make_spatial_network_receipt_image(),
+      image = "slice",
+      k = 1,
+      verbose = TRUE
+    )
+  )
+  hires_plain <- cli::ansi_strip(paste(hires_messages, collapse = "\n"))
+  hires_call <- paste0(
+    "SpatialNetworkPlot(<returned_object>, graph.name = \"slice_knn_k1\", ",
+    "image.scale = \"hires\")"
+  )
+  expect_true(grepl(hires_call, hires_plain, fixed = TRUE))
+  hires_plot <- NULL
+  expect_no_error(
+    hires_plot <- eval(parse(text = sub(
+      "<returned_object>",
+      "hires_out",
+      hires_call,
+      fixed = TRUE
+    )))
+  )
+  expect_s3_class(hires_plot, "ggplot")
+
+  raw_messages <- testthat::capture_messages(
+    raw_out <- RunSpatialNetwork(
+      make_spatial_network_receipt_image(hires = NA_real_),
+      image = "slice",
+      k = 1,
+      verbose = TRUE
+    )
+  )
+  raw_plain <- cli::ansi_strip(paste(raw_messages, collapse = "\n"))
+  raw_call <- paste0(
+    "SpatialNetworkPlot(res = <returned_object>@tools[[\"SpatialNetwork\"]], ",
+    "graph.name = \"slice_knn_k1\")"
+  )
+  expect_true(grepl(raw_call, raw_plain, fixed = TRUE))
+  expect_false(grepl("image.scale", raw_plain, fixed = TRUE))
+  raw_plot <- NULL
+  expect_no_error(
+    raw_plot <- eval(parse(text = sub(
+      "<returned_object>",
+      "raw_out",
+      raw_call,
+      fixed = TRUE
+    )))
+  )
+  expect_s3_class(raw_plot, "ggplot")
+})

--- a/tests/testthat/test-spatial-run-receipt.R
+++ b/tests/testthat/test-spatial-run-receipt.R
@@ -1,0 +1,359 @@
+make_receipt_spatial_object <- function() {
+  counts <- matrix(
+    c(
+      3, 1, 0, 2,
+      0, 4, 1, 0,
+      2, 1, 3, 1
+    ),
+    nrow = 3,
+    byrow = TRUE,
+    dimnames = list(paste0("Gene", 1:3), paste0("Spot", 1:4))
+  )
+  srt <- suppressWarnings(SeuratObject::CreateSeuratObject(counts))
+  srt <- SeuratObject::AddMetaData(srt, metadata = c(0, 2, 1, 3), col.name = "col")
+  SeuratObject::AddMetaData(srt, metadata = c(0, 0, 1, 1), col.name = "row")
+}
+
+make_receipt_multi_image_object <- function() {
+  srt <- make_receipt_spatial_object()
+  assay <- SeuratObject::DefaultAssay(srt)
+  slice1 <- data.frame(
+    x = c(0, 2),
+    y = c(0, 0),
+    row.names = c("Spot1", "Spot2")
+  )
+  slice2 <- data.frame(
+    x = c(1, 3),
+    y = c(1, 1),
+    row.names = c("Spot3", "Spot4")
+  )
+  srt[["slice1"]] <- SeuratObject::CreateFOV(
+    slice1,
+    type = "centroids",
+    assay = assay,
+    key = "receipt1_"
+  )
+  srt[["slice2"]] <- SeuratObject::CreateFOV(
+    slice2,
+    type = "centroids",
+    assay = assay,
+    key = "receipt2_"
+  )
+  srt
+}
+
+receipt_plain <- function(messages) {
+  cli::ansi_strip(paste(messages, collapse = "\n"))
+}
+
+expect_receipt_plot <- function(messages, expected_call, srt) {
+  plain <- receipt_plain(messages)
+  expect_true(grepl(paste0("Plot `", expected_call, "`"), plain, fixed = TRUE))
+  expect_error(parse(text = expected_call), NA)
+  plot <- suppressWarnings(eval(
+    parse(text = expected_call),
+    envir = list(srt = srt),
+    enclos = parent.frame()
+  ))
+  expect_s3_class(plot, "ggplot")
+  invisible(plain)
+}
+
+test_that("spatial_run_receipt renders exact inline labels and a parseable call", {
+  plot_call <- 'SpatialSpotPlot(srt, group.by = "BANKSY_cluster")'
+  out <- testthat::capture_messages(
+    spatial_run_receipt(
+      done = "{.pkg BANKSY} completed for {.val 10} spots",
+      scope = "assay {.val Spatial}, layer {.val counts}",
+      saved = "metadata column {.var BANKSY_cluster} and {.code srt@tools[['BANKSY']]}",
+      plot = plot_call,
+      verbose = TRUE,
+      .envir = environment()
+    )
+  )
+  plain <- receipt_plain(out)
+  expect_match(plain, "BANKSY completed for \"10\" spots")
+  expect_match(plain, "Scope assay \"Spatial\", layer \"counts\"")
+  expect_match(plain, "Saved metadata column `BANKSY_cluster`")
+  expect_match(plain, "srt@tools")
+  expect_true(grepl(paste0("Plot `", plot_call, "`"), plain, fixed = TRUE))
+  expect_error(parse(text = plot_call), NA)
+})
+
+test_that("spatial_run_receipt renders partial output without a warning condition", {
+  old_options <- options(warn = 2)
+  on.exit(options(old_options), add = TRUE)
+  out <- testthat::expect_warning(
+    testthat::capture_messages(
+      spatial_run_receipt(
+        done = "SpotSweeper completed partially",
+        scope = "assay {.val Spatial}",
+        inspect = "srt@tools[['SpotSweeper']]",
+        status = "partial",
+        verbose = TRUE,
+        .envir = environment()
+      )
+    ),
+    NA
+  )
+  plain <- receipt_plain(out)
+  expect_match(plain, "SpotSweeper completed partially")
+  expect_true(grepl("Inspect `srt@tools[['SpotSweeper']]`", plain, fixed = TRUE))
+})
+
+test_that("spatial_run_receipt maps partial output to non-success display", {
+  message_types <- character()
+  testthat::local_mocked_bindings(
+    log_message = function(..., message_type = "info") {
+      message_types <<- c(message_types, message_type)
+      invisible(NULL)
+    },
+    .package = "scop"
+  )
+  spatial_run_receipt(
+    done = "SpotSweeper completed partially",
+    status = "partial",
+    verbose = TRUE
+  )
+  expect_identical(message_types, "running")
+})
+
+test_that("spatial_run_receipt is silent when verbose is FALSE", {
+  expect_silent(
+    spatial_run_receipt(
+      done = "{.pkg BANKSY} completed",
+      scope = "assay {.val Spatial}",
+      saved = "{.code srt@tools[['BANKSY']]}",
+      plot = "SpatialSpotPlot(srt)",
+      verbose = FALSE,
+      .envir = environment()
+    )
+  )
+})
+
+test_that("spatial_run_receipt reuses thisutils verbose NULL semantics", {
+  old_options <- options(log_message.verbose = FALSE)
+  on.exit(options(old_options), add = TRUE)
+  expect_silent(
+    spatial_run_receipt(
+      done = "{.pkg BANKSY} completed",
+      plot = "SpatialSpotPlot(srt)",
+      verbose = NULL,
+      .envir = environment()
+    )
+  )
+})
+
+test_that("spatial_run_receipt uses Replaced and prefers Plot over Inspect", {
+  plot_call <- 'SpatialNetworkPlot(srt, graph.name = "knn_k6")'
+  out <- testthat::capture_messages(
+    spatial_run_receipt(
+      done = "{.pkg SpatialNetwork} completed",
+      saved = "graph {.val knn_k6}",
+      plot = plot_call,
+      inspect = "srt@tools[['SpatialNetwork']]",
+      replaced = TRUE,
+      verbose = TRUE,
+      .envir = environment()
+    )
+  )
+  plain <- receipt_plain(out)
+  expect_match(plain, "Replaced graph")
+  expect_true(grepl(paste0("Plot `", plot_call, "`"), plain, fixed = TRUE))
+  expect_false(grepl("Inspect", plain, fixed = TRUE))
+})
+
+test_that("spatial_run_receipt_quote safely round-trips custom keys", {
+  key <- 'domain "quoted"\\path'
+  quoted <- spatial_run_receipt_quote(key, "key")
+  expect_identical(eval(parse(text = quoted)), key)
+  expect_error(spatial_run_receipt_quote(character(), "key"), "key")
+})
+
+test_that("spatial_run_receipt validates its visible interface", {
+  expect_error(spatial_run_receipt(done = character()), "done")
+  expect_error(spatial_run_receipt(done = "ok", scope = 1), "scope")
+  expect_error(spatial_run_receipt(done = "ok", replaced = NA), "replaced")
+  expect_error(spatial_run_receipt(done = "ok", .envir = NULL), "envir")
+})
+
+test_that("RunSpotQC emits an exact receipt and its Plot call executes", {
+  srt <- make_receipt_spatial_object()
+  out <- NULL
+  messages <- suppressWarnings(testthat::capture_messages(
+    out <- RunSpotQC(
+      srt,
+      assay = "RNA",
+      UMI_threshold = 0,
+      gene_threshold = 0,
+      mito_threshold = 100,
+      verbose = TRUE
+    )
+  ))
+  plain <- receipt_plain(messages)
+  expect_true(grepl(
+    "Spot QC completed: 4 evaluated, 4 Pass, 0 Fail",
+    plain,
+    fixed = TRUE
+  ))
+  expect_true(grepl('Scope assay "RNA", layer "counts"', plain, fixed = TRUE))
+  expect_true(grepl("Saved metadata column `SpotQC`", plain, fixed = TRUE))
+  expect_identical(as.integer(table(out$SpotQC)), c(4L, 0L))
+  expect_receipt_plot(
+    messages,
+    'SpatialSpotPlot(srt, group.by = "SpotQC")',
+    out
+  )
+
+  filtered <- NULL
+  filtered_messages <- suppressWarnings(testthat::capture_messages(
+    filtered <- RunSpotQC(
+      srt,
+      assay = "RNA",
+      UMI_threshold = 0,
+      gene_threshold = 0,
+      mito_threshold = 100,
+      return_filtered = TRUE,
+      verbose = TRUE
+    )
+  ))
+  filtered_plain <- receipt_plain(filtered_messages)
+  expect_true(grepl("4 returned", filtered_plain, fixed = TRUE))
+  expect_false(grepl("Plot", filtered_plain, fixed = TRUE))
+  expect_equal(ncol(filtered), 4)
+})
+
+test_that("RunSpotQC is silent on request and failure has no receipt", {
+  srt <- make_receipt_spatial_object()
+  quiet <- NULL
+  quiet_messages <- suppressWarnings(testthat::capture_messages(
+    quiet <- RunSpotQC(
+      srt,
+      assay = "RNA",
+      UMI_threshold = 0,
+      gene_threshold = 0,
+      mito_threshold = 100,
+      verbose = FALSE
+    )
+  ))
+  expect_length(quiet_messages, 0L)
+  expect_s4_class(quiet, "Seurat")
+
+  failure_messages <- testthat::capture_messages(
+    expect_error(RunSpotQC(list(), verbose = TRUE), "Seurat")
+  )
+  expect_false(grepl("Spot QC completed", receipt_plain(failure_messages), fixed = TRUE))
+})
+
+test_that("RunSpotQC gives an executable all-image Plot call", {
+  srt <- make_receipt_multi_image_object()
+  out <- NULL
+  messages <- suppressWarnings(testthat::capture_messages(
+    out <- RunSpotQC(
+      srt,
+      assay = "RNA",
+      UMI_threshold = 0,
+      gene_threshold = 0,
+      mito_threshold = 100,
+      verbose = TRUE
+    )
+  ))
+  plot_call <- paste0(
+    "lapply(SeuratObject::Images(srt), function(image) ",
+    "SpatialSpotPlot(srt, group.by = \"SpotQC\", image = image))"
+  )
+  plain <- receipt_plain(messages)
+  expect_true(grepl(paste0("Plot `", plot_call, "`"), plain, fixed = TRUE))
+  expect_error(parse(text = plot_call), NA)
+  plots <- suppressWarnings(eval(
+    parse(text = plot_call),
+    envir = list(srt = out),
+    enclos = parent.frame()
+  ))
+  expect_length(plots, 2L)
+  expect_true(all(vapply(plots, inherits, logical(1), what = "ggplot")))
+})
+
+test_that("RunSpatialNetwork emits actual graph state and an executable Plot call", {
+  skip_if_not_installed("BiocNeighbors")
+  srt <- make_receipt_spatial_object()
+  out <- NULL
+  messages <- testthat::capture_messages(
+    out <- RunSpatialNetwork(srt, k = 1, verbose = TRUE)
+  )
+  plain <- receipt_plain(messages)
+  expect_true(grepl(
+    'Spatial graph completed: "knn", `k` = 1, 4 nodes, 3 edges',
+    plain,
+    fixed = TRUE
+  ))
+  expect_true(grepl("Scope raw coordinates; 4 observations", plain, fixed = TRUE))
+  expect_true(grepl('Saved graph "knn_k1"', plain, fixed = TRUE))
+  expect_receipt_plot(
+    messages,
+    'SpatialNetworkPlot(srt, graph.name = "knn_k1")',
+    out
+  )
+
+  replaced <- NULL
+  replaced_messages <- testthat::capture_messages(
+    replaced <- RunSpatialNetwork(out, k = 1, overwrite = TRUE, verbose = TRUE)
+  )
+  replaced_plain <- receipt_plain(replaced_messages)
+  expect_true(grepl('Replaced graph "knn_k1"', replaced_plain, fixed = TRUE))
+  expect_true("knn_k1" %in% names(replaced@tools[["SpatialNetwork"]]$graphs))
+})
+
+test_that("RunSpatialNetwork reports radius and safely quotes a custom graph name", {
+  skip_if_not_installed("BiocNeighbors")
+  srt <- make_receipt_spatial_object()
+  graph_name <- 'radius "quoted"\\graph'
+  out <- NULL
+  messages <- testthat::capture_messages(
+    out <- RunSpatialNetwork(
+      srt,
+      method = "radius",
+      radius = 1.5,
+      graph.name = graph_name,
+      verbose = TRUE
+    )
+  )
+  plain <- receipt_plain(messages)
+  expect_true(grepl(
+    'Spatial graph completed: "radius", `radius` = 1.5',
+    plain,
+    fixed = TRUE
+  ))
+  expect_true(graph_name %in% names(out@tools[["SpatialNetwork"]]$graphs))
+  plot_call <- paste0(
+    "SpatialNetworkPlot(srt, graph.name = ",
+    deparse1(graph_name, width.cutoff = 500L),
+    ")"
+  )
+  expect_receipt_plot(messages, plot_call, out)
+})
+
+test_that("RunSpatialNetwork respects verbose NULL and emits no receipt on failure", {
+  skip_if_not_installed("BiocNeighbors")
+  srt <- make_receipt_spatial_object()
+  old_options <- options(log_message.verbose = FALSE)
+  on.exit(options(old_options), add = TRUE)
+  quiet <- NULL
+  quiet_messages <- testthat::capture_messages(
+    quiet <- RunSpatialNetwork(srt, k = 1, verbose = NULL)
+  )
+  expect_length(quiet_messages, 0L)
+  expect_s4_class(quiet, "Seurat")
+
+  failure_messages <- testthat::capture_messages(
+    expect_error(
+      RunSpatialNetwork(srt, k = ncol(srt), verbose = TRUE),
+      "number of nodes minus one"
+    )
+  )
+  expect_false(grepl(
+    "Spatial graph completed",
+    receipt_plain(failure_messages),
+    fixed = TRUE
+  ))
+})

--- a/tests/testthat/test-spatial-run-receipt.R
+++ b/tests/testthat/test-spatial-run-receipt.R
@@ -613,6 +613,43 @@ test_that("RunSpotQC is silent on request and failure has no receipt", {
   expect_false(grepl("Spot QC completed", receipt_plain(failure_messages), fixed = TRUE))
 })
 
+test_that("quiet RunSpotQC skips receipt image and coordinate probes", {
+  srt <- make_receipt_spatial_object()
+  image_probes <- coordinate_probes <- 0L
+  testthat::local_mocked_bindings(
+    Images = function(...) {
+      image_probes <<- image_probes + 1L
+      stop("quiet RunSpotQC must not inspect images")
+    },
+    .package = "SeuratObject"
+  )
+  testthat::local_mocked_bindings(
+    spot_qc_has_plottable_coordinates = function(...) {
+      coordinate_probes <<- coordinate_probes + 1L
+      stop("quiet RunSpotQC must not inspect coordinates")
+    },
+    .package = "scop"
+  )
+
+  run_quiet <- function(verbose) {
+    suppressWarnings(RunSpotQC(
+      srt,
+      assay = "RNA",
+      UMI_threshold = 0,
+      gene_threshold = 0,
+      mito_threshold = 100,
+      verbose = verbose
+    ))
+  }
+
+  expect_s4_class(run_quiet(FALSE), "Seurat")
+  old_options <- options(log_message.verbose = FALSE)
+  on.exit(options(old_options), add = TRUE)
+  expect_s4_class(run_quiet(NULL), "Seurat")
+  expect_identical(image_probes, 0L)
+  expect_identical(coordinate_probes, 0L)
+})
+
 test_that("RunSpatialVariableFeatures reports exactly what the returned object retains", {
   skip_if_not_installed("BiocNeighbors")
   cases <- list(

--- a/tests/testthat/test-spatial-run-receipt.R
+++ b/tests/testthat/test-spatial-run-receipt.R
@@ -407,6 +407,190 @@ test_that("RunSpotQC aligns metadata outlier metrics to noncontiguous assay cell
   expect_true(all(is.na(out[[outlier_col, drop = TRUE]][c("Spot2", "Spot5")])))
 })
 
+test_that("RunSpotQC preserves tri-state outlier rules and aggregates uncertainty", {
+  full_counts <- matrix(
+    1,
+    nrow = 2,
+    ncol = 8,
+    dimnames = list(paste0("Gene", 1:2), paste0("Spot", 1:8))
+  )
+  srt <- suppressWarnings(SeuratObject::CreateSeuratObject(full_counts))
+  evaluated_spots <- c("Spot1", "Spot3", "Spot4", "Spot5", "Spot7", "Spot8")
+  assay_counts <- full_counts[, evaluated_spots, drop = FALSE]
+  assay_counts[, "Spot3"] <- 0
+  srt[["SUBSET"]] <- suppressWarnings(
+    SeuratObject::CreateAssay5Object(
+      counts = assay_counts
+    )
+  )
+  metric_a <- setNames(rep(0, ncol(srt)), colnames(srt))
+  metric_b <- metric_a
+  metric_a[evaluated_spots] <- c(100, 200, 1, NA, 3, 4)
+  metric_b[evaluated_spots] <- c(100, NA, Inf, NA, 2, 3)
+  srt$metric_a <- metric_a
+  srt$metric_b <- metric_b
+
+  out <- NULL
+  messages <- suppressWarnings(testthat::capture_messages(
+    out <- RunSpotQC(
+      srt,
+      assay = "SUBSET",
+      qc_metrics = c("outlier", "umi"),
+      outlier_threshold = c(
+        "metric_a:higher:3",
+        "metric_b:higher:3"
+      ),
+      outlier_n = 2,
+      UMI_threshold = 1,
+      verbose = TRUE
+    )
+  ))
+
+  expect_identical(
+    unname(as.character(out$SpotQC[evaluated_spots])),
+    c("Fail", "Fail", "Pass", NA, "Pass", "Pass")
+  )
+  expect_identical(
+    unname(as.character(out$spot_outlier_qc[evaluated_spots])),
+    c("Fail", NA, "Pass", NA, "Pass", "Pass")
+  )
+  expect_true(all(is.na(out$SpotQC[c("Spot2", "Spot6")])))
+  raw_a <- make.names("spot_metric_a:higher:3")
+  raw_b <- make.names("spot_metric_b:higher:3")
+  expect_identical(
+    unname(out[[raw_a, drop = TRUE]][evaluated_spots]),
+    c(TRUE, TRUE, FALSE, NA, FALSE, FALSE)
+  )
+  expect_identical(
+    unname(out[[raw_b, drop = TRUE]][evaluated_spots]),
+    c(TRUE, NA, NA, NA, FALSE, FALSE)
+  )
+  expect_true(all(is.na(out[[raw_a, drop = TRUE]][c("Spot2", "Spot6")])))
+  expect_true(grepl(
+    paste0(
+      "Spot QC completed: 5 evaluated, 3 Pass, 2 Fail; 1\\s+",
+      "NotEvaluated"
+    ),
+    receipt_plain(messages)
+  ))
+
+  filtered <- suppressWarnings(RunSpotQC(
+    srt,
+    assay = "SUBSET",
+    qc_metrics = c("outlier", "umi"),
+    outlier_threshold = c(
+      "metric_a:higher:3",
+      "metric_b:higher:3"
+    ),
+    outlier_n = 2,
+    UMI_threshold = 1,
+    return_filtered = TRUE,
+    verbose = FALSE
+  ))
+  expect_identical(
+    colnames(filtered),
+    c("Spot4", "Spot7", "Spot8")
+  )
+})
+
+test_that("RunSpotQC validates outlier aggregation and metadata metrics", {
+  srt <- make_receipt_spatial_object()
+  srt$custom_metric <- c(1, 2, 100, 3)
+
+  expect_error(
+    RunSpotQC(
+      srt,
+      assay = "RNA",
+      qc_metrics = "outlier",
+      outlier_threshold = NA_character_,
+      verbose = FALSE
+    ),
+    "outlier_threshold.*non-empty character vector"
+  )
+  expect_error(
+    RunSpotQC(
+      srt,
+      assay = "RNA",
+      qc_metrics = "outlier",
+      outlier_threshold = "custom_metric:higher:3",
+      outlier_n = NA_real_,
+      verbose = FALSE
+    ),
+    "outlier_n.*finite positive integer"
+  )
+  expect_error(
+    RunSpotQC(
+      srt,
+      assay = "RNA",
+      qc_metrics = "outlier",
+      outlier_threshold = "custom_metric:higher:3",
+      outlier_n = 2,
+      verbose = FALSE
+    ),
+    "cannot exceed.*outlier_threshold"
+  )
+
+  srt$factor_metric <- factor(c("1", "2", "100", "3"))
+  expect_error(
+    suppressWarnings(RunSpotQC(
+      srt,
+      assay = "RNA",
+      qc_metrics = "outlier",
+      outlier_threshold = "factor_metric:higher:3",
+      verbose = FALSE
+    )),
+    "factor_metric.*numeric vector"
+  )
+  expect_error(
+    spot_qc_validate_metric(1, metric = "short", n_expected = 2),
+    "one\\s+value per selected-assay spot"
+  )
+  expect_error(
+    RunSpotQC(
+      srt,
+      assay = "RNA",
+      qc_metrics = "umi",
+      UMI_threshold = NA_real_,
+      verbose = FALSE
+    ),
+    "UMI_threshold.*finite.*number"
+  )
+  expect_error(
+    RunSpotQC(
+      srt,
+      assay = "RNA",
+      qc_metrics = "mito",
+      mito_threshold = Inf,
+      verbose = FALSE
+    ),
+    "mito_threshold.*finite.*number"
+  )
+  expect_error(
+    RunSpotQC(
+      srt,
+      assay = "RNA",
+      return_filtered = NA,
+      verbose = FALSE
+    ),
+    "return_filtered.*TRUE or FALSE"
+  )
+})
+
+test_that("RunSpotQC gives a clear error when filtering would return no spots", {
+  srt <- make_receipt_spatial_object()
+  expect_error(
+    suppressWarnings(RunSpotQC(
+      srt,
+      assay = "RNA",
+      qc_metrics = "umi",
+      UMI_threshold = 1e9,
+      return_filtered = TRUE,
+      verbose = FALSE
+    )),
+    "No spots passed QC.*return_filtered = FALSE"
+  )
+})
+
 test_that("RunSpotQC is silent on request and failure has no receipt", {
   srt <- make_receipt_spatial_object()
   quiet <- NULL

--- a/tests/testthat/test-spatial-run-receipt.R
+++ b/tests/testthat/test-spatial-run-receipt.R
@@ -46,26 +46,25 @@ receipt_plain <- function(messages) {
   cli::ansi_strip(paste(messages, collapse = "\n"))
 }
 
-expect_receipt_plot <- function(messages, expected_call, srt) {
+expect_receipt_plot_hint <- function(messages, expected_call) {
   plain <- receipt_plain(messages)
-  expect_true(grepl(paste0("Plot `", expected_call, "`"), plain, fixed = TRUE))
-  expect_error(parse(text = expected_call), NA)
-  plot <- suppressWarnings(eval(
-    parse(text = expected_call),
-    envir = list(srt = srt),
-    enclos = parent.frame()
+  expect_true(grepl(
+    paste0("Plot returned object `", expected_call, "`"),
+    plain,
+    fixed = TRUE
   ))
-  expect_s3_class(plot, "ggplot")
+  expect_true(grepl("<returned_object>", expected_call, fixed = TRUE))
+  expect_false(grepl("srt", expected_call, fixed = TRUE))
   invisible(plain)
 }
 
-test_that("spatial_run_receipt renders exact inline labels and a parseable call", {
-  plot_call <- 'SpatialSpotPlot(srt, group.by = "BANKSY_cluster")'
+test_that("spatial_run_receipt renders exact inline labels and an explicit result placeholder", {
+  plot_call <- 'SpatialSpotPlot(<returned_object>, group.by = "BANKSY_cluster")'
   out <- testthat::capture_messages(
     spatial_run_receipt(
       done = "{.pkg BANKSY} completed for {.val 10} spots",
       scope = "assay {.val Spatial}, layer {.val counts}",
-      saved = "metadata column {.var BANKSY_cluster} and {.code srt@tools[['BANKSY']]}",
+      saved = "metadata column {.var BANKSY_cluster} and returned object tool bundle {.var BANKSY}",
       plot = plot_call,
       verbose = TRUE,
       .envir = environment()
@@ -75,9 +74,13 @@ test_that("spatial_run_receipt renders exact inline labels and a parseable call"
   expect_match(plain, "BANKSY completed for \"10\" spots")
   expect_match(plain, "Scope assay \"Spatial\", layer \"counts\"")
   expect_match(plain, "Saved metadata column `BANKSY_cluster`")
-  expect_match(plain, "srt@tools")
-  expect_true(grepl(paste0("Plot `", plot_call, "`"), plain, fixed = TRUE))
-  expect_error(parse(text = plot_call), NA)
+  expect_match(plain, "returned object tool bundle `BANKSY`")
+  expect_true(grepl(
+    paste0("Plot returned object `", plot_call, "`"),
+    plain,
+    fixed = TRUE
+  ))
+  expect_false(grepl("srt", plain, fixed = TRUE))
 })
 
 test_that("spatial_run_receipt renders partial output without a warning condition", {
@@ -88,7 +91,7 @@ test_that("spatial_run_receipt renders partial output without a warning conditio
       spatial_run_receipt(
         done = "SpotSweeper completed partially",
         scope = "assay {.val Spatial}",
-        inspect = "srt@tools[['SpotSweeper']]",
+        inspect = "tool bundle SpotSweeper",
         status = "partial",
         verbose = TRUE,
         .envir = environment()
@@ -98,7 +101,11 @@ test_that("spatial_run_receipt renders partial output without a warning conditio
   )
   plain <- receipt_plain(out)
   expect_match(plain, "SpotSweeper completed partially")
-  expect_true(grepl("Inspect `srt@tools[['SpotSweeper']]`", plain, fixed = TRUE))
+  expect_true(grepl(
+    "Inspect returned object `tool bundle SpotSweeper`",
+    plain,
+    fixed = TRUE
+  ))
 })
 
 test_that("spatial_run_receipt maps partial output to non-success display", {
@@ -123,8 +130,8 @@ test_that("spatial_run_receipt is silent when verbose is FALSE", {
     spatial_run_receipt(
       done = "{.pkg BANKSY} completed",
       scope = "assay {.val Spatial}",
-      saved = "{.code srt@tools[['BANKSY']]}",
-      plot = "SpatialSpotPlot(srt)",
+      saved = "returned object tool bundle {.var BANKSY}",
+      plot = "SpatialSpotPlot(<returned_object>)",
       verbose = FALSE,
       .envir = environment()
     )
@@ -137,7 +144,7 @@ test_that("spatial_run_receipt reuses thisutils verbose NULL semantics", {
   expect_silent(
     spatial_run_receipt(
       done = "{.pkg BANKSY} completed",
-      plot = "SpatialSpotPlot(srt)",
+      plot = "SpatialSpotPlot(<returned_object>)",
       verbose = NULL,
       .envir = environment()
     )
@@ -145,13 +152,13 @@ test_that("spatial_run_receipt reuses thisutils verbose NULL semantics", {
 })
 
 test_that("spatial_run_receipt uses Replaced and prefers Plot over Inspect", {
-  plot_call <- 'SpatialNetworkPlot(srt, graph.name = "knn_k6")'
+  plot_call <- 'SpatialNetworkPlot(<returned_object>, graph.name = "knn_k6")'
   out <- testthat::capture_messages(
     spatial_run_receipt(
       done = "{.pkg SpatialNetwork} completed",
       saved = "graph {.val knn_k6}",
       plot = plot_call,
-      inspect = "srt@tools[['SpatialNetwork']]",
+      inspect = "tool bundle SpatialNetwork",
       replaced = TRUE,
       verbose = TRUE,
       .envir = environment()
@@ -159,7 +166,11 @@ test_that("spatial_run_receipt uses Replaced and prefers Plot over Inspect", {
   )
   plain <- receipt_plain(out)
   expect_match(plain, "Replaced graph")
-  expect_true(grepl(paste0("Plot `", plot_call, "`"), plain, fixed = TRUE))
+  expect_true(grepl(
+    paste0("Plot returned object `", plot_call, "`"),
+    plain,
+    fixed = TRUE
+  ))
   expect_false(grepl("Inspect", plain, fixed = TRUE))
 })
 
@@ -173,11 +184,13 @@ test_that("spatial_run_receipt_quote safely round-trips custom keys", {
 test_that("spatial_run_receipt validates its visible interface", {
   expect_error(spatial_run_receipt(done = character()), "done")
   expect_error(spatial_run_receipt(done = "ok", scope = 1), "scope")
+  expect_error(spatial_run_receipt(done = "ok", plot = c("a", "b")), "plot")
+  expect_error(spatial_run_receipt(done = "ok", inspect = c("a", "b")), "inspect")
   expect_error(spatial_run_receipt(done = "ok", replaced = NA), "replaced")
   expect_error(spatial_run_receipt(done = "ok", .envir = NULL), "envir")
 })
 
-test_that("RunSpotQC emits an exact receipt and its Plot call executes", {
+test_that("RunSpotQC emits an exact receipt with an explicit result placeholder", {
   srt <- make_receipt_spatial_object()
   out <- NULL
   messages <- suppressWarnings(testthat::capture_messages(
@@ -199,10 +212,9 @@ test_that("RunSpotQC emits an exact receipt and its Plot call executes", {
   expect_true(grepl('Scope assay "RNA", layer "counts"', plain, fixed = TRUE))
   expect_true(grepl("Saved metadata column `SpotQC`", plain, fixed = TRUE))
   expect_identical(as.integer(table(out$SpotQC)), c(4L, 0L))
-  expect_receipt_plot(
+  expect_receipt_plot_hint(
     messages,
-    'SpatialSpotPlot(srt, group.by = "SpotQC")',
-    out
+    'SpatialSpotPlot(<returned_object>, group.by = "SpotQC")'
   )
 
   filtered <- NULL
@@ -245,7 +257,78 @@ test_that("RunSpotQC is silent on request and failure has no receipt", {
   expect_false(grepl("Spot QC completed", receipt_plain(failure_messages), fixed = TRUE))
 })
 
-test_that("RunSpotQC gives an executable all-image Plot call", {
+test_that("RunSpatialVariableFeatures reports exactly what the returned object retains", {
+  skip_if_not_installed("BiocNeighbors")
+  cases <- list(
+    both = list(set = TRUE, store = TRUE),
+    features_only = list(set = TRUE, store = FALSE),
+    tool_only = list(set = FALSE, store = TRUE),
+    neither = list(set = FALSE, store = FALSE)
+  )
+
+  for (case_name in names(cases)) {
+    case <- cases[[case_name]]
+    messages <- suppressWarnings(testthat::capture_messages(
+      out <- RunSpatialVariableFeatures(
+        make_receipt_spatial_object(),
+        assay = "RNA",
+        layer = "counts",
+        method = "moran",
+        coord.cols = c("col", "row"),
+        k = 1,
+        nfeatures = 2,
+        min_spots = 1,
+        set_variable_features = case$set,
+        store_results = case$store,
+        backend = "r",
+        verbose = TRUE
+      )
+    ))
+    plain <- receipt_plain(messages)
+
+    expect_true(grepl(
+      "Spatial variable features completed: 3 tested, 2 ranked in the top set",
+      plain,
+      fixed = TRUE
+    ), info = case_name)
+    expect_false(grepl("Stored 2 spatial variable features", plain, fixed = TRUE))
+    expect_identical(
+      !is.null(out@tools[["SpatialVariableFeatures"]]),
+      case$store,
+      info = case_name
+    )
+    expect_identical(
+      length(SeuratObject::VariableFeatures(out, assay = "RNA")) == 2L,
+      case$set,
+      info = case_name
+    )
+
+    if (isTRUE(case$store)) {
+      expect_true(grepl(
+        "returned object tool bundle `SpatialVariableFeatures`",
+        plain,
+        fixed = TRUE
+      ), info = case_name)
+      expect_true(grepl(
+        "Plot returned object `SpatialVariableFeaturePlot(<returned_object>",
+        plain,
+        fixed = TRUE
+      ), info = case_name)
+    } else {
+      expect_false(grepl("SpatialVariableFeaturePlot", plain, fixed = TRUE))
+    }
+    if (isTRUE(case$set)) {
+      expect_true(grepl("top features as assay `VariableFeatures`", plain, fixed = TRUE))
+    }
+    if (!isTRUE(case$set) && !isTRUE(case$store)) {
+      expect_true(grepl("results not retained", plain, fixed = TRUE))
+      expect_false(grepl("Saved", plain, fixed = TRUE))
+    }
+    expect_false(grepl("srt", plain, fixed = TRUE))
+  }
+})
+
+test_that("RunSpotQC gives an all-image hint with an explicit result placeholder", {
   srt <- make_receipt_multi_image_object()
   out <- NULL
   messages <- suppressWarnings(testthat::capture_messages(
@@ -259,22 +342,16 @@ test_that("RunSpotQC gives an executable all-image Plot call", {
     )
   ))
   plot_call <- paste0(
-    "lapply(SeuratObject::Images(srt), function(image) ",
-    "SpatialSpotPlot(srt, group.by = \"SpotQC\", image = image))"
+    "lapply(SeuratObject::Images(<returned_object>), function(image) ",
+    "SpatialSpotPlot(<returned_object>, group.by = \"SpotQC\", image = image))"
   )
   plain <- receipt_plain(messages)
-  expect_true(grepl(paste0("Plot `", plot_call, "`"), plain, fixed = TRUE))
-  expect_error(parse(text = plot_call), NA)
-  plots <- suppressWarnings(eval(
-    parse(text = plot_call),
-    envir = list(srt = out),
-    enclos = parent.frame()
-  ))
-  expect_length(plots, 2L)
-  expect_true(all(vapply(plots, inherits, logical(1), what = "ggplot")))
+  expect_receipt_plot_hint(messages, plot_call)
+  expect_s4_class(out, "Seurat")
+  expect_false(grepl("srt", plain, fixed = TRUE))
 })
 
-test_that("RunSpatialNetwork emits actual graph state and an executable Plot call", {
+test_that("RunSpatialNetwork emits actual graph state and an explicit result placeholder", {
   skip_if_not_installed("BiocNeighbors")
   srt <- make_receipt_spatial_object()
   out <- NULL
@@ -289,10 +366,9 @@ test_that("RunSpatialNetwork emits actual graph state and an executable Plot cal
   ))
   expect_true(grepl("Scope raw coordinates; 4 observations", plain, fixed = TRUE))
   expect_true(grepl('Saved graph "knn_k1"', plain, fixed = TRUE))
-  expect_receipt_plot(
+  expect_receipt_plot_hint(
     messages,
-    'SpatialNetworkPlot(srt, graph.name = "knn_k1")',
-    out
+    'SpatialNetworkPlot(<returned_object>, graph.name = "knn_k1")'
   )
 
   replaced <- NULL
@@ -326,11 +402,11 @@ test_that("RunSpatialNetwork reports radius and safely quotes a custom graph nam
   ))
   expect_true(graph_name %in% names(out@tools[["SpatialNetwork"]]$graphs))
   plot_call <- paste0(
-    "SpatialNetworkPlot(srt, graph.name = ",
+    "SpatialNetworkPlot(<returned_object>, graph.name = ",
     deparse1(graph_name, width.cutoff = 500L),
     ")"
   )
-  expect_receipt_plot(messages, plot_call, out)
+  expect_receipt_plot_hint(messages, plot_call)
 })
 
 test_that("RunSpatialNetwork respects verbose NULL and emits no receipt on failure", {

--- a/tests/testthat/test-spatial-run-receipt.R
+++ b/tests/testthat/test-spatial-run-receipt.R
@@ -364,6 +364,49 @@ test_that("RunSpotQC counts and labels only cells present in the selected assay"
   expect_identical(colnames(filtered), paste0("Spot", 2:4))
 })
 
+test_that("RunSpotQC aligns metadata outlier metrics to noncontiguous assay cells", {
+  full_counts <- matrix(
+    1,
+    nrow = 2,
+    ncol = 6,
+    dimnames = list(paste0("Gene", 1:2), paste0("Spot", 1:6))
+  )
+  srt <- suppressWarnings(SeuratObject::CreateSeuratObject(full_counts))
+  evaluated_spots <- c("Spot1", "Spot3", "Spot4", "Spot6")
+  srt[["SUBSET"]] <- suppressWarnings(
+    SeuratObject::CreateAssay5Object(
+      counts = full_counts[, evaluated_spots, drop = FALSE]
+    )
+  )
+  srt$custom_metric <- c(0, 100, 0.5, 1, 2, 1.5)
+
+  out <- NULL
+  messages <- suppressWarnings(testthat::capture_messages(
+    out <- RunSpotQC(
+      srt,
+      assay = "SUBSET",
+      qc_metrics = "outlier",
+      outlier_threshold = "custom_metric:higher:3",
+      outlier_n = 1,
+      verbose = TRUE
+    )
+  ))
+
+  expect_true(grepl(
+    "Spot QC completed: 4 evaluated, 4 Pass, 0 Fail",
+    receipt_plain(messages),
+    fixed = TRUE
+  ))
+  expect_identical(as.character(out$SpotQC[evaluated_spots]), rep("Pass", 4))
+  expect_true(all(is.na(out$SpotQC[c("Spot2", "Spot5")])))
+  outlier_col <- make.names("spot_custom_metric:higher:3")
+  expect_identical(
+    unname(out[[outlier_col, drop = TRUE]][evaluated_spots]),
+    rep(FALSE, 4)
+  )
+  expect_true(all(is.na(out[[outlier_col, drop = TRUE]][c("Spot2", "Spot5")])))
+})
+
 test_that("RunSpotQC is silent on request and failure has no receipt", {
   srt <- make_receipt_spatial_object()
   quiet <- NULL

--- a/tests/testthat/test-spatial-run-receipt.R
+++ b/tests/testthat/test-spatial-run-receipt.R
@@ -42,6 +42,36 @@ make_receipt_multi_image_object <- function() {
   srt
 }
 
+make_receipt_svf_multi_image_object <- function() {
+  srt <- make_receipt_spatial_object()
+  alt_counts <- SeuratObject::LayerData(srt, assay = "RNA", layer = "counts")
+  rownames(alt_counts) <- paste0("AltGene", seq_len(nrow(alt_counts)))
+  srt[["ALT"]] <- SeuratObject::CreateAssay5Object(counts = alt_counts)
+  slice1 <- data.frame(
+    x = c(0, 2, 1),
+    y = c(0, 0, 1),
+    row.names = c("Spot1", "Spot2", "Spot3")
+  )
+  slice2 <- data.frame(
+    x = c(2, 1, 3),
+    y = c(0, 1, 1),
+    row.names = c("Spot2", "Spot3", "Spot4")
+  )
+  srt[["slice1"]] <- SeuratObject::CreateFOV(
+    slice1,
+    type = "centroids",
+    assay = "RNA",
+    key = "svf1_"
+  )
+  srt[["slice2"]] <- SeuratObject::CreateFOV(
+    slice2,
+    type = "centroids",
+    assay = "RNA",
+    key = "svf2_"
+  )
+  srt
+}
+
 receipt_plain <- function(messages) {
   cli::ansi_strip(paste(messages, collapse = "\n"))
 }
@@ -50,6 +80,18 @@ expect_receipt_plot_hint <- function(messages, expected_call) {
   plain <- receipt_plain(messages)
   expect_true(grepl(
     paste0("Plot returned object `", expected_call, "`"),
+    plain,
+    fixed = TRUE
+  ))
+  expect_true(grepl("<returned_object>", expected_call, fixed = TRUE))
+  expect_false(grepl("srt", expected_call, fixed = TRUE))
+  invisible(plain)
+}
+
+expect_receipt_inspect_hint <- function(messages, expected_call) {
+  plain <- receipt_plain(messages)
+  expect_true(grepl(
+    paste0("Inspect returned object `", expected_call, "`"),
     plain,
     fixed = TRUE
   ))
@@ -235,6 +277,37 @@ test_that("RunSpotQC emits an exact receipt with an explicit result placeholder"
   expect_equal(ncol(filtered), 4)
 })
 
+test_that("RunSpotQC offers an honest Inspect hint without plottable coordinates", {
+  counts <- matrix(
+    c(3, 1, 0, 2, 0, 4, 1, 0),
+    nrow = 2,
+    dimnames = list(paste0("Gene", 1:2), paste0("Spot", 1:4))
+  )
+  srt <- suppressWarnings(SeuratObject::CreateSeuratObject(counts))
+  out <- NULL
+  messages <- suppressWarnings(testthat::capture_messages(
+    out <- RunSpotQC(
+      srt,
+      assay = "RNA",
+      UMI_threshold = 0,
+      gene_threshold = 0,
+      mito_threshold = 100,
+      verbose = TRUE
+    )
+  ))
+  inspect_call <- paste0(
+    "table(<returned_object>[[\"SpotQC\", drop = TRUE]], ",
+    "useNA = \"ifany\")"
+  )
+  plain <- expect_receipt_inspect_hint(messages, inspect_call)
+  expect_false(grepl("Plot returned object", plain, fixed = TRUE))
+  expect_true("SpotQC" %in% colnames(out[[]]))
+  expect_identical(
+    eval(parse(text = sub("<returned_object>", "out", inspect_call, fixed = TRUE))),
+    table(out[["SpotQC", drop = TRUE]], useNA = "ifany")
+  )
+})
+
 test_that("RunSpotQC is silent on request and failure has no receipt", {
   srt <- make_receipt_spatial_object()
   quiet <- NULL
@@ -326,6 +399,42 @@ test_that("RunSpatialVariableFeatures reports exactly what the returned object r
     }
     expect_false(grepl("srt", plain, fixed = TRUE))
   }
+})
+
+test_that("RunSpatialVariableFeatures Plot hint preserves resolved plotting context", {
+  skip_if_not_installed("BiocNeighbors")
+  srt <- make_receipt_svf_multi_image_object()
+  out <- NULL
+  messages <- suppressWarnings(testthat::capture_messages(
+    out <- RunSpatialVariableFeatures(
+      srt,
+      assay = "ALT",
+      layer = "counts",
+      method = "moran",
+      image = "slice1",
+      coord.cols = c("ignored_x", "ignored_y"),
+      k = 1,
+      nfeatures = 2,
+      min_spots = 1,
+      backend = "r",
+      verbose = TRUE
+    )
+  ))
+  plot_call <- paste0(
+    "SpatialVariableFeaturePlot(<returned_object>, plot_type = \"combined\", ",
+    "assay = \"ALT\", image = \"slice1\", coord.cols = c(\"x\", \"y\"))"
+  )
+  expect_receipt_plot_hint(messages, plot_call)
+  expect_identical(
+    out@tools[["SpatialVariableFeatures"]]$parameters$assay,
+    "ALT"
+  )
+  expect_error(
+    SpatialVariableFeaturePlot(out, plot_type = "combined"),
+    "Multiple spatial images"
+  )
+  executable_call <- sub("<returned_object>", "out", plot_call, fixed = TRUE)
+  expect_no_error(eval(parse(text = executable_call)))
 })
 
 test_that("RunSpotQC gives an all-image hint with an explicit result placeholder", {

--- a/tests/testthat/test-spatial-run-receipt.R
+++ b/tests/testthat/test-spatial-run-receipt.R
@@ -308,6 +308,62 @@ test_that("RunSpotQC offers an honest Inspect hint without plottable coordinates
   )
 })
 
+test_that("RunSpotQC counts and labels only cells present in the selected assay", {
+  full_counts <- matrix(
+    1,
+    nrow = 2,
+    ncol = 6,
+    dimnames = list(paste0("Gene", 1:2), paste0("Spot", 1:6))
+  )
+  srt <- suppressWarnings(SeuratObject::CreateSeuratObject(full_counts))
+  assay_counts <- full_counts[, 1:4, drop = FALSE]
+  assay_counts[, "Spot1"] <- 0
+  srt[["SUBSET"]] <- suppressWarnings(
+    SeuratObject::CreateAssay5Object(counts = assay_counts)
+  )
+
+  out <- NULL
+  messages <- suppressWarnings(testthat::capture_messages(
+    out <- RunSpotQC(
+      srt,
+      assay = "SUBSET",
+      qc_metrics = c("umi", "gene", "mito"),
+      UMI_threshold = 1,
+      gene_threshold = 0,
+      mito_threshold = 100,
+      verbose = TRUE
+    )
+  ))
+  plain <- receipt_plain(messages)
+
+  expect_true(grepl(
+    "Spot QC completed: 4 evaluated, 3 Pass, 1 Fail",
+    plain,
+    fixed = TRUE
+  ))
+  expect_identical(
+    as.character(out$SpotQC[1:4]),
+    c("Fail", rep("Pass", 3))
+  )
+  expect_true(all(is.na(out$SpotQC[5:6])))
+  expect_identical(
+    as.integer(table(out$SpotQC, useNA = "always")),
+    c(3L, 1L, 2L)
+  )
+
+  filtered <- suppressWarnings(RunSpotQC(
+    srt,
+    assay = "SUBSET",
+    qc_metrics = c("umi", "gene", "mito"),
+    UMI_threshold = 1,
+    gene_threshold = 0,
+    mito_threshold = 100,
+    return_filtered = TRUE,
+    verbose = FALSE
+  ))
+  expect_identical(colnames(filtered), paste0("Spot", 2:4))
+})
+
 test_that("RunSpotQC is silent on request and failure has no receipt", {
   srt <- make_receipt_spatial_object()
   quiet <- NULL

--- a/tests/testthat/test-spatial-variable-features.R
+++ b/tests/testthat/test-spatial-variable-features.R
@@ -176,19 +176,31 @@ test_that("SPARKX backend output is normalized without storing backend objects",
     }
   )
 
-  out <- RunSpatialVariableFeatures(
-    srt,
-    method = "SPARKX",
-    layer = "counts",
-    coord.cols = c("x", "y"),
-    min_spots = 1,
-    nfeatures = 2,
-    verbose = FALSE
+  messages <- testthat::capture_messages(
+    out <- RunSpatialVariableFeatures(
+      srt,
+      method = "SPARKX",
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      min_spots = 1,
+      nfeatures = 2,
+      verbose = TRUE
+    )
   )
 
   result <- out@tools[["SpatialVariableFeatures"]][["result"]]
+  plain <- cli::ansi_strip(paste(messages, collapse = "\n"))
   expect_equal(unique(result$method), "SPARKX")
   expect_equal(result$feature[[1]], "Gene2")
+  expect_true(grepl(
+    'Scope method "SPARKX" ("SPARK" backend)',
+    plain,
+    fixed = TRUE
+  ))
+  expect_identical(
+    out@tools[["SpatialVariableFeatures"]]$parameters$backend,
+    "SPARK"
+  )
   expect_equal(
     out@tools[["SpatialVariableFeatures"]]$summary$top_features,
     c("Gene2", "Gene3")
@@ -221,19 +233,31 @@ test_that("nnSVG backend output is normalized through lightweight helpers", {
     spatial_variable_row_data = function(x) x$row_data
   )
 
-  out <- RunSpatialVariableFeatures(
-    srt,
-    method = "nnSVG",
-    layer = "counts",
-    coord.cols = c("x", "y"),
-    min_spots = 1,
-    nfeatures = 2,
-    verbose = FALSE
+  messages <- testthat::capture_messages(
+    out <- RunSpatialVariableFeatures(
+      srt,
+      method = "nnSVG",
+      layer = "counts",
+      coord.cols = c("x", "y"),
+      min_spots = 1,
+      nfeatures = 2,
+      verbose = TRUE
+    )
   )
 
   result <- out@tools[["SpatialVariableFeatures"]][["result"]]
+  plain <- cli::ansi_strip(paste(messages, collapse = "\n"))
   expect_equal(unique(result$method), "nnSVG")
   expect_equal(result$feature[[1]], "Gene2")
+  expect_true(grepl(
+    'Scope method "nnSVG" ("nnSVG" backend)',
+    plain,
+    fixed = TRUE
+  ))
+  expect_identical(
+    out@tools[["SpatialVariableFeatures"]]$parameters$backend,
+    "nnSVG"
+  )
   expect_equal(
     out@tools[["SpatialVariableFeatures"]]$summary$top_features,
     c("Gene2", "Gene4")

--- a/tests/testthat/test-spatial-variable-features.R
+++ b/tests/testthat/test-spatial-variable-features.R
@@ -17,6 +17,32 @@ make_spatial_variable_seurat <- function() {
   srt
 }
 
+make_spatial_variable_image_seurat <- function(
+  lowres = NA_real_,
+  hires = 0.5
+) {
+  srt <- make_spatial_variable_seurat()
+  scale_factors <- structure(
+    list(spot = 1, fiducial = 1, hires = hires, lowres = lowres),
+    class = "scalefactors"
+  )
+  coordinates <- data.frame(
+    imagerow = c(4, 6, 8, 10, 12),
+    imagecol = c(5, 10, 15, 20, 25),
+    row.names = colnames(srt)
+  )
+  srt[["slice"]] <- methods::new(
+    "VisiumV1",
+    image = array(1, dim = c(20, 30, 3)),
+    scale.factors = scale_factors,
+    coordinates = coordinates,
+    spot.radius = 0.1,
+    assay = SeuratObject::DefaultAssay(srt),
+    key = "svf_"
+  )
+  srt
+}
+
 test_that("native spatial variable feature results keep normalized columns", {
   skip_if_not_installed("BiocNeighbors")
   srt <- RunSpatialVariableFeatures(
@@ -322,4 +348,75 @@ test_that("SpatialVariableFeaturePlot combined returns patchwork when available"
     theme_use = NULL
   )
   expect_s3_class(p, "patchwork")
+})
+
+test_that("SVF receipt carries the hires scale selected by legacy display fallback", {
+  skip_if_not_installed("BiocNeighbors")
+  skip_if_not_installed("patchwork")
+  messages <- testthat::capture_messages(
+    out <- RunSpatialVariableFeatures(
+      make_spatial_variable_image_seurat(),
+      method = "moran",
+      layer = "counts",
+      image = "slice",
+      k = 1,
+      min_spots = 1,
+      nfeatures = 2,
+      coordinate_space = "legacy_display",
+      backend = "r",
+      verbose = TRUE
+    )
+  )
+  plain <- cli::ansi_strip(paste(messages, collapse = "\n"))
+  plot_call <- paste0(
+    "SpatialVariableFeaturePlot(<returned_object>, plot_type = \"combined\", ",
+    "assay = \"RNA\", image = \"slice\", image.scale = \"hires\", ",
+    "coord.cols = c(\"imagecol\", \"imagerow\"))"
+  )
+  expect_true(grepl(plot_call, plain, fixed = TRUE))
+  plot <- NULL
+  expect_no_error(
+    plot <- eval(parse(text = sub(
+      "<returned_object>",
+      "out",
+      plot_call,
+      fixed = TRUE
+    )))
+  )
+  expect_s3_class(plot, "patchwork")
+})
+
+test_that("SVF receipt falls back to a summary plot when no display scale works", {
+  skip_if_not_installed("BiocNeighbors")
+  messages <- testthat::capture_messages(
+    out <- RunSpatialVariableFeatures(
+      make_spatial_variable_image_seurat(hires = NA_real_),
+      method = "moran",
+      layer = "counts",
+      image = "slice",
+      k = 1,
+      min_spots = 1,
+      nfeatures = 2,
+      coordinate_space = "raw",
+      backend = "r",
+      verbose = TRUE
+    )
+  )
+  plain <- cli::ansi_strip(paste(messages, collapse = "\n"))
+  plot_call <- paste0(
+    "SpatialVariableFeaturePlot(<returned_object>, plot_type = \"summary\", ",
+    "assay = \"RNA\")"
+  )
+  expect_true(grepl(plot_call, plain, fixed = TRUE))
+  expect_false(grepl("image.scale", plain, fixed = TRUE))
+  plot <- NULL
+  expect_no_error(
+    plot <- eval(parse(text = sub(
+      "<returned_object>",
+      "out",
+      plot_call,
+      fixed = TRUE
+    )))
+  )
+  expect_s3_class(plot, "ggplot")
 })

--- a/tests/testthat/test-spatial-variable-features.R
+++ b/tests/testthat/test-spatial-variable-features.R
@@ -420,3 +420,44 @@ test_that("SVF receipt falls back to a summary plot when no display scale works"
   )
   expect_s3_class(plot, "ggplot")
 })
+
+test_that("SVF receipt uses a dependency-free summary when patchwork is unavailable", {
+  skip_if_not_installed("BiocNeighbors")
+  testthat::local_mocked_bindings(
+    spatial_run_receipt_package_available = function(package) {
+      expect_identical(package, "patchwork")
+      FALSE
+    },
+    .package = "scop"
+  )
+  messages <- testthat::capture_messages(
+    out <- RunSpatialVariableFeatures(
+      make_spatial_variable_image_seurat(lowres = 0.25),
+      method = "moran",
+      layer = "counts",
+      image = "slice",
+      k = 1,
+      min_spots = 1,
+      nfeatures = 2,
+      backend = "r",
+      verbose = TRUE
+    )
+  )
+  plain <- cli::ansi_strip(paste(messages, collapse = "\n"))
+  plot_call <- paste0(
+    "SpatialVariableFeaturePlot(<returned_object>, plot_type = \"summary\", ",
+    "assay = \"RNA\")"
+  )
+  expect_true(grepl(plot_call, plain, fixed = TRUE))
+  expect_false(grepl("plot_type = \"combined\"", plain, fixed = TRUE))
+  plot <- NULL
+  expect_no_error(
+    plot <- eval(parse(text = sub(
+      "<returned_object>",
+      "out",
+      plot_call,
+      fixed = TRUE
+    )))
+  )
+  expect_s3_class(plot, "ggplot")
+})


### PR DESCRIPTION
## Summary

- add one internal spatial run-receipt renderer; no exported API, registry, result schema, history, environment switch, or new global option
- pilot concise Done / Scope / Saved / Plot-or-Inspect receipts in RunSpotQC, RunSpatialNetwork, RunBayesSpace, and RunSpatialVariableFeatures
- use an explicit <returned_object> placeholder instead of guessing the caller's assignment name
- report analysis separately from retention: full tool result, assay VariableFeatures only, both, or neither
- keep receipt facts aligned with the returned object, including Assay5 cell subsets and metadata-backed outlier metrics
- preserve three-state SpotQC semantics for finite, failed, and unevaluated outlier rules; known Fail takes precedence, otherwise unresolved requested QC remains NA/NotEvaluated
- validate outlier aggregation/cutoffs and give a clear error when filtered output would contain no spots
- emit plot hints only when they are executable: select hires when lowres is invalid, use raw/result-only Network plotting, BayesSpace metadata Inspect, or SVF summary fallbacks when display scales are unavailable
- fall back to the dependency-free SVF summary plot when optional patchwork is unavailable, without installing it
- skip all receipt-only image/coordinate probes when effective verbosity is disabled

## Console shape

```text
✔ Spot QC completed: 120 evaluated, 120 Pass, 0 Fail
ℹ   Scope assay "Spatial", layer "counts"
ℹ   Saved metadata column `SpotQC`
ℹ   Plot returned object `SpatialSpotPlot(<returned_object>, group.by = "SpotQC")`
```

The placeholder is intentional: an R function cannot reliably discover an outer assignment target. The receipt therefore provides an honest template and explicitly names the returned object instead of hard-coding a variable that may not exist.

## Validation

- PASS: latest-head macOS, Ubuntu, and Windows R-CMD-check
- PASS: latest-head pkgdown and changes jobs
- PASS: latest Codex review found no major issues; all review threads are resolved
- PASS: installed-package smoke on 120 bundled Visium spots: SpotQC 120/120 Pass; KNN graph 120 nodes/280 edges; native R Moran SVF 100 tested/10 top; all three suggested plots built; store_results = FALSE retained only VariableFeatures and emitted Inspect without a false tool/Plot claim (1.97 s)
- PASS: test-spatial-run-receipt.R (132 expectations), including Assay5 subsets, noncontiguous/reordered cells, finite/NA/Inf rule aggregation, exact counts, filtering, quiet paths, storage combinations, and executable hints
- PASS: Network display-scale receipt tests, BayesSpace receipt/backend tests, full native spatial-variable-feature tests, spatial coordinate contract v2, spatial core, workflow stage, and SPOTlight dispatch tests
- PASS: package fallback test proving SVF summary remains executable when patchwork is unavailable
- PASS: pkgload::load_all('.', quiet = TRUE, compile = FALSE)
- PASS: prescribed final local rcmdcheck: 0 errors, 2 inherited warnings, 4 notes; unstated dependencies in examples and tests both OK
- PASS: R/Rd parse and git diff --check

The two local check warnings are inherited from upstream main: lifecycle / glmGamPoi / sctransform namespace declarations and pre-existing Rd usage mismatches. This PR does not modify those dependency or Rd topics.

## Validation boundary

BayesSpace adapter behavior is covered with a mocked backend; this PR does not claim a new live upstream BayesSpace integration run. The receipt is deliberately a thin rendering of facts already validated by each producer, not a second result framework.