### PR TITLE
Skip unused Monocle2 dispersion fitting on the R backend

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 * **fix**: Gradient result storage and VariableFeatures updates are independent; explicit empty updates clear VariableFeatures and completion messages describe actual actions.
 * **fix**: Neighborhood spatial counts respect saved analysis scope and condition, distinguish zero from unevaluated cells, reject unsupported plot arguments, and support valid empty observed results.
+* **fix**: `RunMonocle2(backend = "r")` skips `estimateDispersions()` unless `feature_type = "Disp"` or `show_plot = TRUE`, matching the C++ backend. The sparse-matrix `2^31-1` crash in dispersion fitting is fixed in [mengxu98/monocle](https://github.com/mengxu98/monocle) 2.9.3.
 
 * **feat**:
   * `SpatialNeighborhoodProfile()` returns observed per-cell neighbor counts and fractions at multiple raw-coordinate distances, retaining the full selected tissue context for target cells without modifying the Seurat object or storing an edge table.

--- a/R/RunMonocle.R
+++ b/R/RunMonocle.R
@@ -206,10 +206,17 @@ RunMonocle2 <- function(
       args = list()
     )
   )
+  need_dispersion <- monocle2_needs_dispersion(
+    features = features,
+    feature_type = feature_type,
+    show_plot = show_plot
+  )
   uses_negbinomial <- any(c("negbinomial", "negbinomial.size") %in% expressionFamily)
   if (isTRUE(uses_negbinomial)) {
     cds <- get_namespace_fun("BiocGenerics", "estimateSizeFactors")(cds)
-    cds <- get_namespace_fun("BiocGenerics", "estimateDispersions")(cds)
+    if (isTRUE(need_dispersion)) {
+      cds <- get_namespace_fun("BiocGenerics", "estimateDispersions")(cds)
+    }
   }
   dispersion_table <- NULL
   if (is.null(features)) {
@@ -336,6 +343,10 @@ RunMonocle2 <- function(
   return(srt)
 }
 
+monocle2_needs_dispersion <- function(features, feature_type, show_plot) {
+  isTRUE(show_plot) || (is.null(features) && identical(feature_type, "Disp"))
+}
+
 monocle2_reduce_dimension_args <- function(
   cds,
   max_components = 2,
@@ -440,7 +451,11 @@ run_monocle2_cpp <- function(
       args = list()
     )
   )
-  need_dispersion <- isTRUE(show_plot) || (is.null(features) && identical(feature_type, "Disp"))
+  need_dispersion <- monocle2_needs_dispersion(
+    features = features,
+    feature_type = feature_type,
+    show_plot = show_plot
+  )
   uses_negbinomial <- any(c("negbinomial", "negbinomial.size") %in% expressionFamily)
   if (isTRUE(uses_negbinomial)) {
     cds <- get_namespace_fun("BiocGenerics", "estimateSizeFactors")(cds)

--- a/tests/testthat/test-monocle2-cpp.R
+++ b/tests/testthat/test-monocle2-cpp.R
@@ -391,3 +391,10 @@ test_that("RunMonocle2 cpp backend preserves root_state error behavior", {
     "no cells for State"
   )
 })
+
+test_that("monocle2_needs_dispersion is required only for Disp or ordering-gene plots", {
+  expect_false(monocle2_needs_dispersion(NULL, "HVF", FALSE))
+  expect_true(monocle2_needs_dispersion(NULL, "Disp", FALSE))
+  expect_true(monocle2_needs_dispersion(NULL, "HVF", TRUE))
+  expect_false(monocle2_needs_dispersion("g1", "Disp", FALSE))
+})


### PR DESCRIPTION
## Summary
- `RunMonocle2(backend = "r")` now skips `estimateDispersions()` unless `feature_type = "Disp"` or `show_plot = TRUE`, matching the C++ backend.
- Default HVF trajectory runs no longer densify the full count matrix.
- Large-matrix overflow in dispersion fitting is fixed in [mengxu98/monocle](https://github.com/mengxu98/monocle) 2.9.3; install that release for `feature_type = "Disp"`.

## Test plan
- [x] `monocle2_needs_dispersion()` unit checks for HVF vs Disp vs `show_plot`
- [ ] After installing monocle 2.9.3, `RunMonocle2(srt, group.by = ..., backend = "r")` on a large object completes
- [ ] Existing R vs C++ backend ordering tests still pass