### PR TITLE
Fix remaining reference examples and clarify optional templates

### DIFF
--- a/R/RunBayesSpace.R
+++ b/R/RunBayesSpace.R
@@ -37,7 +37,7 @@
 #'   n.PCs = 5,
 #'   n.HVGs = 200,
 #'   store_sce = FALSE,
-#'   spatial_cluster_params = list(nrep = 20, burn.in = 10, thin = 5),
+#'   spatial_cluster_params = list(nrep = 100, burn.in = 10, thin = 5),
 #'   coord.cols = c("x", "y"),
 #'   verbose = FALSE
 #' )

--- a/R/RunCARD.R
+++ b/R/RunCARD.R
@@ -3,7 +3,8 @@
 #' @description
 #' Estimate spot-level cell-type proportions from a spatial `Seurat` object
 #' using a single-cell `Seurat` reference and the optional `CARD`/`CARDspa`
-#' backend.
+#' backend. The example is a non-executing template because CARD installation
+#' and execution are optional.
 #'
 #' @md
 #' @inheritParams RunRCTD
@@ -25,6 +26,7 @@
 #'
 #' @examples
 #' \dontrun{
+#' check_r("YingMa0107/CARD", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' data(panc8_sub)
 #' keep_spots <- unique(round(seq(

--- a/R/RunCARD.R
+++ b/R/RunCARD.R
@@ -26,7 +26,7 @@
 #'
 #' @examples
 #' \dontrun{
-#' check_r("YingMa0107/CARD", verbose = FALSE)
+#' thisutils::check_r("YingMa0107/CARD", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' data(panc8_sub)
 #' keep_spots <- unique(round(seq(

--- a/R/RunCSIDE.R
+++ b/R/RunCSIDE.R
@@ -46,7 +46,7 @@
 #'
 #' @examples
 #' \dontrun{
-#' check_r("dmcable/spacexr", verbose = FALSE)
+#' thisutils::check_r("dmcable/spacexr", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' data(panc8_sub)
 #' keep_spots <- unique(round(seq(

--- a/R/RunCSIDE.R
+++ b/R/RunCSIDE.R
@@ -6,7 +6,8 @@
 #' significance results, not spot-level cell-type proportions, so it has no
 #' recommended proportion plot. Inspect its stored
 #' tables in `srt@tools[[tool_name]]` or plot an explicit summary column with
-#' [SpatialSpotPlot()].
+#' [SpatialSpotPlot()]. The example is a non-executing template because C-SIDE
+#' requires a completed optional RCTD result.
 #'
 #' @md
 #' @inheritParams RunRCTD
@@ -45,6 +46,7 @@
 #'
 #' @examples
 #' \dontrun{
+#' check_r("dmcable/spacexr", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' data(panc8_sub)
 #' keep_spots <- unique(round(seq(

--- a/R/RunCell2location.R
+++ b/R/RunCell2location.R
@@ -63,7 +63,6 @@
 #' \dontrun{
 #' # Official cell2location Human Lymph Node tutorial data:
 #' # https://cell2location.readthedocs.io/en/latest/notebooks/cell2location_tutorial.html
-#' check_python(c("cell2location", "scanpy", "anndata"))
 #' reference <- h5ad_to_srt("reference_subset.h5ad")
 #' spatial <- h5ad_to_srt("spatial_subset.h5ad")
 #' spatial <- RunCell2location(

--- a/R/RunCell2location.R
+++ b/R/RunCell2location.R
@@ -4,7 +4,8 @@
 #' Estimate spot-level absolute cell abundance and proportions with the official
 #' Python `cell2location` backend. The Python model runs in an isolated
 #' subprocess while inputs, models, posterior outputs, logs, and a reproducible
-#' manifest are persisted under `result_dir`.
+#' manifest are persisted under `result_dir`. The example uses the official
+#' Human Lymph Node tutorial files; those input files are not bundled with SCOP.
 #'
 #' @md
 #' @inheritParams thisutils::log_message
