### PR TITLE
fix(spatial): make gradient storage and feature selection independent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # scop 0.9.1
 
+* **fix**: Gradient result storage and VariableFeatures updates are independent; explicit empty updates clear VariableFeatures and completion messages describe actual actions.
+
 * **feat**:
   * `RunDEtest()` sample-level methods gain `min.cells.sample` (default `10`) to drop pseudobulk samples whose cell count in the current `group.by` level is below a threshold, which can reverse DE direction relative to cell-level tests. Set `min.cells.sample = 1` to keep the previous unfiltered behavior.
   * Internal preprocessing and integration workflows now use scop's Seurat-compatible entry points, enabling validated native acceleration for normalization, variable-feature selection, scaling, PCA, and neighbor search while retaining transparent Seurat fallback for unsupported paths.

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -52,13 +52,16 @@
 #' @param nfeatures Number of top gradient variables retained in
 #' `top_variables` and optionally set as Seurat variable features.
 #' @param set_variable_features Whether to set top gradient variables as Seurat
-#' variable features.
+#' variable features independently of `store_results`. If explicitly `TRUE`,
+#' an empty selection clears the target assay's variable features.
 #' @param store_results Whether to store the normalized result in `srt@tools`.
 #' @param ... Additional named arguments accepted for compatibility. The native
 #' backend ignores them and does not store them as effective parameters.
 #'
-#' @return A `Seurat` object with spatial gradient screening results stored in
-#' `srt@tools[["SpatialGradientFeatures"]]`.
+#' @return A `Seurat` object. When `store_results = TRUE`, spatial gradient
+#' screening results are stored in `srt@tools[["SpatialGradientFeatures"]]`.
+#' Otherwise existing stored results are unchanged. Variable features are
+#' independently updated only when `set_variable_features = TRUE`.
 #' @export
 #'
 #' @examples
@@ -137,6 +140,12 @@ RunSpatialGradientFeatures <- function(
   coordinate_space = c("raw", "legacy_display"),
   ...
 ) {
+  for (flag in c("store_results", "set_variable_features")) {
+    value <- get(flag)
+    if (!is.logical(value) || length(value) != 1L || is.na(value)) {
+      stop(paste0(flag, " must be a single non-missing logical value"), call. = FALSE)
+    }
+  }
   if (!inherits(srt, "Seurat")) {
     log_message("{.arg srt} must be a {.cls Seurat} object", message_type = "error")
   }
@@ -232,6 +241,10 @@ RunSpatialGradientFeatures <- function(
     )
   }
 
+  vars <- sgf_validate_result(result)
+  if (isTRUE(set_variable_features) && any(!vars %in% rownames(srt[[assay]]))) {
+    stop("Spatial gradient result contains variables absent from the target assay", call. = FALSE)
+  }
   if (isTRUE(store_results)) {
     source <- result$source %||% list(
       image = image,
@@ -254,12 +267,16 @@ RunSpatialGradientFeatures <- function(
       result = result,
       assay = assay,
       backend = backend,
-      source = source,
-      set_variable_features = set_variable_features
+      source = source
     )
   }
+  if (isTRUE(set_variable_features)) {
+    srt <- spatial_set_active_variable_features(srt, assay, vars)
+  }
+  saved_message <- if (store_results) "results stored" else "this run's results were not stored"
+  feature_message <- if (!set_variable_features) "VariableFeatures unchanged" else if (length(vars)) "VariableFeatures updated" else "VariableFeatures cleared"
   log_message(
-    "Stored {.val {nrow(result$top_variables)}} spatial gradient features",
+    "Completed spatial gradient screening: {.val {length(vars)}} features; {saved_message}; {feature_message}",
     message_type = "success",
     verbose = verbose
   )
@@ -858,15 +875,7 @@ sgf_best_model_fits <- function(model_fits) {
   do.call(rbind, best)
 }
 
-sgf_store_result <- function(
-  srt,
-  result_name,
-  result,
-  assay,
-  backend = "cpp",
-  source = NULL,
-  set_variable_features
-) {
+sgf_validate_result <- function(result) {
   expected <- c("screening", "significance", "model_fits", "top_variables", "parameters")
   missing <- setdiff(expected, names(result))
   if (length(missing) > 0L) {
@@ -884,7 +893,18 @@ sgf_store_result <- function(
     }
   }
   vars <- result$top_variables$variable
-  vars <- vars[!is.na(vars) & nzchar(vars)]
+  if (!is.character(vars) || anyNA(vars) || any(!nzchar(vars))) {
+    stop("Spatial gradient top_variables must contain a character variable column without missing or empty names", call. = FALSE)
+  }
+  if (!is.null(result$source) && !is.list(result$source)) {
+    stop("Spatial gradient result source must be a list", call. = FALSE)
+  }
+  unique(vars)
+}
+
+sgf_store_result <- function(srt, result_name, result, assay, backend = "cpp", source = NULL) {
+  vars <- sgf_validate_result(result)
+  expected <- c("screening", "significance", "model_fits", "top_variables", "parameters")
   if (is.null(srt@tools[["SpatialGradientFeatures"]])) {
     srt@tools[["SpatialGradientFeatures"]] <- list()
   }
@@ -913,9 +933,6 @@ sgf_store_result <- function(
       c("parameters", "summary")
     ))
   )
-  if (isTRUE(set_variable_features) && length(vars) > 0L) {
-    SeuratObject::VariableFeatures(srt, assay = assay) <- vars
-  }
   srt
 }
 

