### PR TITLE
fix(test): build the Giotto fixture without `SeuratObject::scalefactors()`

### DIFF
--- a/tests/testthat/test-framework-bridges.R
+++ b/tests/testthat/test-framework-bridges.R
@@ -201,11 +201,9 @@ make_live_giotto_seurat <- function() {
     assay = "Spatial",
     key = "slice1_",
     image = array(0.5, dim = c(8L, 8L, 3L)),
-    scale.factors = SeuratObject::scalefactors(
-      spot = 1,
-      fiducial = 1,
-      hires = 1,
-      lowres = 1
+    scale.factors = structure(
+      list(spot = 1, fiducial = 1, hires = 1, lowres = 1),
+      class = "scalefactors"
     ),
     coordinates = data.frame(
       tissue = 1L,


### PR DESCRIPTION
## Problem

The `giotto` suite of `optional-backends` fails on `main` (run [34349465819](https://github.com/mengxu98/scop/actions/runs/34349465819)):

```
── 1. Error ('test-framework-bridges.R:235:3'): srt_to_giotto and giotto_to_srt …
Error: 'scalefactors' is not an exported object from 'namespace:SeuratObject'
```

`SeuratObject::scalefactors()` is no longer exported in SeuratObject 5.x, so `make_live_giotto_seurat()` aborts before the live round-trip starts. The suite has no PR trigger, so #410 merged without this surfacing.

## Fix

Construct the S3 `scalefactors` list directly, matching the existing fixtures in `test-spatial-network-receipt.R` and `test-run-spatial-cellchat.R`:

```r
scale.factors = structure(
  list(spot = 1, fiducial = 1, hires = 1, lowres = 1),
  class = "scalefactors"
)
```

## Validation

- `testthat::test_local(filter = "framework-bridges")` — 36 tests pass locally (SeuratObject 5.4.0, GiottoClass installed).
- `optional-backends` will be re-dispatched on `main` after merge to confirm the giotto suite turns green.