@@ -62,6 +63,7 @@
 #' \dontrun{
 #' # Official cell2location Human Lymph Node tutorial data:
 #' # https://cell2location.readthedocs.io/en/latest/notebooks/cell2location_tutorial.html
+#' check_python(c("cell2location", "scanpy", "anndata"))
 #' reference <- h5ad_to_srt("reference_subset.h5ad")
 #' spatial <- h5ad_to_srt("spatial_subset.h5ad")
 #' spatial <- RunCell2location(
@@ -437,6 +439,7 @@ RunCell2location <- function(
 #' @examples
 #' \dontrun{
 #' # Result from the official Human Lymph Node example in RunCell2location().
+#' # The tutorial result is an external file and is not downloaded by pkgdown.
 #' spatial <- readRDS("human_lymph_node_cell2location/official_human_lymph_node.rds")
 #' selected <- names(sort(
 #'   colMeans(spatial@tools$Cell2location$proportions),

--- a/R/RunCellTypist.R
+++ b/R/RunCellTypist.R
@@ -439,7 +439,8 @@ TrainCellTypist <- function(
 #' @description
 #' Unified CellTypist model management interface. Use it to list available models,
 #' download models, inspect model metadata, extract model markers, subset models,
-#' convert models, or delete local models.
+#' convert models, or delete local models. Model listing and file-management
+#' examples are non-executing because they may download or modify local files.
 #'
 #' @md
 #' @inheritParams thisutils::log_message

--- a/R/RunKNNMap.R
+++ b/R/RunKNNMap.R
@@ -56,8 +56,7 @@
 #'   srt_query = srt_query,
 #'   srt_ref = srt_ref,
 #'   query_group = "celltype",
-#'   ref_group = "celltype",
-#'   legend.position = "bottom"
+#'   ref_group = "celltype"
 #' )
 RunKNNMap <- function(
   srt_query,

--- a/R/RunKNNPredict.R
+++ b/R/RunKNNPredict.R
@@ -66,9 +66,15 @@
 #' @examples
 #' data(panc8_sub)
 #' keep <- panc8_sub$celltype %in% c("ductal", "alpha", "beta")
-#' reference <- panc8_sub[, keep & panc8_sub$tech != "fluidigmc1"]
-#' query <- panc8_sub[, keep & panc8_sub$tech == "fluidigmc1"]
-#' genes <- intersect(rownames(reference), rownames(query))[1:200]
+#' reference <- Seurat::NormalizeData(
+#'   panc8_sub[, keep & panc8_sub$tech != "fluidigmc1"],
+#'   verbose = FALSE
+#' )
+#' query <- Seurat::NormalizeData(
+#'   panc8_sub[, keep & panc8_sub$tech == "fluidigmc1"],
+#'   verbose = FALSE
+#' )
+#' genes <- head(intersect(rownames(reference), rownames(query)), 200)
 #' query <- RunKNNPredict(
 #'   query, srt_ref = reference, ref_group = "celltype",
 #'   features = genes, nfeatures = length(genes),
@@ -79,7 +85,12 @@
 #'   query, group.by = "KNNPredict_classification",
 #'   label = TRUE, legend.position = "bottom"
 #' )
-#' FeatureDimPlot(query, features = "KNNPredict_simil")
+#' FeatureStatPlot(
+#'   query,
+#'   stat.by = "KNNPredict_prob",
+#'   group.by = "KNNPredict_classification",
+#'   plot_type = "box"
+#' )
 RunKNNPredict <- function(
   srt_query,
   srt_ref = NULL,

--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -49,7 +49,7 @@
 #'
 #' @examples
 #' \dontrun{
-#' check_r("dmcable/spacexr", verbose = FALSE)
+#' thisutils::check_r("dmcable/spacexr", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' data(panc8_sub)
 #' keep_spots <- unique(round(seq(

--- a/R/RunRCTD.R
+++ b/R/RunRCTD.R
@@ -2,7 +2,9 @@
 #'
 #' @description
 #' Estimate spot-level cell type proportions from a spatial `Seurat` object
-#' using a single-cell `Seurat` reference and `spacexr` RCTD.
+#' using a single-cell `Seurat` reference and the optional `spacexr` RCTD
+#' backend. The example is a non-executing template so pkgdown does not need
+#' to install or run this heavy optional dependency.
 #'
 #' @md
 #' @inheritParams thisutils::log_message
@@ -47,6 +49,7 @@
 #'
 #' @examples
 #' \dontrun{
+#' check_r("dmcable/spacexr", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' data(panc8_sub)
 #' keep_spots <- unique(round(seq(

--- a/R/RunSPOTlight.R
+++ b/R/RunSPOTlight.R
@@ -3,6 +3,8 @@
 #' @description
 #' Estimate spot-level cell type proportions from a spatial `Seurat` object
 #' using a single-cell `Seurat` reference and the optional `SPOTlight` package.
+#' The example is a non-executing template because the backend is optional and
+#' may require additional Bioconductor dependencies.
 #'
 #' @md
 #' @inheritParams RunRCTD
@@ -27,6 +29,7 @@
 #'
 #' @examples
 #' \dontrun{
+#' check_r("SPOTlight", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' data(panc8_sub)
 #' keep_spots <- unique(round(seq(

--- a/R/RunSPOTlight.R
+++ b/R/RunSPOTlight.R
@@ -29,7 +29,7 @@
 #'
 #' @examples
 #' \dontrun{
-#' check_r("SPOTlight", verbose = FALSE)
+#' thisutils::check_r("SPOTlight", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' data(panc8_sub)
 #' keep_spots <- unique(round(seq(

--- a/R/RunSTdeconvolve.R
+++ b/R/RunSTdeconvolve.R
@@ -32,7 +32,7 @@
 #'
 #' @examples
 #' \dontrun{
-#' check_r("JEFworks-Lab/STdeconvolve", verbose = FALSE)
+#' thisutils::check_r("JEFworks-Lab/STdeconvolve", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' keep_spots <- unique(round(seq(
 #'   1,

--- a/R/RunSTdeconvolve.R
+++ b/R/RunSTdeconvolve.R
@@ -2,7 +2,9 @@
 #'
 #' @description
 #' Estimate spot-level topic proportions from a spatial `Seurat` object using
-#' the optional `STdeconvolve` package.
+#' the optional `STdeconvolve` package. The producer example is a
+#' non-executing template; [STdeconvolvePlot()] demonstrates a validated stored
+#' result without rerunning the backend.
 #'
 #' @md
 #' @inheritParams RunRCTD
@@ -30,6 +32,7 @@
 #'
 #' @examples
 #' \dontrun{
+#' check_r("JEFworks-Lab/STdeconvolve", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' keep_spots <- unique(round(seq(
 #'   1,

--- a/R/RunSpaNorm.R
+++ b/R/RunSpaNorm.R
@@ -27,7 +27,7 @@
 #'
 #' @examples
 #' \dontrun{
-#' check_r("SpaNorm", verbose = FALSE)
+#' thisutils::check_r("SpaNorm", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' keep_spots <- unique(round(seq(
 #'   1,

--- a/R/RunSpaNorm.R
+++ b/R/RunSpaNorm.R
@@ -3,6 +3,9 @@
 #' @description
 #' Normalize spatial transcriptomics counts with the optional Bioconductor
 #' `SpaNorm` backend and store the normalized expression in a new Seurat assay.
+#' The example is a non-executing template because the optional backend and its
+#' platform-specific numerical requirements are not part of a standard SCOP
+#' installation.
 #'
 #' @md
 #' @inheritParams RunSpatialVariableFeatures
@@ -24,6 +27,7 @@
 #'
 #' @examples
 #' \dontrun{
+#' check_r("SpaNorm", verbose = FALSE)
 #' data(visium_human_pancreas_sub)
 #' keep_spots <- unique(round(seq(
 #'   1,

--- a/R/RunSpatialEcoTyper.R
+++ b/R/RunSpatialEcoTyper.R
@@ -331,6 +331,8 @@ RunSpatialEcoTyper <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_pair_sub)
+#' # The stored `domain` column is a real PRECAST grouping used only for this
+#' # fast spatial plotting example; it is not a new SpatialEcoTyper inference.
 #' SpatialEcoTyperSpatialPlot(
 #'   visium_human_pancreas_pair_sub,
 #'   group.by = "domain",
@@ -392,8 +394,11 @@ SpatialEcoTyperSpatialPlot <- function(
 #'
 #' @examples
 #' data(visium_human_pancreas_pair_sub)
+#' # This fixture stores real PRECAST domains for a fast plot demonstration;
+#' # use `se.by = "domain"` explicitly because it is not a new SE inference.
 #' SpatialEcoTyperCompositionPlot(
 #'   visium_human_pancreas_pair_sub,
+#'   se.by = "domain",
 #'   group.by = "coda_label",
 #'   sample.by = "sample",
 #'   position = "fill"

--- a/R/RunSpatialNeighborhood.R
+++ b/R/RunSpatialNeighborhood.R
@@ -56,9 +56,6 @@
 #'   verbose = FALSE
 #' )
 #'
-#' SpatialNeighborhoodPlot(spatial, plot_type = "heatmap")
-#' SpatialNeighborhoodPlot(spatial, plot_type = "network", top_n = 12)
-#' SpatialNeighborhoodPlot(spatial, plot_type = "stat", top_n = 12)
 #' SpatialNeighborhoodPlot(
 #'   spatial,
 #'   plot_type = "spatial",
@@ -255,21 +252,9 @@ RunSpatialNeighborhood <- function(
 #' @export
 #'
 #' @examples
-#' data(visium_human_pancreas_sub)
-#' spatial <- visium_human_pancreas_sub
-#' spatial <- RunSpatialNeighborhood(
-#'   spatial,
-#'   group.by = "coda_label",
-#'   coord.cols = c("x", "y"),
-#'   k = 4,
-#'   verbose = FALSE
-#' )
-#'
-#' SpatialNeighborhoodPlot(spatial, plot_type = "heatmap")
-#' SpatialNeighborhoodPlot(spatial, plot_type = "network", top_n = 12)
-#' SpatialNeighborhoodPlot(spatial, plot_type = "stat", top_n = 12)
+#' data(visium_human_pancreas_results_sub)
 #' SpatialNeighborhoodPlot(
-#'   spatial,
+#'   visium_human_pancreas_results_sub,
 #'   plot_type = "spatial",
 #'   overlay_image = FALSE,
 #'   coord.cols = c("x", "y")

--- a/man/Cell2locationPlot.Rd
+++ b/man/Cell2locationPlot.Rd
@@ -52,6 +52,7 @@ Plot cell2location spatial results
 \examples{
 \dontrun{
 # Result from the official Human Lymph Node example in RunCell2location().
+# The tutorial result is an external file and is not downloaded by pkgdown.
 spatial <- readRDS("human_lymph_node_cell2location/official_human_lymph_node.rds")
 selected <- names(sort(
   colMeans(spatial@tools$Cell2location$proportions),

--- a/man/CellTypistModels.Rd
+++ b/man/CellTypistModels.Rd
@@ -72,7 +72,8 @@ Depends on \code{action}: a data frame, a summary list, or a character vector.
 \description{
 Unified CellTypist model management interface. Use it to list available models,
 download models, inspect model metadata, extract model markers, subset models,
-convert models, or delete local models.
+convert models, or delete local models. Model listing and file-management
+examples are non-executing because they may download or modify local files.
 }
 \examples{
 \dontrun{

--- a/man/RunBayesSpace.Rd
+++ b/man/RunBayesSpace.Rd
@@ -83,7 +83,7 @@ spatial <- RunBayesSpace(
   n.PCs = 5,
   n.HVGs = 200,
   store_sce = FALSE,
-  spatial_cluster_params = list(nrep = 20, burn.in = 10, thin = 5),
+  spatial_cluster_params = list(nrep = 100, burn.in = 10, thin = 5),
   coord.cols = c("x", "y"),
   verbose = FALSE
 )

--- a/man/RunCARD.Rd
+++ b/man/RunCARD.Rd
@@ -100,7 +100,7 @@ and execution are optional.
 }
 \examples{
 \dontrun{
-check_r("YingMa0107/CARD", verbose = FALSE)
+thisutils::check_r("YingMa0107/CARD", verbose = FALSE)
 data(visium_human_pancreas_sub)
 data(panc8_sub)
 keep_spots <- unique(round(seq(

--- a/man/RunCARD.Rd
+++ b/man/RunCARD.Rd
@@ -95,10 +95,12 @@ are stored in \code{srt@tools[[tool_name]]}.
 \description{
 Estimate spot-level cell-type proportions from a spatial \code{Seurat} object
 using a single-cell \code{Seurat} reference and the optional \code{CARD}/\code{CARDspa}
-backend.
+backend. The example is a non-executing template because CARD installation
+and execution are optional.
 }
 \examples{
 \dontrun{
+check_r("YingMa0107/CARD", verbose = FALSE)
 data(visium_human_pancreas_sub)
 data(panc8_sub)
 keep_spots <- unique(round(seq(

--- a/man/RunCSIDE.Rd
+++ b/man/RunCSIDE.Rd
@@ -93,7 +93,7 @@ requires a completed optional RCTD result.
 }
 \examples{
 \dontrun{
-check_r("dmcable/spacexr", verbose = FALSE)
+thisutils::check_r("dmcable/spacexr", verbose = FALSE)
 data(visium_human_pancreas_sub)
 data(panc8_sub)
 keep_spots <- unique(round(seq(

--- a/man/RunCSIDE.Rd
+++ b/man/RunCSIDE.Rd
@@ -88,10 +88,12 @@ condition-aware differential expression. C-SIDE stores effect and
 significance results, not spot-level cell-type proportions, so it has no
 recommended proportion plot. Inspect its stored
 tables in \code{srt@tools[[tool_name]]} or plot an explicit summary column with
-\code{\link[=SpatialSpotPlot]{SpatialSpotPlot()}}.
+\code{\link[=SpatialSpotPlot]{SpatialSpotPlot()}}. The example is a non-executing template because C-SIDE
+requires a completed optional RCTD result.
 }
 \examples{
 \dontrun{
+check_r("dmcable/spacexr", verbose = FALSE)
 data(visium_human_pancreas_sub)
 data(panc8_sub)
 keep_spots <- unique(round(seq(

--- a/man/RunCell2location.Rd
+++ b/man/RunCell2location.Rd
@@ -125,7 +125,6 @@ model implemented by this function.
 \dontrun{
 # Official cell2location Human Lymph Node tutorial data:
 # https://cell2location.readthedocs.io/en/latest/notebooks/cell2location_tutorial.html
-check_python(c("cell2location", "scanpy", "anndata"))
 reference <- h5ad_to_srt("reference_subset.h5ad")
 spatial <- h5ad_to_srt("spatial_subset.h5ad")
 spatial <- RunCell2location(

--- a/man/RunCell2location.Rd
+++ b/man/RunCell2location.Rd
@@ -110,7 +110,8 @@ cell type, and maximum-proportion metadata.
 Estimate spot-level absolute cell abundance and proportions with the official
 Python \code{cell2location} backend. The Python model runs in an isolated
 subprocess while inputs, models, posterior outputs, logs, and a reproducible
-manifest are persisted under \code{result_dir}.
+manifest are persisted under \code{result_dir}. The example uses the official
+Human Lymph Node tutorial files; those input files are not bundled with SCOP.
 }
 \section{Official human lymph node result}{
 
@@ -124,6 +125,7 @@ model implemented by this function.
 \dontrun{
 # Official cell2location Human Lymph Node tutorial data:
 # https://cell2location.readthedocs.io/en/latest/notebooks/cell2location_tutorial.html
+check_python(c("cell2location", "scanpy", "anndata"))
 reference <- h5ad_to_srt("reference_subset.h5ad")
 spatial <- h5ad_to_srt("spatial_subset.h5ad")
 spatial <- RunCell2location(

--- a/man/RunKNNMap.Rd
+++ b/man/RunKNNMap.Rd
@@ -116,8 +116,7 @@ ProjectionPlot(
   srt_query = srt_query,
   srt_ref = srt_ref,
   query_group = "celltype",
-  ref_group = "celltype",
-  legend.position = "bottom"
+  ref_group = "celltype"
 )
 }
 \seealso{

--- a/man/RunKNNPredict.Rd
+++ b/man/RunKNNPredict.Rd
@@ -120,9 +120,15 @@ Performs KNN prediction to annotate cell types based on reference scRNA-seq or b
 \examples{
 data(panc8_sub)
 keep <- panc8_sub$celltype \%in\% c("ductal", "alpha", "beta")
-reference <- panc8_sub[, keep & panc8_sub$tech != "fluidigmc1"]
-query <- panc8_sub[, keep & panc8_sub$tech == "fluidigmc1"]
-genes <- intersect(rownames(reference), rownames(query))[1:200]
+reference <- Seurat::NormalizeData(
+  panc8_sub[, keep & panc8_sub$tech != "fluidigmc1"],
+  verbose = FALSE
+)
+query <- Seurat::NormalizeData(
+  panc8_sub[, keep & panc8_sub$tech == "fluidigmc1"],
+  verbose = FALSE
+)
+genes <- head(intersect(rownames(reference), rownames(query)), 200)
 query <- RunKNNPredict(
   query, srt_ref = reference, ref_group = "celltype",
   features = genes, nfeatures = length(genes),
@@ -133,7 +139,12 @@ CellDimPlot(
   query, group.by = "KNNPredict_classification",
   label = TRUE, legend.position = "bottom"
 )
-FeatureDimPlot(query, features = "KNNPredict_simil")
+FeatureStatPlot(
+  query,
+  stat.by = "KNNPredict_prob",
+  group.by = "KNNPredict_classification",
+  plot_type = "box"
+)
 }
 \seealso{
 \link{RunKNNMap}, \link{RunSingleR}, \link{CellCorHeatmap}

--- a/man/RunRCTD.Rd
+++ b/man/RunRCTD.Rd
@@ -99,7 +99,7 @@ to install or run this heavy optional dependency.
 }
 \examples{
 \dontrun{
-check_r("dmcable/spacexr", verbose = FALSE)
+thisutils::check_r("dmcable/spacexr", verbose = FALSE)
 data(visium_human_pancreas_sub)
 data(panc8_sub)
 keep_spots <- unique(round(seq(

--- a/man/RunRCTD.Rd
+++ b/man/RunRCTD.Rd
@@ -93,10 +93,13 @@ are also stored in \code{srt@tools[[tool_name]]}.
 }
 \description{
 Estimate spot-level cell type proportions from a spatial \code{Seurat} object
-using a single-cell \code{Seurat} reference and \code{spacexr} RCTD.
+using a single-cell \code{Seurat} reference and the optional \code{spacexr} RCTD
+backend. The example is a non-executing template so pkgdown does not need
+to install or run this heavy optional dependency.
 }
 \examples{
 \dontrun{
+check_r("dmcable/spacexr", verbose = FALSE)
 data(visium_human_pancreas_sub)
 data(panc8_sub)
 keep_spots <- unique(round(seq(
@@ -112,7 +115,6 @@ features_use <- head(intersect(
   SeuratObject::VariableFeatures(reference),
   rownames(spatial)
 ), 300)
-
 spatial <- RunRCTD(
   srt = spatial,
   reference = reference,

--- a/man/RunSPOTlight.Rd
+++ b/man/RunSPOTlight.Rd
@@ -85,7 +85,7 @@ may require additional Bioconductor dependencies.
 }
 \examples{
 \dontrun{
-check_r("SPOTlight", verbose = FALSE)
+thisutils::check_r("SPOTlight", verbose = FALSE)
 data(visium_human_pancreas_sub)
 data(panc8_sub)
 keep_spots <- unique(round(seq(

--- a/man/RunSPOTlight.Rd
+++ b/man/RunSPOTlight.Rd
@@ -80,9 +80,12 @@ are stored in \code{srt@tools[[tool_name]]}.
 \description{
 Estimate spot-level cell type proportions from a spatial \code{Seurat} object
 using a single-cell \code{Seurat} reference and the optional \code{SPOTlight} package.
+The example is a non-executing template because the backend is optional and
+may require additional Bioconductor dependencies.
 }
 \examples{
 \dontrun{
+check_r("SPOTlight", verbose = FALSE)
 data(visium_human_pancreas_sub)
 data(panc8_sub)
 keep_spots <- unique(round(seq(

--- a/man/RunSTdeconvolve.Rd
+++ b/man/RunSTdeconvolve.Rd
@@ -83,7 +83,7 @@ result without rerunning the backend.
 }
 \examples{
 \dontrun{
-check_r("JEFworks-Lab/STdeconvolve", verbose = FALSE)
+thisutils::check_r("JEFworks-Lab/STdeconvolve", verbose = FALSE)
 data(visium_human_pancreas_sub)
 keep_spots <- unique(round(seq(
   1,

--- a/man/RunSTdeconvolve.Rd
+++ b/man/RunSTdeconvolve.Rd
@@ -77,10 +77,13 @@ results stored in \code{srt@tools[[tool_name]]} when \code{store_results = TRUE}
 }
 \description{
 Estimate spot-level topic proportions from a spatial \code{Seurat} object using
-the optional \code{STdeconvolve} package.
+the optional \code{STdeconvolve} package. The producer example is a
+non-executing template; \code{\link[=STdeconvolvePlot]{STdeconvolvePlot()}} demonstrates a validated stored
+result without rerunning the backend.
 }
 \examples{
 \dontrun{
+check_r("JEFworks-Lab/STdeconvolve", verbose = FALSE)
 data(visium_human_pancreas_sub)
 keep_spots <- unique(round(seq(
   1,

--- a/man/RunSpaNorm.Rd
+++ b/man/RunSpaNorm.Rd
@@ -58,9 +58,13 @@ cells, and optional backend output are stored in \code{srt@tools[[tool_name]]}.
 \description{
 Normalize spatial transcriptomics counts with the optional Bioconductor
 \code{SpaNorm} backend and store the normalized expression in a new Seurat assay.
+The example is a non-executing template because the optional backend and its
+platform-specific numerical requirements are not part of a standard SCOP
+installation.
 }
 \examples{
 \dontrun{
+check_r("SpaNorm", verbose = FALSE)
 data(visium_human_pancreas_sub)
 keep_spots <- unique(round(seq(
   1,
@@ -78,7 +82,6 @@ spatial <- RunSpaNorm(
   sample.p = 0.25,
   verbose = FALSE
 )
-
 SpatialSpotPlot(
   spatial,
   features = rownames(spatial[["SpaNorm"]])[1],

--- a/man/RunSpaNorm.Rd
+++ b/man/RunSpaNorm.Rd
@@ -64,7 +64,7 @@ installation.
 }
 \examples{
 \dontrun{
-check_r("SpaNorm", verbose = FALSE)
+thisutils::check_r("SpaNorm", verbose = FALSE)
 data(visium_human_pancreas_sub)
 keep_spots <- unique(round(seq(
   1,

--- a/man/RunSpatialNeighborhood.Rd
+++ b/man/RunSpatialNeighborhood.Rd
@@ -103,9 +103,6 @@ spatial <- RunSpatialNeighborhood(
   verbose = FALSE
 )
 
-SpatialNeighborhoodPlot(spatial, plot_type = "heatmap")
-SpatialNeighborhoodPlot(spatial, plot_type = "network", top_n = 12)
-SpatialNeighborhoodPlot(spatial, plot_type = "stat", top_n = 12)
 SpatialNeighborhoodPlot(
   spatial,
   plot_type = "spatial",

--- a/man/SpatialEcoTyperCompositionPlot.Rd
+++ b/man/SpatialEcoTyperCompositionPlot.Rd
@@ -50,8 +50,11 @@ metadata groups using the default plotting theme and palettes.
 }
 \examples{
 data(visium_human_pancreas_pair_sub)
+# This fixture stores real PRECAST domains for a fast plot demonstration;
+# use `se.by = "domain"` explicitly because it is not a new SE inference.
 SpatialEcoTyperCompositionPlot(
   visium_human_pancreas_pair_sub,
+  se.by = "domain",
   group.by = "coda_label",
   sample.by = "sample",
   position = "fill"

--- a/man/SpatialEcoTyperSpatialPlot.Rd
+++ b/man/SpatialEcoTyperSpatialPlot.Rd
@@ -53,6 +53,8 @@ plotting style.
 }
 \examples{
 data(visium_human_pancreas_pair_sub)
+# The stored `domain` column is a real PRECAST grouping used only for this
+# fast spatial plotting example; it is not a new SpatialEcoTyper inference.
 SpatialEcoTyperSpatialPlot(
   visium_human_pancreas_pair_sub,
   group.by = "domain",

--- a/man/SpatialNeighborhoodPlot.Rd
+++ b/man/SpatialNeighborhoodPlot.Rd
@@ -88,7 +88,7 @@ differential neighborhood statistics.}
 
 \item{theme_args}{Theme name or function, plus extra theme arguments.}
 
-\item{combine, nrow, ncol, byrow}{Combine plots with \link[patchwork:patchwork]{patchwork}. \code{combine = FALSE}
+\item{combine, nrow, ncol, byrow}{Combine plots with \link[patchwork:patchwork-package]{patchwork::patchwork}. \code{combine = FALSE}
 returns a list of ggplots.}
 
 \item{seed}{Random seed used by layouts and jittered plot layers.}
@@ -110,21 +110,9 @@ Visualize results produced by \code{\link[=RunSpatialNeighborhood]{RunSpatialNei
 statistical, and network plotting conventions.
 }
 \examples{
-data(visium_human_pancreas_sub)
-spatial <- visium_human_pancreas_sub
-spatial <- RunSpatialNeighborhood(
-  spatial,
-  group.by = "coda_label",
-  coord.cols = c("x", "y"),
-  k = 4,
-  verbose = FALSE
-)
-
-SpatialNeighborhoodPlot(spatial, plot_type = "heatmap")
-SpatialNeighborhoodPlot(spatial, plot_type = "network", top_n = 12)
-SpatialNeighborhoodPlot(spatial, plot_type = "stat", top_n = 12)
+data(visium_human_pancreas_results_sub)
 SpatialNeighborhoodPlot(
-  spatial,
+  visium_human_pancreas_results_sub,
   plot_type = "spatial",
   overlay_image = FALSE,
   coord.cols = c("x", "y")


### PR DESCRIPTION
Follow-up to #394. Fixes the four reference pages that rendered actual example errors: remove the unsupported legend.position from RunKNNMap; normalize panc8 reference/query data before RunKNNPredict and plot the real KNNPredict_prob metadata; raise BayesSpace nrep to the backend minimum of 100; and set se.by = domain in SpatialEcoTyperCompositionPlot. The corrected BayesSpace, KNNMap, KNNPredict, EcoTyper composition, and neighborhood examples were run locally, and targeted pkgdown produced no r-err output. Also reduces RunSpatialNeighborhood/SpatialNeighborhoodPlot to one representative stored-result plot and adds explicit optional-backend/tutorial-file explanations plus check_r/check_python calls to non-executing templates. No workflow, public signature, or DESCRIPTION dependency changes.