### PR TITLE
fix(ci): install `geometry` for the giotto optional suite

### DIFF
--- a/.github/workflows/optional-backends.yaml
+++ b/.github/workflows/optional-backends.yaml
@@ -27,8 +27,12 @@ jobs:
               DDRTree
           - suite: giotto
             filter: framework-bridges|param-list-utils|pr306-spatial-baseline
-            packages: giotto-suite/Giotto@080d2e206c2f8b567a9ec2527297b6abd463ee64
-            required: Giotto
+            packages: |-
+              giotto-suite/Giotto@080d2e206c2f8b567a9ec2527297b6abd463ee64
+              cran::geometry
+            required: |-
+              Giotto
+              geometry
           - suite: tage
             filter: runtage-preprocessing
             packages: Gladyshev-Lab/tAge@d2bae09a2409deb42031f2b31aa3d9f391d5e2ab

--- a/tests/testthat/test-framework-bridges.R
+++ b/tests/testthat/test-framework-bridges.R
@@ -223,6 +223,9 @@ test_that("srt_to_giotto and giotto_to_srt round-trip with a real GiottoClass", 
   if (!isTRUE(all(unlist(giotto_class, use.names = FALSE)))) {
     skip("GiottoClass is not installed")
   }
+  # The Visium path estimates scale factors through a Delaunay network that
+  # GiottoClass builds with the optional `geometry` package.
+  skip_if_not_installed("geometry")
 
   # In-process tiny fixture: callr+load_all of the source tree exceeds 120s in
   # optional CI before conversion starts, and visium_human_pancreas_sub is far


### PR DESCRIPTION
## Problem

After #413, the giotto suite of `optional-backends` still fails (run [34355614606](https://github.com/mengxu98/scop/actions/runs/34355614606)):

```
── 1. Error ('test-framework-bridges.R:235:3'): srt_to_giotto and giotto_to_srt …
Error: package 'geometry' is not yet installed
```

`GiottoClass::seuratToGiottoV5()` estimates Visium scale factors through a Delaunay network built by `createNetwork(type = "delaunay", method = "geometry")`, and `geometry` is a *Suggests* of GiottoClass, so pak does not install it with the suite.

## Fix

- Install `cran::geometry` for the giotto suite (and verify it through `required`).
- `skip_if_not_installed("geometry")` in the live round-trip, so the test degrades instead of erroring in environments without the optional package.

## Validation

- `testthat::test_local(filter = "framework-bridges")` — 36 tests pass locally (GiottoClass + geometry installed).
- Workflow YAML parses; the giotto matrix entry now lists `cran::geometry`.
- `optional-backends` will be re-dispatched on `main` after merge to confirm the suite turns green.