--- a/R/SpatialUtils.R
+++ b/R/SpatialUtils.R
@@ -304,7 +304,15 @@ spatial_set_active_variable_features <- function(srt, assay, features) {
   features <- features[!is.na(features) & nzchar(features)]
   assay_object <- srt[[assay]]
 
+  if (length(features) > 0L) {
+    features <- intersect(features, rownames(assay_object))
+    if (length(features) == 0L) {
+      stop("None of the features specified are present in this assay", call. = FALSE)
+    }
+  }
   if (inherits(assay_object, "StdAssay")) {
+    # Write full, ID-aligned metadata: some Assay5 setters recycle short
+    # character selections and treat an empty assignment as a no-op.
     feature_names <- rownames(assay_object)
     empty_labels <- feature_names %in% features
     empty_ranks <- match(feature_names, features)

--- a/R/SpatialUtils.R
+++ b/R/SpatialUtils.R
@@ -304,17 +304,15 @@ spatial_set_active_variable_features <- function(srt, assay, features) {
   features <- features[!is.na(features) & nzchar(features)]
   assay_object <- srt[[assay]]
 
-  if (length(features) > 0L) {
-    SeuratObject::VariableFeatures(assay_object) <- features
-  } else if (inherits(assay_object, "StdAssay")) {
+  if (inherits(assay_object, "StdAssay")) {
     feature_names <- rownames(assay_object)
-    empty_labels <- rep(FALSE, length(feature_names))
-    empty_ranks <- rep(NA_integer_, length(feature_names))
+    empty_labels <- feature_names %in% features
+    empty_ranks <- match(feature_names, features)
     names(empty_labels) <- names(empty_ranks) <- feature_names
     assay_object[["var.features"]] <- empty_labels
     assay_object[["var.features.rank"]] <- empty_ranks
   } else {
-    SeuratObject::VariableFeatures(assay_object) <- character()
+    SeuratObject::VariableFeatures(assay_object) <- features
   }
 
   marker_key <- spatial_svf_selection_marker_key()

--- a/man/RunSpatialGradientFeatures.Rd
+++ b/man/RunSpatialGradientFeatures.Rd
@@ -114,7 +114,8 @@ the \code{"cpp"} backend.}
 \code{top_variables} and optionally set as Seurat variable features.}
 
 \item{set_variable_features}{Whether to set top gradient variables as Seurat
-variable features.}
+variable features independently of \code{store_results}. If explicitly \code{TRUE},
+an empty selection clears the target assay's variable features.}
 
 \item{store_results}{Whether to store the normalized result in \code{srt@tools}.}
 
@@ -132,8 +133,10 @@ backend.}
 backend ignores them and does not store them as effective parameters.}
 }
 \value{
-A \code{Seurat} object with spatial gradient screening results stored in
-\code{srt@tools[["SpatialGradientFeatures"]]}.
+A \code{Seurat} object. When \code{store_results = TRUE}, spatial gradient
+screening results are stored in \code{srt@tools[["SpatialGradientFeatures"]]}.
+Otherwise existing stored results are unchanged. Variable features are
+independently updated only when \code{set_variable_features = TRUE}.
 }
 \description{
 Run native spatial trajectory or annotation gradient screening for Seurat

--- a/tests/testthat/test-gradient-truthfulness.R
+++ b/tests/testthat/test-gradient-truthfulness.R
@@ -45,6 +45,7 @@ test_that("active variable feature helper supports legacy assays and ranked Assa
   for (assay in list(SeuratObject::CreateAssayObject(counts = counts),
                      SeuratObject::CreateAssay5Object(counts = counts))) {
     srt <- Seurat::CreateSeuratObject(assay)
+    expect_error(spatial_set_active_variable_features(srt, "RNA", "absent"), "None of the features")
     srt <- spatial_set_active_variable_features(srt, "RNA", c("g2", "g1", "g2"))
     expect_identical(SeuratObject::VariableFeatures(srt), c("g2", "g1"))
     srt <- spatial_set_active_variable_features(srt, "RNA", character())

--- a/tests/testthat/test-gradient-truthfulness.R
+++ b/tests/testthat/test-gradient-truthfulness.R
@@ -1,0 +1,53 @@
+test_that("gradient flags independently control storage and variable features", {
+  counts <- Matrix::Matrix(matrix(1:12, 3, dimnames = list(paste0("g", 1:3), paste0("s", 1:4))), sparse = TRUE)
+  srt <- Seurat::CreateSeuratObject(counts)
+  other <- srt[["RNA"]]
+  SeuratObject::Key(other) <- "other_"
+  srt[["other"]] <- other
+  srt$x <- 1:4
+  srt$y <- c(1, 1, 2, 2)
+  srt <- spatial_set_active_variable_features(srt, "other", "g3")
+  srt@tools$SpatialGradientFeatures <- list(new = "unchanged")
+  payload <- list(screening = data.frame(), significance = data.frame(),
+    model_fits = data.frame(), top_variables = data.frame(variable = "g1"), parameters = data.frame())
+  local_mocked_bindings(sgf_run_cpp_gradient = function(...) payload, .package = "scop")
+  run <- function(...) RunSpatialGradientFeatures(srt, assay = "other", layer = "counts",
+    variables = "g1", result_name = "new", verbose = FALSE, ...)
+  for (empty in c(FALSE, TRUE)) {
+    payload$top_variables <- data.frame(variable = if (empty) character() else "g1")
+    for (save in c(FALSE, TRUE)) for (update in c(FALSE, TRUE)) {
+      out <- run(store_results = save, set_variable_features = update)
+      selected <- SeuratObject::VariableFeatures(out, assay = "other")
+      selected <- as.character(selected[!is.na(selected)])
+      expect_identical(selected,
+        if (update) payload$top_variables$variable else "g3")
+      expect_identical(out[["RNA"]], srt[["RNA"]])
+      if (update && empty) expect_true(spatial_has_explicit_empty_variable_features(out, "other"))
+      if (save) expect_identical(out@tools$SpatialGradientFeatures$new$top_variables,
+        payload$top_variables)
+      else expect_identical(out@tools, srt@tools)
+    }
+  }
+  for (bad in list(NA, 1, logical(), c(TRUE, FALSE))) {
+    expect_error(run(store_results = bad), "single non-missing logical")
+    expect_error(run(set_variable_features = bad), "single non-missing logical")
+  }
+  payload$top_variables <- data.frame(variable = "absent")
+  expect_error(run(store_results = FALSE, set_variable_features = TRUE), "absent from")
+  payload$screening <- NULL
+  expect_error(run(store_results = FALSE), "missing required")
+  expect_identical(srt@tools$SpatialGradientFeatures, list(new = "unchanged"))
+})
+
+test_that("active variable feature helper supports legacy assays and ranked Assay5 selections", {
+  counts <- Matrix::Matrix(matrix(1:12, 3,
+    dimnames = list(paste0("g", 1:3), paste0("s", 1:4))), sparse = TRUE)
+  for (assay in list(SeuratObject::CreateAssayObject(counts = counts),
+                     SeuratObject::CreateAssay5Object(counts = counts))) {
+    srt <- Seurat::CreateSeuratObject(assay)
+    srt <- spatial_set_active_variable_features(srt, "RNA", c("g2", "g1", "g2"))
+    expect_identical(SeuratObject::VariableFeatures(srt), c("g2", "g1"))
+    srt <- spatial_set_active_variable_features(srt, "RNA", character())
+    expect_true(spatial_has_explicit_empty_variable_features(srt, "RNA"))
+  }
+})

--- a/tests/testthat/test-spatial-gradient.R
+++ b/tests/testthat/test-spatial-gradient.R
@@ -137,8 +137,7 @@ test_that("spatial gradient storage keeps only plain data frames", {
     srt = srt,
     result_name = "mock",
     result = result,
-    assay = "RNA",
-    set_variable_features = FALSE
+    assay = "RNA"
   )
 
   stored <- srt@tools[["SpatialGradientFeatures"]][["mock"]]
@@ -171,6 +170,7 @@ test_that("cpp backend stores annotation gradient result tables", {
     reference = "annotation",
     backend = "cpp",
     result_name = "cpp_annotation",
+    set_variable_features = TRUE,
     variables = c("Gene1", "Gene2"),
     annotation.variable = "source_score",
     annotation.threshold = 0,
@@ -193,6 +193,8 @@ test_that("cpp backend stores annotation gradient result tables", {
   expect_false(any(vapply(stored, methods::is, logical(1), class2 = "SPATA2")))
   expect_true(nrow(stored$screening) > 0)
   expect_true(nrow(stored$top_variables) > 0)
+  expect_identical(SeuratObject::VariableFeatures(srt, assay = "RNA"),
+    unique(stored$top_variables$variable))
   expect_equal(stored$parameters$value[match("backend", stored$parameters$key)], "cpp")
   expect_false("spata2_version" %in% stored$parameters$key)
   expect_true(all(c("norm_var", "rel_var", "linear_r2") %in% colnames(stored$significance)))
@@ -273,7 +275,7 @@ test_that("cpp backend stores trajectory gradient result tables", {
 test_that("SpatialGradientPlot handles stored results and missing tables clearly", {
   srt <- make_spatial_gradient_seurat()
   result <- make_spatial_gradient_result()
-  srt <- sgf_store_result(srt, "mock", result, assay = "RNA", set_variable_features = FALSE)
+  srt <- sgf_store_result(srt, "mock", result, assay = "RNA")
 
   expect_s3_class(
     SpatialGradientPlot(srt, result_name = "mock", plot_type = "line", theme_use = NULL),
@@ -321,7 +323,7 @@ test_that("SpatialGradientPlot handles stored results and missing tables clearly
 
   no_screening <- result
   no_screening$screening <- data.frame()
-  srt <- sgf_store_result(srt, "no_screening", no_screening, assay = "RNA", set_variable_features = FALSE)
+  srt <- sgf_store_result(srt, "no_screening", no_screening, assay = "RNA")
   expect_error(
     SpatialGradientPlot(srt, result_name = "no_screening", plot_type = "line", theme_use = NULL),
     "screening data"
@@ -329,7 +331,7 @@ test_that("SpatialGradientPlot handles stored results and missing tables clearly
 
   empty_top <- result
   empty_top$top_variables <- empty_top$top_variables[0, , drop = FALSE]
-  srt <- sgf_store_result(srt, "empty_top", empty_top, assay = "RNA", set_variable_features = FALSE)
+  srt <- sgf_store_result(srt, "empty_top", empty_top, assay = "RNA")
   expect_error(
     SpatialGradientPlot(srt, result_name = "empty_top", plot_type = "summary", theme_use = NULL),
     "No top spatial gradient variables"
@@ -340,7 +342,7 @@ test_that("SpatialGradientPlot combined returns patchwork when available", {
   testthat::skip_if_not_installed("patchwork")
   srt <- make_spatial_gradient_seurat()
   result <- make_spatial_gradient_result()
-  srt <- sgf_store_result(srt, "mock", result, assay = "RNA", set_variable_features = FALSE)
+  srt <- sgf_store_result(srt, "mock", result, assay = "RNA")
 
   p <- SpatialGradientPlot(
     srt,
@@ -364,7 +366,7 @@ test_that("SpatialGradientPlot reuses stored assay layer for surface plots", {
     value = c("RNA", "counts"),
     stringsAsFactors = FALSE
   )
-  srt <- sgf_store_result(srt, "mock_counts", result, assay = "RNA", set_variable_features = FALSE)
+  srt <- sgf_store_result(srt, "mock_counts", result, assay = "RNA")
 
   p <- expect_warning(
     SpatialGradientPlot(


### PR DESCRIPTION
## Summary
Validate gradient payloads regardless of storage; independently update active features, including explicit empty selections. Reuse and harden the existing Assay5 feature setter with ID-aligned logical labels/ranks. Report actual save/update actions. No new public API.

## Validation
- Focused tests passed; all nine combined regression files also passed after merging current upstream main 73cee6135 into an isolated verification worktree.
- Native gradient/observed-neighborhood entry points were exercised. C-SIDE coverage uses adapter mocks; live spacexr was not revalidated.
- Final Windows package check completed: **0 errors, 2 warnings, 4 notes**, using --no-manual --as-cran --no-examples --no-tests and _R_CHECK_FORCE_SUGGESTS_=false.
- Warnings are in unchanged baseline code/docs: undeclared lifecycle calls in R/PseudobulkExpression.R; undocumented arguments in CellDimPlot3D.Rd, FeatureDimPlot.Rd, IntegrationBenchmarkPlot.Rd, and RunIntegrationBenchmark.Rd. This is not a warning-free check.
- Unstated dependencies in examples: OK. Code/documentation mismatches: OK. Changed Rd extraction/parsing and git diff --check: passed.
- Initial Windows temporary-library reparse-point errors were resolved with task-local D: temporary storage. No dependency bypasses, optional backend switches, or global package options were added.
- pkgdown passed on GitHub; three-platform R CMD check is still pending at the time of this update.

## Integration
Independent branch based on d6646dc; current upstream changes were checked in the combined validation worktree. Source changes do not depend on the other two PRs. Merging the three may require trivial reconciliation of their NEWS entries. Existing user worktree edits and the installed D: library were not modified.

Assay5 selections use the existing shared helper with full ID-aligned logical labels/ranks. The local SeuratObject 5.2.0 getter has an NA edge case for an empty selection; tests verify that no active features remain and all explicit selection flags/ranks are empty, without modifying SeuratObject.
