### PR TITLE
fix: reject Windows Python execution aliases

### DIFF
--- a/R/RunCell2location.R
+++ b/R/RunCell2location.R
@@ -192,8 +192,18 @@ RunCell2location <- function(
     conda_python(envname = get_envname(envname), conda = resolve_conda("auto")),
     error = function(...) NULL
   )
-  if (is.null(python) || !file.exists(python)) {
-    log_message("Unable to resolve the cell2location Python executable", message_type = "error")
+  windows_alias <- !is.null(python) && length(python) == 1L &&
+    grepl("[/\\\\]WindowsApps[/\\\\]", as.character(python), ignore.case = TRUE)
+  if (is.null(python) || !file.exists(python) || windows_alias) {
+    detail <- if (isTRUE(windows_alias)) {
+      "The resolved path is a WindowsApps execution alias; configure the SCOP conda environment instead"
+    } else {
+      "Run PrepareEnv() and verify the configured SCOP Python environment"
+    }
+    log_message(
+      "Unable to resolve the cell2location Python executable. {detail}",
+      message_type = "error"
+    )
   }
   python <- normalizePath(python, winslash = "/", mustWork = TRUE)
   workdir <- tempfile("cell2location_inputs_")

--- a/tests/testthat/test-cell2location.R
+++ b/tests/testthat/test-cell2location.R
@@ -55,9 +55,14 @@ test_that("cell2location environment module pins compatible versions", {
 })
 
 test_that("cell2location runner translates trainer devices to Pyro device", {
-  python <- unname(Sys.which(c("python3", "python")))
-  python <- python[nzchar(python)][1]
-  skip_if(is.na(python), "Python is not available")
+  python_candidates <- unname(Sys.which(c("python3", "python")))
+  python_candidates <- python_candidates[
+    nzchar(python_candidates) &
+      file.exists(python_candidates) &
+      !grepl("[/\\\\]WindowsApps[/\\\\]", python_candidates, ignore.case = TRUE)
+  ]
+  python <- if (length(python_candidates) == 0L) NA_character_ else python_candidates[[1L]]
+  skip_if(is.na(python), "A runnable Python executable is not available")
   runner <- getFromNamespace("runner_script_path", "scop")(
     "cell2location.py",
     "cell2location"
@@ -131,6 +136,33 @@ test_that("cell2location rejects normalized input and invalid signatures", {
   expect_error(signatures_fun(bad), "finite and non-negative")
 })
 
+test_that("cell2location rejects a WindowsApps Python execution alias", {
+  pair <- make_cell2location_pair()
+  signatures <- matrix(
+    1,
+    nrow = 4,
+    ncol = 2,
+    dimnames = list(paste0("Gene", 1:4), c("Alpha", "Beta"))
+  )
+  testthat::local_mocked_bindings(
+    PrepareEnv = function(...) invisible(NULL),
+    check_python = function(...) TRUE,
+    conda_python = function(...) "C:/Users/test/AppData/Local/Microsoft/WindowsApps/python3.exe",
+    resolve_conda = function(...) "mamba",
+    .package = "scop"
+  )
+  expect_error(
+    RunCell2location(
+      pair$spatial,
+      result_dir = tempfile("cell2location_alias_"),
+      reference_signatures = signatures,
+      assay = "RNA",
+      verbose = FALSE
+    ),
+    "WindowsApps"
+  )
+})
+
 test_that("RunCell2location writes abundance, proportions, and reproducible tools", {
   pair <- make_cell2location_pair()
   signatures <- matrix(
@@ -148,7 +180,11 @@ test_that("RunCell2location writes abundance, proportions, and reproducible tool
       checked_python_packages <<- packages
       TRUE
     },
-    conda_python = function(...) Sys.which("python3"),
+    conda_python = function(...) normalizePath(
+      file.path(R.home("bin"), if (.Platform$OS.type == "windows") "Rscript.exe" else "R"),
+      winslash = "/",
+      mustWork = TRUE
+    ),
     resolve_conda = function(...) "mamba",
     runner_script_path = function(...) "cell2location.py",
     runner_write_json = function(...) invisible(NULL),
@@ -216,7 +252,11 @@ test_that("RunCell2location does not mutate Seurat when Python fails", {
     .package = "scop",
     PrepareEnv = function(...) invisible(NULL),
     check_python = function(...) TRUE,
-    conda_python = function(...) Sys.which("python3"),
+    conda_python = function(...) normalizePath(
+      file.path(R.home("bin"), if (.Platform$OS.type == "windows") "Rscript.exe" else "R"),
+      winslash = "/",
+      mustWork = TRUE
+    ),
     resolve_conda = function(...) "mamba",
     runner_script_path = function(...) "cell2location.py",
     runner_write_json = function(...) invisible(NULL),


### PR DESCRIPTION
## Summary
- reject the Microsoft WindowsApps `python3.exe` execution alias before launching the cell2location subprocess
- direct users to the configured SCOP conda environment when the resolved path is not executable
- make mocked cell2location tests independent of the host's `python3` app alias

## Validation
- `test-cell2location.R`: passed
- `pkgload::load_all('.', quiet = TRUE, compile = FALSE)`: passed
- `git diff --check`: passed
- prescribed local `rcmdcheck`: 0 errors, 2 inherited warnings, 4 inherited notes; unstated example dependencies check passed. The warnings are unchanged main-branch dependency/Rd issues outside this two-file diff.

This does not change cell2location model parameters or scientific output parsing.