### PR TITLE
fix(spatial): accept object alias for native spatial APIs

### DIFF
--- a/R/RunSpatialNetwork.R
+++ b/R/RunSpatialNetwork.R
@@ -6,7 +6,10 @@
 #' `srt@tools$SpatialNetwork`.
 #'
 #' @inheritParams thisutils::log_message
-#' @param srt A `Seurat` object.
+#' @param srt A `Seurat` object. The same object may be supplied as
+#' `object =` for consistency with spatial plotting APIs.
+#' @param object Optional alias for `srt`. Supply exactly one of `srt` or
+#' `object`.
 #' @param method Network method, either `"knn"` or `"radius"`.
 #' @param image Seurat image name. A single image is selected automatically;
 #'   multi-image objects require an explicit value.
@@ -25,12 +28,12 @@
 #' @examples
 #' data(visium_human_pancreas_sub)
 #' spatial <- visium_human_pancreas_sub
-#' spatial <- RunSpatialNetwork(spatial, k = 6, verbose = FALSE)
-#' SpatialNetworkPlot(spatial, group.by = "coda_label")
+#' spatial <- RunSpatialNetwork(object = spatial, k = 6, verbose = FALSE)
+#' SpatialNetworkPlot(object = spatial, group.by = "coda_label")
 #'
 #' @export
 RunSpatialNetwork <- function(
-  srt,
+  srt = NULL,
   method = c("knn", "radius"),
   image = NULL,
   coord.cols = c("col", "row"),
@@ -38,11 +41,10 @@ RunSpatialNetwork <- function(
   radius = NULL,
   graph.name = NULL,
   overwrite = FALSE,
-  verbose = TRUE
+  verbose = TRUE,
+  object = NULL
 ) {
-  if (!inherits(srt, "Seurat")) {
-    log_message("{.arg srt} must be a {.cls Seurat} object", message_type = "error")
-  }
+  srt <- spatial_resolve_srt(srt = srt, object = object)
   if (!is.null(image) && (!is.character(image) || length(image) != 1L || is.na(image) || !nzchar(image))) {
     log_message("{.arg image} must be one non-empty image name", message_type = "error")
   }

--- a/R/RunSpatialVariableFeatures.R
+++ b/R/RunSpatialVariableFeatures.R
@@ -663,8 +663,8 @@ SpatialVariableFeaturePlot <- function(
   nrow = NULL,
   ncol = NULL,
   byrow = TRUE,
-  image.scale = c("lowres", "hires"),
-  object = NULL
+  object = NULL,
+  image.scale = c("lowres", "hires")
 ) {
   srt <- spatial_resolve_srt(srt = srt, object = object)
   plot_type <- match.arg(plot_type)

--- a/R/RunSpatialVariableFeatures.R
+++ b/R/RunSpatialVariableFeatures.R
@@ -31,6 +31,10 @@
 #' @param seed Random seed used for permutation tests.
 #' @param backend Backend used by the package `"moran"` and `"geary"` methods.
 #' `"cpp"` is the default; use `"r"` for the reference implementation.
+#' @param srt A `Seurat` object. The same object may be supplied as
+#' `object =` for consistency with spatial plotting APIs.
+#' @param object Optional alias for `srt`. Supply exactly one of `srt` or
+#' `object`.
 #' @param ... Additional arguments passed to external backends.
 #'
 #' @return A `Seurat` object with spatial variable feature results stored in
@@ -53,18 +57,18 @@
 #' )
 #'
 #' SpatialSpotPlot(
-#'   spatial,
+#'   object = spatial,
 #'   features = Seurat::VariableFeatures(spatial, assay = "Spatial")[1:2]
 #' )
 #'
 #' spatial <- RunSpatialVariableFeatures(
-#'   spatial,
+#'   object = spatial,
 #'   assay = "Spatial",
 #'   nfeatures = 50
 #' )
-#' SpatialVariableFeaturePlot(spatial, plot_type = "combined", nfeatures = 2)
+#' SpatialVariableFeaturePlot(object = spatial, plot_type = "combined", nfeatures = 2)
 RunSpatialVariableFeatures <- function(
-  srt,
+  srt = NULL,
   assay = NULL,
   layer = "data",
   features = NULL,
@@ -81,8 +85,10 @@ RunSpatialVariableFeatures <- function(
   seed = 11,
   coordinate_space = c("raw", "legacy_display"),
   backend = c("cpp", "r"),
-  ...
+  ...,
+  object = NULL
 ) {
+  srt <- spatial_resolve_srt(srt = srt, object = object)
   backend_missing <- missing(backend)
   coordinate_space <- match.arg(coordinate_space)
   log_message(
@@ -90,12 +96,6 @@ RunSpatialVariableFeatures <- function(
     message_type = "running",
     verbose = verbose
   )
-  if (!inherits(srt, "Seurat")) {
-    log_message(
-      "{.arg srt} must be a {.cls Seurat} object",
-      message_type = "error"
-    )
-  }
   validate_scalar_flag(set_variable_features, "set_variable_features")
   validate_scalar_flag(store_results, "store_results")
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
@@ -610,6 +610,10 @@ spatial_variable_result_features <- function(df, fallback) {
 #'
 #' @md
 #' @inheritParams SpatialSpotPlot
+#' @param srt A `Seurat` object. The same object may be supplied as
+#' `object =` for consistency with spatial plotting APIs.
+#' @param object Optional alias for `srt`. Supply exactly one of `srt` or
+#' `object`.
 #' @param plot_type Plot type: `"summary"`, `"surface"`, or `"combined"`.
 #' @param features Features to plot. If `NULL`, top features from the stored
 #' spatial variable feature result are used.
@@ -628,14 +632,14 @@ spatial_variable_result_features <- function(df, fallback) {
 #'   verbose = FALSE
 #' )
 #' spatial <- RunSpatialVariableFeatures(
-#'   spatial,
+#'   object = spatial,
 #'   assay = "Spatial",
 #'   nfeatures = 10,
 #'   verbose = FALSE
 #' )
-#' SpatialVariableFeaturePlot(spatial, plot_type = "summary")
+#' SpatialVariableFeaturePlot(object = spatial, plot_type = "summary")
 SpatialVariableFeaturePlot <- function(
-  srt,
+  srt = NULL,
   plot_type = c("summary", "surface", "combined"),
   features = NULL,
   nfeatures = 10,
@@ -659,11 +663,10 @@ SpatialVariableFeaturePlot <- function(
   nrow = NULL,
   ncol = NULL,
   byrow = TRUE,
-  image.scale = c("lowres", "hires")
+  image.scale = c("lowres", "hires"),
+  object = NULL
 ) {
-  if (!inherits(srt, "Seurat")) {
-    log_message("{.arg srt} must be a {.cls Seurat} object", message_type = "error")
-  }
+  srt <- spatial_resolve_srt(srt = srt, object = object)
   plot_type <- match.arg(plot_type)
   image.scale <- match.arg(image.scale)
   stored <- spatial_variable_get_stored_result(srt)

--- a/R/RunSpotQC.R
+++ b/R/RunSpotQC.R
@@ -8,6 +8,10 @@
 #' @md
 #' @inheritParams RunStandardWorkflow
 #' @inheritParams thisutils::log_message
+#' @param srt A `Seurat` object. The same object may be supplied as
+#' `object =` for consistency with spatial plotting APIs.
+#' @param object Optional alias for `srt`. Supply exactly one of `srt` or
+#' `object`.
 #' @param return_filtered Whether to return a spot-filtered
 #' Seurat object.
 #' @param qc_metrics QC metrics to apply. Available metrics are `"outlier"`,
@@ -38,12 +42,12 @@
 #' @examples
 #' data(visium_human_pancreas_sub)
 #' spatial <- RunSpotQC(
-#'   visium_human_pancreas_sub,
+#'   object = visium_human_pancreas_sub,
 #'   assay = "Spatial"
 #' )
-#' SpatialSpotPlot(spatial, group.by = "SpotQC")
+#' SpatialSpotPlot(object = spatial, group.by = "SpotQC")
 RunSpotQC <- function(
-  srt,
+  srt = NULL,
   assay = NULL,
   return_filtered = FALSE,
   qc_metrics = c("outlier", "umi", "gene", "mito"),
@@ -59,19 +63,15 @@ RunSpotQC <- function(
   mito_pattern = c("MT-", "Mt-", "mt-"),
   mito_gene = NULL,
   verbose = TRUE,
-  seed = 11
+  seed = 11,
+  object = NULL
 ) {
+  srt <- spatial_resolve_srt(srt = srt, object = object)
   log_message(
     "Running spot-level quality control",
     message_type = "running",
     verbose = verbose
   )
-  if (!inherits(srt, "Seurat")) {
-    log_message(
-      "{.arg srt} must be a {.cls Seurat} object",
-      message_type = "error"
-    )
-  }
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
   if (!assay %in% SeuratObject::Assays(srt)) {
     log_message(

--- a/R/SpatialSpotPlot.R
+++ b/R/SpatialSpotPlot.R
@@ -3,6 +3,10 @@
 #' @md
 #' @inheritParams CellDimPlot
 #' @inheritParams scop-params
+#' @param srt A `Seurat` object. The same object may be supplied as
+#' `object =` for consistency with spatial plotting APIs.
+#' @param object Optional alias for `srt`. Supply exactly one of `srt` or
+#' `object`.
 #' @param group.by Metadata columns to color spots by.
 #' @param features Features to color spots by (from `assay`/`layer`).
 #' @param values Spot-level values (named vector, matrix, or data.frame).
@@ -33,17 +37,17 @@
 #' @examples
 #' data(visium_human_pancreas_sub)
 #' SpatialSpotPlot(
-#'   visium_human_pancreas_sub,
+#'   object = visium_human_pancreas_sub,
 #'   group.by = "coda_label"
 #' )
 #'
 #' SpatialSpotPlot(
-#'   visium_human_pancreas_sub,
+#'   object = visium_human_pancreas_sub,
 #'   features = rownames(visium_human_pancreas_sub)[1:2],
 #'   layer = "counts"
 #' )
 SpatialSpotPlot <- function(
-  srt,
+  srt = NULL,
   group.by = NULL,
   features = NULL,
   assay = NULL,
@@ -84,14 +88,10 @@ SpatialSpotPlot <- function(
   ncol = NULL,
   byrow = TRUE,
   verbose = TRUE,
-  image.scale = c("lowres", "hires")
+  image.scale = c("lowres", "hires"),
+  object = NULL
 ) {
-  if (!inherits(srt, "Seurat")) {
-    log_message(
-      "{.arg srt} must be a {.cls Seurat} object",
-      message_type = "error"
-    )
-  }
+  srt <- spatial_resolve_srt(srt = srt, object = object)
   plot_type <- match.arg(plot_type)
   geom <- match.arg(geom)
   image.scale <- match.arg(image.scale)

--- a/R/SpatialSpotPlot.R
+++ b/R/SpatialSpotPlot.R
@@ -88,8 +88,8 @@ SpatialSpotPlot <- function(
   ncol = NULL,
   byrow = TRUE,
   verbose = TRUE,
-  image.scale = c("lowres", "hires"),
-  object = NULL
+  object = NULL,
+  image.scale = c("lowres", "hires")
 ) {
   srt <- spatial_resolve_srt(srt = srt, object = object)
   plot_type <- match.arg(plot_type)

--- a/R/SpatialUtils.R
+++ b/R/SpatialUtils.R
@@ -1,5 +1,35 @@
 # Internal helpers shared by spatial workflow wrappers.
 
+# Resolve the common Seurat-object input used by native spatial functions.
+#
+# Spatial plotting and analysis APIs historically used `srt`, while some
+# result-oriented plotting APIs use `object`. Keep `srt` as the documented
+# primary name for backwards compatibility and accept `object` as an explicit
+# alias so named calls are consistent from a user's perspective.
+spatial_resolve_srt <- function(srt = NULL, object = NULL) {
+  if (!is.null(srt) && !is.null(object)) {
+    log_message(
+      "Provide only one of {.arg srt} or {.arg object}",
+      message_type = "error"
+    )
+  }
+  input_arg <- if (is.null(srt)) "object" else "srt"
+  resolved <- if (is.null(srt)) object else srt
+  if (is.null(resolved)) {
+    log_message(
+      "Provide a {.cls Seurat} object through {.arg srt} or {.arg object}",
+      message_type = "error"
+    )
+  }
+  if (!inherits(resolved, "Seurat")) {
+    log_message(
+      "{.arg {input_arg}} must be a {.cls Seurat} object",
+      message_type = "error"
+    )
+  }
+  resolved
+}
+
 spatial_resolve_coord_cols <- function(srt, coord.cols = c("col", "row")) {
   if (!inherits(srt, "Seurat")) {
     log_message("{.arg srt} must be a {.cls Seurat} object", message_type = "error")

--- a/man/RunSpatialNetwork.Rd
+++ b/man/RunSpatialNetwork.Rd
@@ -5,7 +5,7 @@
 \title{Build a native spatial network}
 \usage{
 RunSpatialNetwork(
-  srt,
+  srt = NULL,
   method = c("knn", "radius"),
   image = NULL,
   coord.cols = c("col", "row"),
@@ -13,11 +13,16 @@ RunSpatialNetwork(
   radius = NULL,
   graph.name = NULL,
   overwrite = FALSE,
-  verbose = TRUE
+  verbose = TRUE,
+  object = NULL
 )
 }
 \arguments{
-\item{srt}{A `Seurat` object.}
+\item{srt}{A `Seurat` object. The same object may be supplied as
+\code{object =} for consistency with spatial plotting APIs.}
+
+\item{object}{Optional alias for \code{srt}. Supply exactly one of \code{srt} or
+\code{object}.}
 
 \item{method}{Network method, either `"knn"` or `"radius"`.}
 

--- a/man/RunSpatialVariableFeatures.Rd
+++ b/man/RunSpatialVariableFeatures.Rd
@@ -5,7 +5,7 @@
 \title{Run spatial variable feature detection}
 \usage{
 RunSpatialVariableFeatures(
-  srt,
+  srt = NULL,
   assay = NULL,
   layer = "data",
   features = NULL,
@@ -22,11 +22,16 @@ RunSpatialVariableFeatures(
   seed = 11,
   coordinate_space = c("raw", "legacy_display"),
   backend = c("cpp", "r"),
-  ...
+  ...,
+  object = NULL
 )
 }
 \arguments{
-\item{srt}{A \code{Seurat} object.}
+\item{srt}{A \code{Seurat} object. The same object may be supplied as
+\code{object =} for consistency with spatial plotting APIs.}
+
+\item{object}{Optional alias for \code{srt}. Supply exactly one of \code{srt} or
+\code{object}.}
 
 \item{assay}{Assay to use. \code{NULL} uses the default assay.}
 

--- a/man/RunSpotQC.Rd
+++ b/man/RunSpotQC.Rd
@@ -5,7 +5,7 @@
 \title{Run spot-level quality control}
 \usage{
 RunSpotQC(
-  srt,
+  srt = NULL,
   assay = NULL,
   return_filtered = FALSE,
   qc_metrics = c("outlier", "umi", "gene", "mito"),
@@ -18,11 +18,16 @@ RunSpotQC(
   mito_pattern = c("MT-", "Mt-", "mt-"),
   mito_gene = NULL,
   verbose = TRUE,
-  seed = 11
+  seed = 11,
+  object = NULL
 )
 }
 \arguments{
-\item{srt}{A \code{Seurat} object.}
+\item{srt}{A \code{Seurat} object. The same object may be supplied as
+\code{object =} for consistency with spatial plotting APIs.}
+
+\item{object}{Optional alias for \code{srt}. Supply exactly one of \code{srt} or
+\code{object}.}
 
 \item{assay}{Assay to use. \code{NULL} uses the default assay.}
 

--- a/man/SpatialSpotPlot.Rd
+++ b/man/SpatialSpotPlot.Rd
@@ -46,8 +46,8 @@ SpatialSpotPlot(
   ncol = NULL,
   byrow = TRUE,
   verbose = TRUE,
-  image.scale = c("lowres", "hires"),
-  object = NULL
+  object = NULL,
+  image.scale = c("lowres", "hires")
 )
 }
 \arguments{

--- a/man/SpatialSpotPlot.Rd
+++ b/man/SpatialSpotPlot.Rd
@@ -5,7 +5,7 @@
 \title{Spatial spot plot}
 \usage{
 SpatialSpotPlot(
-  srt,
+  srt = NULL,
   group.by = NULL,
   features = NULL,
   assay = NULL,
@@ -46,11 +46,16 @@ SpatialSpotPlot(
   ncol = NULL,
   byrow = TRUE,
   verbose = TRUE,
-  image.scale = c("lowres", "hires")
+  image.scale = c("lowres", "hires"),
+  object = NULL
 )
 }
 \arguments{
-\item{srt}{A \code{Seurat} object.}
+\item{srt}{A \code{Seurat} object. The same object may be supplied as
+\code{object =} for consistency with spatial plotting APIs.}
+
+\item{object}{Optional alias for \code{srt}. Supply exactly one of \code{srt} or
+\code{object}.}
 
 \item{group.by}{Metadata columns to color spots by.}
 

--- a/man/SpatialVariableFeaturePlot.Rd
+++ b/man/SpatialVariableFeaturePlot.Rd
@@ -29,8 +29,8 @@ SpatialVariableFeaturePlot(
   nrow = NULL,
   ncol = NULL,
   byrow = TRUE,
-  image.scale = c("lowres", "hires"),
-  object = NULL
+  object = NULL,
+  image.scale = c("lowres", "hires")
 )
 }
 \arguments{

--- a/man/SpatialVariableFeaturePlot.Rd
+++ b/man/SpatialVariableFeaturePlot.Rd
@@ -5,7 +5,7 @@
 \title{Plot spatial variable feature results}
 \usage{
 SpatialVariableFeaturePlot(
-  srt,
+  srt = NULL,
   plot_type = c("summary", "surface", "combined"),
   features = NULL,
   nfeatures = 10,
@@ -29,11 +29,16 @@ SpatialVariableFeaturePlot(
   nrow = NULL,
   ncol = NULL,
   byrow = TRUE,
-  image.scale = c("lowres", "hires")
+  image.scale = c("lowres", "hires"),
+  object = NULL
 )
 }
 \arguments{
-\item{srt}{A \code{Seurat} object.}
+\item{srt}{A \code{Seurat} object. The same object may be supplied as
+\code{object =} for consistency with spatial plotting APIs.}
+
+\item{object}{Optional alias for \code{srt}. Supply exactly one of \code{srt} or
+\code{object}.}
 
 \item{plot_type}{Plot type: \code{"summary"}, \code{"surface"}, or \code{"combined"}.}
 

--- a/tests/testthat/test-spatial-object-alias.R
+++ b/tests/testthat/test-spatial-object-alias.R
@@ -1,0 +1,96 @@
+make_spatial_object_alias_fixture <- function() {
+  counts <- matrix(
+    c(
+      5, 4, 0, 1, 5, 4, 0, 1, 5,
+      0, 1, 4, 5, 0, 1, 4, 5, 0,
+      1, 1, 1, 1, 1, 1, 1, 1, 1,
+      3, 0, 3, 0, 3, 0, 3, 0, 3
+    ),
+    nrow = 4,
+    byrow = TRUE,
+    dimnames = list(
+      paste0("Gene", 1:4),
+      paste0("Spot", 1:9)
+    )
+  )
+  srt <- suppressWarnings(Seurat::CreateSeuratObject(counts = counts))
+  srt$x <- rep(1:3, 3)
+  srt$y <- rep(1:3, each = 3)
+  srt
+}
+
+test_that("native spatial APIs accept object as an input alias", {
+  skip_if_not_installed("BiocNeighbors")
+  srt <- make_spatial_object_alias_fixture()
+
+  qc <- suppressWarnings(RunSpotQC(
+    object = srt,
+    assay = "RNA",
+    qc_metrics = c("umi", "gene"),
+    UMI_threshold = 0,
+    gene_threshold = 0,
+    verbose = FALSE
+  ))
+  expect_s4_class(qc, "Seurat")
+  expect_s3_class(
+    SpatialSpotPlot(
+      object = qc,
+      group.by = "SpotQC",
+      overlay_image = FALSE,
+      theme_use = NULL
+    ),
+    "ggplot"
+  )
+
+  network <- RunSpatialNetwork(
+    object = qc,
+    k = 1,
+    verbose = FALSE
+  )
+  expect_s4_class(network, "Seurat")
+  expect_s3_class(
+    SpatialNetworkPlot(
+      object = network,
+      graph.name = "knn_k1",
+      theme_use = NULL
+    ),
+    "ggplot"
+  )
+
+  svf <- RunSpatialVariableFeatures(
+    object = network,
+    assay = "RNA",
+    layer = "counts",
+    method = "moran",
+    backend = "r",
+    coord.cols = c("x", "y"),
+    nfeatures = 2,
+    min_spots = 1,
+    verbose = FALSE
+  )
+  expect_s4_class(svf, "Seurat")
+  expect_s3_class(
+    SpatialVariableFeaturePlot(
+      object = svf,
+      plot_type = "summary",
+      theme_use = NULL
+    ),
+    "ggplot"
+  )
+})
+
+test_that("spatial object aliases reject ambiguous or missing input", {
+  srt <- make_spatial_object_alias_fixture()
+  expect_error(
+    RunSpotQC(srt = srt, object = srt, verbose = FALSE),
+    "only one of.*srt.*object"
+  )
+  expect_error(
+    SpatialSpotPlot(verbose = FALSE),
+    "through.*srt.*object"
+  )
+  expect_error(
+    RunSpatialNetwork(object = list(), verbose = FALSE),
+    "object.*Seurat"
+  )
+})


### PR DESCRIPTION
## Summary
- accept `object =` as a backwards-compatible alias for the Seurat input in native spatial QC, plotting, network, and spatial-variable-feature APIs
- reject ambiguous calls that provide both `srt` and `object`, with a clear input error when neither is supplied
- update spatial examples and generated Rd usage to demonstrate the consistent named-object form
- add an end-to-end regression test covering QC, spot/network/SVF plots, KNN storage, and input validation

## Validation
- `pkgload::load_all('.', quiet = TRUE, compile = FALSE)`
- `testthat::test_file('tests/testthat/test-spatial-object-alias.R')`
- targeted spatial tests: `test-spatial-core.R`, `test-spatial-utils.R`, `test-spatial-network-receipt.R`, `test-spatial-variable-features.R`, `test-spatial-run-receipt.R`
- independent `R CMD INSTALL --preclean` succeeded on Windows R 4.5.2

The required `rcmdcheck` wrapper reached package checks but exited while parsing the very large Windows compiler output (`embedded nul`); this is recorded as an environment/tooling limitation, not as a passing full check.

Existing unstaged thin-receipt work was intentionally kept out of this PR.