### PR TITLE
style: apply styler to scop

### DIFF
--- a/R/CellScoringPlot.R
+++ b/R/CellScoringPlot.R
@@ -767,8 +767,7 @@ scoreplot_umap <- function(
   plot$data$Dim2 <- plot$data$y
   plot$data$group.by <- plot$data$score
   plot$data <- plot$data[
-    order(plot$data$score, na.last = TRUE),
-    ,
+    order(plot$data$score, na.last = TRUE), ,
     drop = FALSE
   ]
   for (i in seq_along(plot$layers)) {
@@ -780,8 +779,7 @@ scoreplot_umap <- function(
     ) {
       layer_data$group.by <- unname(score_by_cell[rownames(layer_data)])
       layer_data <- layer_data[
-        order(layer_data$group.by, na.last = TRUE),
-        ,
+        order(layer_data$group.by, na.last = TRUE), ,
         drop = FALSE
       ]
       plot$layers[[i]]$data <- layer_data
@@ -827,14 +825,12 @@ scoreplot_umap <- function(
     scoreplot_legend_theme(if (show.legend) legend.position else "none")
 
   highlighted <- plot$data[
-    as.character(plot$data$group) %in% highlight.group,
-    ,
+    as.character(plot$data$group) %in% highlight.group, ,
     drop = FALSE
   ]
   for (highlight in highlight.group) {
     subset <- highlighted[
-      as.character(highlighted$group) == highlight,
-      ,
+      as.character(highlighted$group) == highlight, ,
       drop = FALSE
     ]
     if (
@@ -983,8 +979,7 @@ scoreplot_stat <- function(
       set.seed(seed)
       count <- max(1L, floor(nrow(data) * point.fraction))
       point_data <- data[
-        sample.int(nrow(data), min(count, nrow(data))),
-        ,
+        sample.int(nrow(data), min(count, nrow(data))), ,
         drop = FALSE
       ]
       box <- box +
@@ -1089,8 +1084,7 @@ scoreplot_stat <- function(
       ggplot2::geom_col(width = 0.9, position = "stack") +
       ggplot2::geom_text(
         data = threshold_data[
-          threshold_data$status == status_levels[[1]],
-          ,
+          threshold_data$status == status_levels[[1]], ,
           drop = FALSE
         ],
         ggplot2::aes(y = 0.5, label = label),

--- a/R/ClusterTreePlot.R
+++ b/R/ClusterTreePlot.R
@@ -969,8 +969,7 @@ clustertree_resolve_legend_position <- function(
   if (!identical(legend.position, "auto")) {
     return(legend.position)
   }
-  switch(
-    direction,
+  switch(direction,
     "left-to-right" = "top-left",
     "right-to-left" = "top-right",
     "top-to-bottom" = "right",
@@ -980,8 +979,7 @@ clustertree_resolve_legend_position <- function(
 }
 
 clustertree_legend_anchor <- function(direction = "left-to-right") {
-  switch(
-    direction,
+  switch(direction,
     "left-to-right" = list(
       position = c(0.022, 0.978),
       justification = c(0, 1)

--- a/R/FindAllMarkers.R
+++ b/R/FindAllMarkers.R
@@ -276,8 +276,7 @@ marker_all_from_context <- function(
         verbose = FALSE
       )
       block <- presto_result[
-        as.character(presto_result$group) == "Group1",
-        ,
+        as.character(presto_result$group) == "Group1", ,
         drop = FALSE
       ]
       block$pval[match(ctx$features, block$feature)]

--- a/R/PrepareEnv.R
+++ b/R/PrepareEnv.R
@@ -1890,16 +1890,15 @@ env_requirements <- function(
     spatialdm_core_python_requirements()
   } else if ("scmalignantfinder" %in% modules) {
     scmalignantfinder_core_python_requirements()
-  } else if (any(c("scenic", "cell2fate") %in% modules)) {{
-    list(
-      packages = c(
-        "setuptools" = "setuptools<81"
-      ),
-      install_methods = c(
-        "setuptools" = "pip"
-      ),
-      package_aliases = list()
-    ) }} else {
+  } else if (any(c("scenic", "cell2fate") %in% modules)) {{ list(
+    packages = c(
+      "setuptools" = "setuptools<81"
+    ),
+    install_methods = c(
+      "setuptools" = "pip"
+    ),
+    package_aliases = list()
+  ) }} else {
     core_python_requirements()
   }
   package_install_methods <- base_requirements$install_methods

--- a/R/RunCellRank.R
+++ b/R/RunCellRank.R
@@ -232,39 +232,39 @@ RunCellRank <- function(
       )
     }
     srt <- run_cellrank_cpp(
-        srt = srt, assay_y = assay_y, layer_y = layer_y,
-        group.by = group.by, linear_reduction = linear_reduction,
-        nonlinear_reduction = nonlinear_reduction,
-        n_pcs = n_pcs, n_neighbors = n_neighbors,
-        mode = mode, kernel_type = kernel_type, time_key = time_key,
-        velocity_weight = velocity_weight,
-        connectivity_weight = connectivity_weight,
-        use_connectivity_kernel = use_connectivity_kernel,
-        softmax_scale = softmax_scale,
-        n_macrostates = n_macrostates,
-        schur_n_components = schur_n_components,
-        n_cells_terminal = n_cells_terminal,
-        terminal_states = terminal_states,
-        terminal_state_agg = terminal_state_agg,
-        driver_lineages = driver_lineages,
-        estimator_type = tolower(estimator_type_upper),
-        backward = backward,
-        schur_method = schur_method,
-        recompute_neighbors = recompute_neighbors,
-        time_field = time_field,
-        fitting_by = fitting_by,
-        magic_impute = magic_impute,
-        magic_knn = knn,
-        magic_t = t,
-        min_shared_counts = min_shared_counts,
-        denoise = denoise,
-        kinetics = kinetics,
-        calculate_velocity_genes = calculate_velocity_genes,
-        compute_lineage_drivers = compute_lineage_drivers,
-        max_dense_gib = max_dense_gib,
-        cores = cores, return_seurat = return_seurat,
-        verbose = verbose
-      )
+      srt = srt, assay_y = assay_y, layer_y = layer_y,
+      group.by = group.by, linear_reduction = linear_reduction,
+      nonlinear_reduction = nonlinear_reduction,
+      n_pcs = n_pcs, n_neighbors = n_neighbors,
+      mode = mode, kernel_type = kernel_type, time_key = time_key,
+      velocity_weight = velocity_weight,
+      connectivity_weight = connectivity_weight,
+      use_connectivity_kernel = use_connectivity_kernel,
+      softmax_scale = softmax_scale,
+      n_macrostates = n_macrostates,
+      schur_n_components = schur_n_components,
+      n_cells_terminal = n_cells_terminal,
+      terminal_states = terminal_states,
+      terminal_state_agg = terminal_state_agg,
+      driver_lineages = driver_lineages,
+      estimator_type = tolower(estimator_type_upper),
+      backward = backward,
+      schur_method = schur_method,
+      recompute_neighbors = recompute_neighbors,
+      time_field = time_field,
+      fitting_by = fitting_by,
+      magic_impute = magic_impute,
+      magic_knn = knn,
+      magic_t = t,
+      min_shared_counts = min_shared_counts,
+      denoise = denoise,
+      kinetics = kinetics,
+      calculate_velocity_genes = calculate_velocity_genes,
+      compute_lineage_drivers = compute_lineage_drivers,
+      max_dense_gib = max_dense_gib,
+      cores = cores, return_seurat = return_seurat,
+      verbose = verbose
+    )
     if (isTRUE(show_plot) || isTRUE(save_plot)) {
       plot <- CellRankPlot(srt, plot_type = "fate", reduction = nonlinear_reduction)
       if (isTRUE(show_plot)) print(plot)
@@ -817,7 +817,8 @@ cellrank_knn_from_connectivities <- function(connectivities, k) {
   k <- min(as.integer(k), nrow(graph) - 1L)
   idx <- t(apply(graph, 1L, function(x) order(x, decreasing = TRUE)[seq_len(k)]))
   weight <- matrix(graph[cbind(rep(seq_len(nrow(graph)), each = k), as.vector(t(idx)))],
-    nrow = nrow(graph), byrow = TRUE)
+    nrow = nrow(graph), byrow = TRUE
+  )
   list(idx = idx, dist = 1 - pmax(weight, 0))
 }
 
@@ -1194,7 +1195,9 @@ run_cellrank_cpp <- function(
         assay = assay_y[[1L]],
         layer = layer_y
       ))[, cells, drop = FALSE]
-      lineage_idx <- if (is.null(driver_lineages)) integer() else {
+      lineage_idx <- if (is.null(driver_lineages)) {
+        integer()
+      } else {
         idx <- suppressWarnings(as.integer(driver_lineages))
         idx[is.finite(idx) & idx >= 1L & idx <= ncol(ap)]
       }

--- a/R/RunCellTypist.R
+++ b/R/RunCellTypist.R
@@ -46,10 +46,12 @@
 #' check_python(c("celltypist", "anndata"))
 #' data(pbmcmultiome_sub)
 #' pbmcmultiome_sub <- RunStandardWorkflow(
-#'   pbmcmultiome_sub, assay = "RNA", linear_reduction_dims = 10
+#'   pbmcmultiome_sub,
+#'   assay = "RNA", linear_reduction_dims = 10
 #' )
 #' pbmcmultiome_sub <- RunCellTypist(
-#'   pbmcmultiome_sub, model = "Immune_All_Low.pkl", verbose = FALSE
+#'   pbmcmultiome_sub,
+#'   model = "Immune_All_Low.pkl", verbose = FALSE
 #' )
 #' }
 RunCellTypist <- function(
@@ -265,7 +267,8 @@ RunCellTypist <- function(
 #' check_python(c("celltypist", "anndata"))
 #' data(pbmcmultiome_sub)
 #' pbmcmultiome_sub <- RunStandardWorkflow(
-#'   pbmcmultiome_sub, assay = "RNA", linear_reduction_dims = 10
+#'   pbmcmultiome_sub,
+#'   assay = "RNA", linear_reduction_dims = 10
 #' )
 #' model_info <- TrainCellTypist(
 #'   srt = pbmcmultiome_sub, labels = "CellType",

--- a/R/RunDEtest.R
+++ b/R/RunDEtest.R
@@ -1905,8 +1905,7 @@ RunDEtest_pseudobulk <- function(
         return(list(markers = NULL, inventory = inventory))
       }
       meta_use <- meta_use[
-        as.character(meta_use[[sample_col]]) %in% keep_samples,
-        ,
+        as.character(meta_use[[sample_col]]) %in% keep_samples, ,
         drop = FALSE
       ]
       cells_use <- rownames(meta_use)

--- a/R/RunKNNMap.R
+++ b/R/RunKNNMap.R
@@ -41,7 +41,8 @@
 #' keep <- panc8_sub$celltype %in% c("ductal", "alpha", "beta")
 #' panc8_sub <- panc8_sub[, keep]
 #' panc8_sub <- RunStandardWorkflow(
-#'   panc8_sub, verbose = FALSE, linear_reduction_dims = 10
+#'   panc8_sub,
+#'   verbose = FALSE, linear_reduction_dims = 10
 #' )
 #' srt_ref <- panc8_sub[, panc8_sub$tech != "fluidigmc1"]
 #' srt_query <- panc8_sub[, panc8_sub$tech == "fluidigmc1"]

--- a/R/RunKNNPredict.R
+++ b/R/RunKNNPredict.R
@@ -76,13 +76,15 @@
 #' )
 #' genes <- head(intersect(rownames(reference), rownames(query)), 200)
 #' query <- RunKNNPredict(
-#'   query, srt_ref = reference, ref_group = "celltype",
+#'   query,
+#'   srt_ref = reference, ref_group = "celltype",
 #'   features = genes, nfeatures = length(genes),
 #'   ref_collapsing = FALSE, k = 10, verbose = FALSE
 #' )
 #' query <- RunStandardWorkflow(query, verbose = FALSE, linear_reduction_dims = 10)
 #' CellDimPlot(
-#'   query, group.by = "KNNPredict_classification",
+#'   query,
+#'   group.by = "KNNPredict_classification",
 #'   label = TRUE, legend.position = "bottom"
 #' )
 #' FeatureStatPlot(

--- a/R/RunMERINGUE.R
+++ b/R/RunMERINGUE.R
@@ -39,7 +39,8 @@
 #' \dontrun{
 #' data(visium_human_pancreas_sub)
 #' visium_human_pancreas_sub <- Seurat::NormalizeData(
-#'   visium_human_pancreas_sub, assay = "Spatial", verbose = FALSE
+#'   visium_human_pancreas_sub,
+#'   assay = "Spatial", verbose = FALSE
 #' )
 #' spatial <- RunMERINGUE(
 #'   visium_human_pancreas_sub,

--- a/R/RunMistyR.R
+++ b/R/RunMistyR.R
@@ -46,7 +46,8 @@
 #' spatial <- Seurat::NormalizeData(visium_human_pancreas_sub, verbose = FALSE)
 #' # Paraview bandwidth: 1000 full-resolution image pixels.
 #' spatial <- RunMistyR(
-#'   spatial, assay = "Spatial", features = rownames(spatial)[1:5],
+#'   spatial,
+#'   assay = "Spatial", features = rownames(spatial)[1:5],
 #'   image = "slice1", views = "para", para_l = 1000,
 #'   cv_folds = 3, verbose = FALSE
 #' )

--- a/R/RunPHATE.R
+++ b/R/RunPHATE.R
@@ -429,11 +429,14 @@ run_phate_cpp_reduction <- function(
       )
     )
     if (isTRUE(do_cluster)) {
-      cluster_count <- if (is.numeric(n_clusters)) as.integer(n_clusters) else {
+      cluster_count <- if (is.numeric(n_clusters)) {
+        as.integer(n_clusters)
+      } else {
         min(as.integer(max_clusters), max(2L, round(sqrt(n_cells / 2))))
       }
       clusters <- factor(stats::kmeans(
-        embedding, centers = min(max(1L, cluster_count), n_cells)
+        embedding,
+        centers = min(max(1L, cluster_count), n_cells)
       )$cluster)
       names(clusters) <- rownames(embedding)
       SeuratObject::Misc(reduction, slot = "clusters") <- clusters
@@ -532,7 +535,8 @@ phate_native_affinity <- function(data, k, decay, metric) {
   diag(distance) <- Inf
   idx <- t(apply(distance, 1L, order))[, seq_len(k), drop = FALSE]
   d <- matrix(distance[cbind(rep(seq_len(nrow(data)), each = k), as.vector(t(idx)))],
-    nrow = nrow(data), byrow = TRUE)
+    nrow = nrow(data), byrow = TRUE
+  )
   bandwidth <- pmax(d[, min(k, ncol(d))], .Machine$double.eps)
   weight <- exp(-(d / bandwidth)^as.numeric(decay))
   list(

--- a/R/RunPalantir.R
+++ b/R/RunPalantir.R
@@ -702,7 +702,9 @@ run_palantir_cpp <- function(
     if (isTRUE(adjust_early_cell)) {
       candidates <- if (!is.null(early_group)) {
         which(srt@meta.data[[group.by]] == early_group)
-      } else seq_len(n_cells)
+      } else {
+        seq_len(n_cells)
+      }
       adjusted_early <- candidates[which.min(pseudotime[candidates])]
     }
     adjusted_terminal <- terminal_state_cells

--- a/R/RunSCVELO.R
+++ b/R/RunSCVELO.R
@@ -186,7 +186,8 @@ RunSCVELO <- function(
     }
     if (isTRUE(show_plot) || isTRUE(save_plot)) {
       plot <- VelocityPlot(
-        srt, reduction = nonlinear_reduction, velocity = unlist(mode)[[1L]],
+        srt,
+        reduction = nonlinear_reduction, velocity = unlist(mode)[[1L]],
         plot_type = "stream", group.by = group.by,
         density = stream_density, smooth = stream_smooth %||% 0.5,
         streamline_width = c(0, arrow_size / 5)

--- a/R/RunSciBet.R
+++ b/R/RunSciBet.R
@@ -42,7 +42,8 @@
 #' )
 #' query <- RunStandardWorkflow(query, verbose = FALSE, linear_reduction_dims = 10)
 #' CellDimPlot(
-#'   query, group.by = "scibet_annotation",
+#'   query,
+#'   group.by = "scibet_annotation",
 #'   label = TRUE, legend.position = "bottom"
 #' )
 RunSciBet <- function(

--- a/R/RunScmap.R
+++ b/R/RunScmap.R
@@ -28,7 +28,8 @@
 #' )
 #' query <- RunStandardWorkflow(query, verbose = FALSE, linear_reduction_dims = 10)
 #' CellDimPlot(
-#'   query, group.by = "scmap_annotation",
+#'   query,
+#'   group.by = "scmap_annotation",
 #'   label = TRUE, legend.position = "bottom"
 #' )
 RunScmap <- function(

--- a/R/RunSingleR.R
+++ b/R/RunSingleR.R
@@ -33,11 +33,13 @@
 #' )
 #' query <- RunStandardWorkflow(query, verbose = FALSE, linear_reduction_dims = 10)
 #' CellDimPlot(
-#'   query, group.by = "singler_annotation",
+#'   query,
+#'   group.by = "singler_annotation",
 #'   label = TRUE, legend.position = "bottom"
 #' )
 #' FeatureStatPlot(
-#'   query, stat.by = "singler_score",
+#'   query,
+#'   stat.by = "singler_score",
 #'   group.by = "singler_annotation"
 #' )
 RunSingleR <- function(

--- a/R/RunSpatialBenchmark.R
+++ b/R/RunSpatialBenchmark.R
@@ -50,11 +50,15 @@
 #' n_genes <- 60L
 #' grid <- expand.grid(x = 1:6, y = 1:6)
 #' domain <- factor(ifelse(grid$x <= 2, "left", ifelse(grid$x <= 4, "middle", "right")))
-#' counts <- matrix(rpois(n_genes * n_spots, 2), nrow = n_genes,
-#'   dimnames = list(paste0("Gene", seq_len(n_genes)), paste0("spot", seq_len(n_spots))))
+#' counts <- matrix(rpois(n_genes * n_spots, 2),
+#'   nrow = n_genes,
+#'   dimnames = list(paste0("Gene", seq_len(n_genes)), paste0("spot", seq_len(n_spots)))
+#' )
 #' signal <- split(seq_len(n_genes), rep(c("left", "middle", "right"), each = 20))
-#' for (label in names(signal)) counts[signal[[label]], domain == label] <-
-#'   counts[signal[[label]], domain == label] + rpois(sum(domain == label) * 20, 5)
+#' for (label in names(signal)) {
+#'   counts[signal[[label]], domain == label] <-
+#'     counts[signal[[label]], domain == label] + rpois(sum(domain == label) * 20, 5)
+#' }
 #' spatial <- SeuratObject::CreateSeuratObject(counts)
 #' spatial$x <- grid$x
 #' spatial$y <- grid$y

--- a/R/RunSpatialCellChat.R
+++ b/R/RunSpatialCellChat.R
@@ -902,7 +902,8 @@ spatialcellchat_run_one <- function(
 #' \dontrun{
 #' data(visium_human_pancreas_sub)
 #' visium_human_pancreas_sub <- Seurat::NormalizeData(
-#'   visium_human_pancreas_sub, assay = "Spatial", verbose = FALSE
+#'   visium_human_pancreas_sub,
+#'   assay = "Spatial", verbose = FALSE
 #' )
 #' # Group Visium spots by their CODA tissue labels.
 #' spatial <- RunSpatialCellChat(

--- a/R/RunSpatialEcoTyper.R
+++ b/R/RunSpatialEcoTyper.R
@@ -186,8 +186,10 @@ RunSpatialEcoTyper <- function(
     coordinate_input$sources <- list(single = c(coordinate_input$source, list(transform = coordinate_input$transform)))
   } else if (identical(mode, "multi")) {
     validate_scalar_string(sample.by, "sample.by", require_character = FALSE)
-    coordinate_input <- spatial_sample_coords(srt, sample.by = sample.by, image = image,
-                                              coord.cols = c(x.by, y.by))
+    coordinate_input <- spatial_sample_coords(srt,
+      sample.by = sample.by, image = image,
+      coord.cols = c(x.by, y.by)
+    )
   }
   check_r("digitalcytometry/SpatialEcoTyper", verbose = FALSE)
 
@@ -889,8 +891,10 @@ spatialecotyper_coordinate_metadata <- function(srt, cells, celltype.by, coords)
   if (!all(cells %in% rownames(coords))) {
     log_message("SpatialEcoTyper coordinates are missing expression cells", message_type = "error")
   }
-  meta <- data.frame(X = coords[cells, "x"], Y = coords[cells, "y"],
-                     CellType = srt[[]][cells, celltype.by], row.names = cells)
+  meta <- data.frame(
+    X = coords[cells, "x"], Y = coords[cells, "y"],
+    CellType = srt[[]][cells, celltype.by], row.names = cells
+  )
   spatialecotyper_build_metadata(meta, "CellType", "X", "Y")
 }
 

--- a/R/RunSpatialGradientFeatures.R
+++ b/R/RunSpatialGradientFeatures.R
@@ -378,7 +378,6 @@ SpatialGradientPlot <- function(
       theme_args = theme_args
     ))
   }
-
 }
 
 

--- a/R/RunSpatialIntegration.R
+++ b/R/RunSpatialIntegration.R
@@ -306,8 +306,10 @@ spatial_integration_prepare_input <- function(
     srt_list <- NULL
   } else {
     srt_list <- spatial_integration_as_list(object, sample.by = sample.by)
-    list_coordinates <- spatial_integration_list_coords(srt_list, sample.by, image,
-                                                       coord.cols, coordinate_space)
+    list_coordinates <- spatial_integration_list_coords(
+      srt_list, sample.by, image,
+      coord.cols, coordinate_space
+    )
     srt <- spatial_integration_merge_list(srt_list, sample.by = sample.by)
   }
   assay <- assay %||% SeuratObject::DefaultAssay(srt)
@@ -684,7 +686,7 @@ spatial_integration_standardize_embedding <- function(embedding, cells) {
   } else {
     ids <- rownames(embedding)
     if (anyNA(ids) || any(!nzchar(ids)) || anyDuplicated(ids) ||
-        !setequal(ids, cells)) {
+      !setequal(ids, cells)) {
       log_message(
         "Backend embedding row IDs must match Seurat cells exactly",
         message_type = "error"
@@ -772,7 +774,7 @@ spatial_integration_standardize_coords <- function(coords, cells) {
   } else {
     ids <- rownames(coords)
     if (anyNA(ids) || any(!nzchar(ids)) || anyDuplicated(ids) ||
-        !setequal(ids, cells)) {
+      !setequal(ids, cells)) {
       log_message(
         "Backend aligned-coordinate row IDs must match Seurat cells exactly",
         message_type = "error"

--- a/R/RunSpatialNeighborhood.R
+++ b/R/RunSpatialNeighborhood.R
@@ -123,7 +123,7 @@ RunSpatialNeighborhood <- function(
   )
   for (labels in list(from, to)) {
     if (!is.null(labels) && (!is.character(labels) || anyNA(labels) ||
-        any(!labels %in% input$cells$group))) {
+      any(!labels %in% input$cells$group))) {
       stop("from/to must contain labels present in the analysis input", call. = FALSE)
     }
   }
@@ -584,14 +584,18 @@ spatial_neighborhood_observed_pairs <- function(
   })
   edge_table <- do.call(rbind, edge_list)
   if (is.null(edge_table) || nrow(edge_table) == 0L) {
-    edge_table <- data.frame(cell = character(), neighbor = character(),
+    edge_table <- data.frame(
+      cell = character(), neighbor = character(),
       from = character(), to = character(), sample = character(),
-      condition = character(), subject = character(), distance = numeric())
-    pair_table <- data.frame(method = character(), comparison = character(),
+      condition = character(), subject = character(), distance = numeric()
+    )
+    pair_table <- data.frame(
+      method = character(), comparison = character(),
       condition = character(), from = character(), to = character(), estimate = numeric(),
       statistic = numeric(), pval = numeric(), FDR = numeric(), direction = character(),
       sample = character(), subject = character(), count = integer(), total = integer(),
-      fraction = numeric())
+      fraction = numeric()
+    )
     return(list(pair_table = pair_table, edge_table = edge_table))
   }
   rownames(edge_table) <- NULL
@@ -1028,11 +1032,11 @@ spatial_neighborhood_spatial_plot <- function(
   edges <- bundle$edge_table
   input <- bundle$input
   if (!is.data.frame(input) || !all(c("cell", "group", "condition") %in% names(input)) ||
-      !is.data.frame(edges) || !all(c("cell", "neighbor", "from", "to", "condition") %in% names(edges))) {
+    !is.data.frame(edges) || !all(c("cell", "neighbor", "from", "to", "condition") %in% names(edges))) {
     stop("Saved analysis input or edge table is incomplete; rerun RunSpatialNeighborhood()", call. = FALSE)
   }
   if (anyNA(input$cell) || anyDuplicated(input$cell) || anyNA(input$group) ||
-      anyNA(input$condition) || anyNA(edges$cell) || any(!edges$cell %in% input$cell)) {
+    anyNA(input$condition) || anyNA(edges$cell) || any(!edges$cell %in% input$cell)) {
     stop("Saved neighborhood identifiers are invalid; rerun RunSpatialNeighborhood()", call. = FALSE)
   }
   if (!is.null(condition)) {
@@ -1047,8 +1051,8 @@ spatial_neighborhood_spatial_plot <- function(
   }
   pair_use <- spatial_neighborhood_resolve_pair(pair, edges)
   if (anyNA(pair_use) || any(!nzchar(pair_use)) || any(!pair_use %in% bundle$input$group) ||
-      (!is.null(bundle$parameters$from) && !pair_use[1L] %in% bundle$parameters$from) ||
-      (!is.null(bundle$parameters$to) && !pair_use[2L] %in% bundle$parameters$to)) {
+    (!is.null(bundle$parameters$from) && !pair_use[1L] %in% bundle$parameters$from) ||
+    (!is.null(bundle$parameters$to) && !pair_use[2L] %in% bundle$parameters$to)) {
     stop("pair must contain known labels within the saved from/to scope", call. = FALSE)
   }
   hit <- edges$from == pair_use[1L] & edges$to == pair_use[2L]

--- a/R/RunSpotSweeper.R
+++ b/R/RunSpotSweeper.R
@@ -597,12 +597,16 @@ spot_sweeper_run_local_outliers <- function(
 spot_sweeper_align_local_output <- function(output, input, sample_col, metric) {
   input_ids <- colnames(input)
   output_ids <- colnames(output)
-  fail <- function() log_message(
-    "{.pkg SpotSweeper} {.fn localOutliers} changed spot identities or data for metric {.val {metric}}",
-    message_type = "error"
-  )
+  fail <- function() {
+    log_message(
+      "{.pkg SpotSweeper} {.fn localOutliers} changed spot identities or data for metric {.val {metric}}",
+      message_type = "error"
+    )
+  }
   if (is.null(output_ids) || length(output_ids) != length(input_ids) ||
-      anyNA(output_ids) || anyDuplicated(output_ids)) fail()
+    anyNA(output_ids) || anyDuplicated(output_ids)) {
+    fail()
+  }
   # localOutliers 1.5.0 rbinds named per-sample results, prefixing their IDs.
   # Match the complete expected names; never strip an arbitrary prefix.
   prefixed <- paste(as.character(SummarizedExperiment::colData(input)[[sample_col]]), input_ids, sep = ".")
@@ -610,14 +614,20 @@ spot_sweeper_align_local_output <- function(output, input, sample_col, metric) {
   valid <- vapply(candidates, function(ids) !anyDuplicated(ids) && setequal(ids, output_ids), logical(1))
   mappings <- lapply(candidates[valid], function(ids) match(ids, output_ids))
   if (length(mappings) == 0L ||
-      any(!vapply(mappings, identical, logical(1), mappings[[1L]]))) fail()
+    any(!vapply(mappings, identical, logical(1), mappings[[1L]]))) {
+    fail()
+  }
   output <- output[, mappings[[1L]], drop = FALSE]
   colnames(output) <- input_ids
   same <- function(a, b) isTRUE(all.equal(unname(a), unname(b), check.attributes = FALSE))
   if (!same(SpatialExperiment::spatialCoords(output), SpatialExperiment::spatialCoords(input)) ||
-      !same(SummarizedExperiment::assay(output), SummarizedExperiment::assay(input)) ||
-      !identical(as.character(SummarizedExperiment::colData(output)[[sample_col]]),
-                 as.character(SummarizedExperiment::colData(input)[[sample_col]]))) fail()
+    !same(SummarizedExperiment::assay(output), SummarizedExperiment::assay(input)) ||
+    !identical(
+      as.character(SummarizedExperiment::colData(output)[[sample_col]]),
+      as.character(SummarizedExperiment::colData(input)[[sample_col]])
+    )) {
+    fail()
+  }
   output
 }
 

--- a/R/RunStatialKontextual.R
+++ b/R/RunStatialKontextual.R
@@ -45,7 +45,8 @@
 #' data(visium_human_pancreas_sub)
 #' # Compare tissue-labelled spots at two radii (full-resolution image pixels).
 #' spatial <- RunStatialKontextual(
-#'   visium_human_pancreas_sub, group.by = "coda_label", image = "slice1",
+#'   visium_human_pancreas_sub,
+#'   group.by = "coda_label", image = "slice1",
 #'   r = c(500, 1000), from = "collagen", to = "acini", parent = c("collagen", "acini"),
 #'   verbose = FALSE
 #' )

--- a/R/RunscOMM.R
+++ b/R/RunscOMM.R
@@ -32,7 +32,6 @@
 #' @export
 #' @examples
 #' \dontrun{
-#' \dontrun{
 #' data("pbmcmultiome_sub", package = "scop")
 #' pbmcmultiome_sub <- RunStandardWorkflow(pbmcmultiome_sub, assay = "RNA")
 #' ref_cells <- colnames(pbmcmultiome_sub)[1:250]
@@ -66,7 +65,6 @@
 #'   xlab = "UMAP_1",
 #'   ylab = "UMAP_2"
 #' )
-#' }
 #' }
 RunscOMM <- function(
   srt,

--- a/R/SCTransform.R
+++ b/R/SCTransform.R
@@ -562,8 +562,7 @@ SCTransform.Seurat <- function(
   methods::slot(assay.out, "data") <- data_layer
   rm(data_layer)
   scale.data <- vst.out$y[
-    rownames(assay.out)[rownames(assay.out) %in% rownames(vst.out$y)],
-    ,
+    rownames(assay.out)[rownames(assay.out) %in% rownames(vst.out$y)], ,
     drop = FALSE
   ]
   methods::slot(assay.out, "scale.data") <- scale.data

--- a/R/SpatialCore.R
+++ b/R/SpatialCore.R
@@ -290,7 +290,7 @@ spatial_image_x_orientation <- function(object, image) {
     if (length(orientation) == 0L) orientation <- "vertical"
   }
   if (length(orientation) != 1L || is.na(orientation) ||
-      !orientation %in% c("horizontal", "vertical")) {
+    !orientation %in% c("horizontal", "vertical")) {
     log_message("Image coords_x_orientation must be horizontal or vertical", message_type = "error")
   }
   orientation
@@ -511,7 +511,8 @@ SpatialCoordinates <- function(
 #' @examples
 #' data(visium_human_pancreas_sub)
 #' spatial <- SetSpatialImageAxes(
-#'   visium_human_pancreas_sub, image = "slice1", x_orientation = "horizontal"
+#'   visium_human_pancreas_sub,
+#'   image = "slice1", x_orientation = "horizontal"
 #' )
 #' SpatialCoordinates(spatial, image = "slice1")$source$coord.cols
 #' @export

--- a/R/SpatialDataConvert.R
+++ b/R/SpatialDataConvert.R
@@ -110,7 +110,7 @@ spe_to_srt <- function(
   }
   counts <- SummarizedExperiment::assay(spe, layer)
   if (length(coord.cols) != 2L || anyNA(coord.cols) ||
-      any(!nzchar(coord.cols)) || anyDuplicated(coord.cols)) {
+    any(!nzchar(coord.cols)) || anyDuplicated(coord.cols)) {
     log_message("{.arg coord.cols} must contain two unique non-empty names", message_type = "error")
   }
   meta <- as.data.frame(SummarizedExperiment::colData(spe), optional = TRUE)
@@ -134,7 +134,7 @@ spe_to_srt <- function(
     if (!is.null(provenance)) {
       space <- provenance$source$coordinate_space
       if (!is.character(space) || length(space) != 1L || is.na(space) ||
-          !space %in% c("raw", "display", "legacy_display")) {
+        !space %in% c("raw", "display", "legacy_display")) {
         log_message("Invalid SCOP SpatialExperiment coordinate provenance", message_type = "error")
       }
       if (space != "raw") {

--- a/R/SpatialDeconvolutionPlot.R
+++ b/R/SpatialDeconvolutionPlot.R
@@ -31,8 +31,10 @@
 #' data(panc8_sub)
 #' reference <- panc8_sub[, panc8_sub$celltype %in% c("ductal", "alpha", "beta")]
 #' reference <- Seurat::FindVariableFeatures(reference, nfeatures = 300, verbose = FALSE)
-#' features <- head(intersect(SeuratObject::VariableFeatures(reference),
-#'   rownames(visium_human_pancreas_sub)), 300)
+#' features <- head(intersect(
+#'   SeuratObject::VariableFeatures(reference),
+#'   rownames(visium_human_pancreas_sub)
+#' ), 300)
 #' spatial <- RunRCTD(
 #'   visium_human_pancreas_sub,
 #'   reference = reference,

--- a/R/SpatialNeighborhoodProfile.R
+++ b/R/SpatialNeighborhoodProfile.R
@@ -38,7 +38,8 @@
 #' object$row <- c(0, 0, 0, 0)
 #' object$celltype <- c("T", "M", "M", "T")
 #' profile <- SpatialNeighborhoodProfile(
-#'   object, "celltype", radii = c(1, 3), cells = "a", verbose = FALSE
+#'   object, "celltype",
+#'   radii = c(1, 3), cells = "a", verbose = FALSE
 #' )
 #' profile
 SpatialNeighborhoodProfile <- function(
@@ -51,7 +52,7 @@ SpatialNeighborhoodProfile <- function(
   validate_scalar_string(group.by, "group.by")
   if (!is.null(sample.by)) validate_scalar_string(sample.by, "sample.by")
   if (!is.numeric(radii) || !length(radii) || any(!is.finite(radii)) ||
-      any(radii <= 0) || any(diff(radii) <= 0)) {
+    any(radii <= 0) || any(diff(radii) <= 0)) {
     log_message(
       "{.arg radii} must be positive, finite and strictly increasing",
       message_type = "error"
@@ -75,7 +76,7 @@ SpatialNeighborhoodProfile <- function(
   co <- resolved$data
   idx <- match(co$cell_id, rownames(meta))
   if (!nrow(co) || anyNA(idx) || anyNA(co$cell_id) || any(!nzchar(co$cell_id)) ||
-      anyDuplicated(co$cell_id)) {
+    anyDuplicated(co$cell_id)) {
     log_message("invalid context cell IDs", message_type = "error")
   }
   labels <- as.character(meta[[group.by]][idx])
@@ -88,7 +89,7 @@ SpatialNeighborhoodProfile <- function(
   }
   if (is.null(cells)) cells <- co$cell_id
   if (!is.character(cells) || anyNA(cells) || anyDuplicated(cells) ||
-      !all(cells %in% co$cell_id)) {
+    !all(cells %in% co$cell_id)) {
     log_message(
       "{.arg cells} must be unique IDs in the resolved context",
       message_type = "error"
@@ -96,15 +97,17 @@ SpatialNeighborhoodProfile <- function(
   }
   xy <- as.matrix(co[, c("x", "y")])
   if (any(!is.finite(xy)) || min(radii) < sqrt(.Machine$double.xmin) ||
-      max(radii) > sqrt(.Machine$double.xmax) / 4 ||
-      max(abs(xy)) > sqrt(.Machine$double.xmax) / 4 || max(abs(xy)) / max(radii) > 1e12) {
+    max(radii) > sqrt(.Machine$double.xmax) / 4 ||
+    max(abs(xy)) > sqrt(.Machine$double.xmax) / 4 || max(abs(xy)) / max(radii) > 1e12) {
     log_message(
       "unsupported coordinate/radius magnitude; recenter or rescale",
       message_type = "error"
     )
   }
   groups <- sort(unique(labels))
-  nq <- length(cells); ng <- length(groups); nr <- length(radii)
+  nq <- length(cells)
+  ng <- length(groups)
+  nr <- length(radii)
   if (as.double(nq) * ng * nr > .Machine$integer.max) {
     log_message(
       "output too large; select fewer cells, groups or radii",
@@ -124,8 +127,10 @@ SpatialNeighborhoodProfile <- function(
   if (cumulative && nr > 1L) {
     for (b in 2:nr) counts[, , b] <- counts[, , b] + counts[, , b - 1L]
   }
-  out <- expand.grid(cell_id = cells, group = groups, radius = radii,
-                     KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE)
+  out <- expand.grid(
+    cell_id = cells, group = groups, radius = radii,
+    KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE
+  )
   out$sample <- rep(samples[target], ng * nr)
   out$lower <- rep(if (cumulative) rep(0, nr) else c(0, head(radii, -1L)), each = nq * ng)
   out$count <- as.vector(counts)
@@ -136,12 +141,16 @@ SpatialNeighborhoodProfile <- function(
   out$fraction[out$total == 0] <- NA_real_
   out <- out[, c("cell_id", "sample", "group", "lower", "radius", "count", "total", "fraction")]
   attr(out, "source") <- resolved$source
-  attr(out, "parameters") <- list(group.by = group.by, sample.by = sample.by,
-    radii = radii, cumulative = cumulative, context_n = nrow(co), backend = "native")
+  attr(out, "parameters") <- list(
+    group.by = group.by, sample.by = sample.by,
+    radii = radii, cumulative = cumulative, context_n = nrow(co), backend = "native"
+  )
   spatial_run_receipt(
     done = "Spatial neighborhood profile completed",
-    scope = sprintf("%s target cells; %s context cells; %s samples; %s distances (raw coordinate units).",
-                    nq, nrow(co), length(unique(samples)), nr),
+    scope = sprintf(
+      "%s target cells; %s context cells; %s samples; %s distances (raw coordinate units).",
+      nq, nrow(co), length(unique(samples)), nr
+    ),
     inspect = "Returned data.frame: count, total and fraction; input object unchanged.",
     verbose = verbose
   )

--- a/R/SpatialRunReceipt.R
+++ b/R/SpatialRunReceipt.R
@@ -33,30 +33,33 @@ spatial_run_receipt_display_scale <- function(srt, image) {
   if (is.null(image)) {
     return(NULL)
   }
-  tryCatch({
-    resolved_image <- spatial_image_resolve(
-      srt = srt,
-      image = image,
-      image_policy = "strict"
-    )$image
-    if (is.null(resolved_image)) {
-      return(NULL)
-    }
-    spatial_image <- srt[[resolved_image]]
-    candidates <- c("lowres", "hires")
-    usable <- vapply(candidates, function(candidate) {
-      scale <- spatial_image_scale_info(
-        spatial_image,
-        image.scale = candidate,
-        required = FALSE
-      )$scale
-      length(scale) == 1L && is.finite(scale) && scale > 0
-    }, logical(1))
-    if (!any(usable)) {
-      return(NULL)
-    }
-    candidates[[which(usable)[[1L]]]]
-  }, error = function(e) NULL)
+  tryCatch(
+    {
+      resolved_image <- spatial_image_resolve(
+        srt = srt,
+        image = image,
+        image_policy = "strict"
+      )$image
+      if (is.null(resolved_image)) {
+        return(NULL)
+      }
+      spatial_image <- srt[[resolved_image]]
+      candidates <- c("lowres", "hires")
+      usable <- vapply(candidates, function(candidate) {
+        scale <- spatial_image_scale_info(
+          spatial_image,
+          image.scale = candidate,
+          required = FALSE
+        )$scale
+        length(scale) == 1L && is.finite(scale) && scale > 0
+      }, logical(1))
+      if (!any(usable)) {
+        return(NULL)
+      }
+      candidates[[which(usable)[[1L]]]]
+    },
+    error = function(e) NULL
+  )
 }
 
 spatial_run_receipt <- function(

--- a/R/SpatialUtils.R
+++ b/R/SpatialUtils.R
@@ -126,8 +126,10 @@ spatial_sample_coords <- function(srt, sample.by, image = NULL,
       }
       selected <- candidates[[1L]]
     }
-    resolved <- spatial_analysis_coords(srt, image = selected, coord.cols = coord.cols,
-                                        coordinate_space = coordinate_space)
+    resolved <- spatial_analysis_coords(srt,
+      image = selected, coord.cols = coord.cols,
+      coordinate_space = coordinate_space
+    )
     if (!all(cells %in% resolved$data$cell_id)) {
       log_message("Selected image does not cover every cell in sample {.val {sample}}", message_type = "error")
     }

--- a/R/StandardWorkflow.R
+++ b/R/StandardWorkflow.R
@@ -1434,15 +1434,15 @@ run_standard_spatial_workflow <- function(
       preserve_empty_selection <-
         length(standard_spatial_variable_features(srt, assay = svf_assay)) ==
           0L &&
-        spatial_has_explicit_empty_variable_features(
-          srt,
-          assay = svf_assay,
-          expected_token = svf_selection_marker$token %||% NULL
-        ) &&
-        (
-          !svf_store_results ||
-            standard_spatial_svf_has_valid_empty_selection(srt)
-        )
+          spatial_has_explicit_empty_variable_features(
+            srt,
+            assay = svf_assay,
+            expected_token = svf_selection_marker$token %||% NULL
+          ) &&
+          (
+            !svf_store_results ||
+              standard_spatial_svf_has_valid_empty_selection(srt)
+          )
       srt <- standard_spatial_restore_variable_feature_info(
         srt,
         assay = svf_assay,

--- a/R/integration.R
+++ b/R/integration.R
@@ -3138,8 +3138,7 @@ BBKNN_integrate <- function(
 }
 
 bbknn_seurat_annoy_cross <- function(reference, query, k, n_trees, metric) {
-  seurat_metric <- switch(
-    metric,
+  seurat_metric <- switch(metric,
     angular = "cosine",
     euclidean = "euclidean",
     manhattan = "manhattan",

--- a/man/RunCellTypist.Rd
+++ b/man/RunCellTypist.Rd
@@ -92,10 +92,12 @@ on a Seurat object or AnnData object.
 check_python(c("celltypist", "anndata"))
 data(pbmcmultiome_sub)
 pbmcmultiome_sub <- RunStandardWorkflow(
-  pbmcmultiome_sub, assay = "RNA", linear_reduction_dims = 10
+  pbmcmultiome_sub,
+  assay = "RNA", linear_reduction_dims = 10
 )
 pbmcmultiome_sub <- RunCellTypist(
-  pbmcmultiome_sub, model = "Immune_All_Low.pkl", verbose = FALSE
+  pbmcmultiome_sub,
+  model = "Immune_All_Low.pkl", verbose = FALSE
 )
 }
 }

--- a/man/RunKNNMap.Rd
+++ b/man/RunKNNMap.Rd
@@ -101,7 +101,8 @@ data(panc8_sub)
 keep <- panc8_sub$celltype \%in\% c("ductal", "alpha", "beta")
 panc8_sub <- panc8_sub[, keep]
 panc8_sub <- RunStandardWorkflow(
-  panc8_sub, verbose = FALSE, linear_reduction_dims = 10
+  panc8_sub,
+  verbose = FALSE, linear_reduction_dims = 10
 )
 srt_ref <- panc8_sub[, panc8_sub$tech != "fluidigmc1"]
 srt_query <- panc8_sub[, panc8_sub$tech == "fluidigmc1"]

--- a/man/RunKNNPredict.Rd
+++ b/man/RunKNNPredict.Rd
@@ -130,13 +130,15 @@ query <- Seurat::NormalizeData(
 )
 genes <- head(intersect(rownames(reference), rownames(query)), 200)
 query <- RunKNNPredict(
-  query, srt_ref = reference, ref_group = "celltype",
+  query,
+  srt_ref = reference, ref_group = "celltype",
   features = genes, nfeatures = length(genes),
   ref_collapsing = FALSE, k = 10, verbose = FALSE
 )
 query <- RunStandardWorkflow(query, verbose = FALSE, linear_reduction_dims = 10)
 CellDimPlot(
-  query, group.by = "KNNPredict_classification",
+  query,
+  group.by = "KNNPredict_classification",
   label = TRUE, legend.position = "bottom"
 )
 FeatureStatPlot(

--- a/man/RunMERINGUE.Rd
+++ b/man/RunMERINGUE.Rd
@@ -110,7 +110,8 @@ spatial module analysis for a spatial \code{Seurat} object.
 \dontrun{
 data(visium_human_pancreas_sub)
 visium_human_pancreas_sub <- Seurat::NormalizeData(
-  visium_human_pancreas_sub, assay = "Spatial", verbose = FALSE
+  visium_human_pancreas_sub,
+  assay = "Spatial", verbose = FALSE
 )
 spatial <- RunMERINGUE(
   visium_human_pancreas_sub,

--- a/man/RunMistyR.Rd
+++ b/man/RunMistyR.Rd
@@ -97,7 +97,8 @@ data(visium_human_pancreas_sub)
 spatial <- Seurat::NormalizeData(visium_human_pancreas_sub, verbose = FALSE)
 # Paraview bandwidth: 1000 full-resolution image pixels.
 spatial <- RunMistyR(
-  spatial, assay = "Spatial", features = rownames(spatial)[1:5],
+  spatial,
+  assay = "Spatial", features = rownames(spatial)[1:5],
   image = "slice1", views = "para", para_l = 1000,
   cv_folds = 3, verbose = FALSE
 )

--- a/man/RunSciBet.Rd
+++ b/man/RunSciBet.Rd
@@ -89,7 +89,8 @@ query <- RunSciBet(
 )
 query <- RunStandardWorkflow(query, verbose = FALSE, linear_reduction_dims = 10)
 CellDimPlot(
-  query, group.by = "scibet_annotation",
+  query,
+  group.by = "scibet_annotation",
   label = TRUE, legend.position = "bottom"
 )
 }

--- a/man/RunScmap.Rd
+++ b/man/RunScmap.Rd
@@ -59,7 +59,8 @@ query <- RunScmap(
 )
 query <- RunStandardWorkflow(query, verbose = FALSE, linear_reduction_dims = 10)
 CellDimPlot(
-  query, group.by = "scmap_annotation",
+  query,
+  group.by = "scmap_annotation",
   label = TRUE, legend.position = "bottom"
 )
 }

--- a/man/RunSingleR.Rd
+++ b/man/RunSingleR.Rd
@@ -101,11 +101,13 @@ query <- RunSingleR(
 )
 query <- RunStandardWorkflow(query, verbose = FALSE, linear_reduction_dims = 10)
 CellDimPlot(
-  query, group.by = "singler_annotation",
+  query,
+  group.by = "singler_annotation",
   label = TRUE, legend.position = "bottom"
 )
 FeatureStatPlot(
-  query, stat.by = "singler_score",
+  query,
+  stat.by = "singler_score",
   group.by = "singler_annotation"
 )
 }

--- a/man/RunSpatialBenchmark.Rd
+++ b/man/RunSpatialBenchmark.Rd
@@ -79,11 +79,15 @@ n_spots <- 36L
 n_genes <- 60L
 grid <- expand.grid(x = 1:6, y = 1:6)
 domain <- factor(ifelse(grid$x <= 2, "left", ifelse(grid$x <= 4, "middle", "right")))
-counts <- matrix(rpois(n_genes * n_spots, 2), nrow = n_genes,
-  dimnames = list(paste0("Gene", seq_len(n_genes)), paste0("spot", seq_len(n_spots))))
+counts <- matrix(rpois(n_genes * n_spots, 2),
+  nrow = n_genes,
+  dimnames = list(paste0("Gene", seq_len(n_genes)), paste0("spot", seq_len(n_spots)))
+)
 signal <- split(seq_len(n_genes), rep(c("left", "middle", "right"), each = 20))
-for (label in names(signal)) counts[signal[[label]], domain == label] <-
-  counts[signal[[label]], domain == label] + rpois(sum(domain == label) * 20, 5)
+for (label in names(signal)) {
+  counts[signal[[label]], domain == label] <-
+    counts[signal[[label]], domain == label] + rpois(sum(domain == label) * 20, 5)
+}
 spatial <- SeuratObject::CreateSeuratObject(counts)
 spatial$x <- grid$x
 spatial$y <- grid$y

--- a/man/RunSpatialCellChat.Rd
+++ b/man/RunSpatialCellChat.Rd
@@ -170,7 +170,8 @@ additional analysis with the upstream SpatialCellChat object is needed.
 \dontrun{
 data(visium_human_pancreas_sub)
 visium_human_pancreas_sub <- Seurat::NormalizeData(
-  visium_human_pancreas_sub, assay = "Spatial", verbose = FALSE
+  visium_human_pancreas_sub,
+  assay = "Spatial", verbose = FALSE
 )
 # Group Visium spots by their CODA tissue labels.
 spatial <- RunSpatialCellChat(

--- a/man/RunStatialKontextual.Rd
+++ b/man/RunStatialKontextual.Rd
@@ -95,7 +95,8 @@ parent context using Statial Kontextual.
 data(visium_human_pancreas_sub)
 # Compare tissue-labelled spots at two radii (full-resolution image pixels).
 spatial <- RunStatialKontextual(
-  visium_human_pancreas_sub, group.by = "coda_label", image = "slice1",
+  visium_human_pancreas_sub,
+  group.by = "coda_label", image = "slice1",
   r = c(500, 1000), from = "collagen", to = "acini", parent = c("collagen", "acini"),
   verbose = FALSE
 )

--- a/man/RunscOMM.Rd
+++ b/man/RunscOMM.Rd
@@ -72,7 +72,6 @@ evaluate predictions against a truth label.
 }
 \examples{
 \dontrun{
-\dontrun{
 data("pbmcmultiome_sub", package = "scop")
 pbmcmultiome_sub <- RunStandardWorkflow(pbmcmultiome_sub, assay = "RNA")
 ref_cells <- colnames(pbmcmultiome_sub)[1:250]
@@ -106,6 +105,5 @@ FeatureDimPlot(
   xlab = "UMAP_1",
   ylab = "UMAP_2"
 )
-}
 }
 }

--- a/man/SetSpatialImageAxes.Rd
+++ b/man/SetSpatialImageAxes.Rd
@@ -32,7 +32,8 @@ analyses must be rerun after changing the convention.
 \examples{
 data(visium_human_pancreas_sub)
 spatial <- SetSpatialImageAxes(
-  visium_human_pancreas_sub, image = "slice1", x_orientation = "horizontal"
+  visium_human_pancreas_sub,
+  image = "slice1", x_orientation = "horizontal"
 )
 SpatialCoordinates(spatial, image = "slice1")$source$coord.cols
 }

--- a/man/SpatialDeconvolutionPlot.Rd
+++ b/man/SpatialDeconvolutionPlot.Rd
@@ -55,8 +55,10 @@ data(visium_human_pancreas_sub)
 data(panc8_sub)
 reference <- panc8_sub[, panc8_sub$celltype \%in\% c("ductal", "alpha", "beta")]
 reference <- Seurat::FindVariableFeatures(reference, nfeatures = 300, verbose = FALSE)
-features <- head(intersect(SeuratObject::VariableFeatures(reference),
-  rownames(visium_human_pancreas_sub)), 300)
+features <- head(intersect(
+  SeuratObject::VariableFeatures(reference),
+  rownames(visium_human_pancreas_sub)
+), 300)
 spatial <- RunRCTD(
   visium_human_pancreas_sub,
   reference = reference,

--- a/man/SpatialNeighborhoodProfile.Rd
+++ b/man/SpatialNeighborhoodProfile.Rd
@@ -66,7 +66,8 @@ object$col <- c(0, 1, 3, 5)
 object$row <- c(0, 0, 0, 0)
 object$celltype <- c("T", "M", "M", "T")
 profile <- SpatialNeighborhoodProfile(
-  object, "celltype", radii = c(1, 3), cells = "a", verbose = FALSE
+  object, "celltype",
+  radii = c(1, 3), cells = "a", verbose = FALSE
 )
 profile
 }

--- a/man/TrainCellTypist.Rd
+++ b/man/TrainCellTypist.Rd
@@ -110,7 +110,8 @@ Train a CellTypist model from a Seurat object, AnnData object, or h5ad file.
 check_python(c("celltypist", "anndata"))
 data(pbmcmultiome_sub)
 pbmcmultiome_sub <- RunStandardWorkflow(
-  pbmcmultiome_sub, assay = "RNA", linear_reduction_dims = 10
+  pbmcmultiome_sub,
+  assay = "RNA", linear_reduction_dims = 10
 )
 model_info <- TrainCellTypist(
   srt = pbmcmultiome_sub, labels = "CellType",

--- a/tests/testthat/test-cell2location.R
+++ b/tests/testthat/test-cell2location.R
@@ -180,11 +180,13 @@ test_that("RunCell2location writes abundance, proportions, and reproducible tool
       checked_python_packages <<- packages
       TRUE
     },
-    conda_python = function(...) normalizePath(
-      file.path(R.home("bin"), if (.Platform$OS.type == "windows") "Rscript.exe" else "R"),
-      winslash = "/",
-      mustWork = TRUE
-    ),
+    conda_python = function(...) {
+      normalizePath(
+        file.path(R.home("bin"), if (.Platform$OS.type == "windows") "Rscript.exe" else "R"),
+        winslash = "/",
+        mustWork = TRUE
+      )
+    },
     resolve_conda = function(...) "mamba",
     runner_script_path = function(...) "cell2location.py",
     runner_write_json = function(...) invisible(NULL),
@@ -252,11 +254,13 @@ test_that("RunCell2location does not mutate Seurat when Python fails", {
     .package = "scop",
     PrepareEnv = function(...) invisible(NULL),
     check_python = function(...) TRUE,
-    conda_python = function(...) normalizePath(
-      file.path(R.home("bin"), if (.Platform$OS.type == "windows") "Rscript.exe" else "R"),
-      winslash = "/",
-      mustWork = TRUE
-    ),
+    conda_python = function(...) {
+      normalizePath(
+        file.path(R.home("bin"), if (.Platform$OS.type == "windows") "Rscript.exe" else "R"),
+        winslash = "/",
+        mustWork = TRUE
+      )
+    },
     resolve_conda = function(...) "mamba",
     runner_script_path = function(...) "cell2location.py",
     runner_write_json = function(...) invisible(NULL),
@@ -297,15 +301,13 @@ test_that("standard spatial workflow dispatches cell2location signatures", {
   testthat::local_mocked_bindings(
     .package = "scop",
     RunStandardWorkflow = function(srt, ...) srt,
-    RunCell2location = function(
-      srt,
-      result_dir,
-      reference_signatures,
-      prefix,
-      tool_name,
-      store_results,
-      ...
-    ) {
+    RunCell2location = function(srt,
+                                result_dir,
+                                reference_signatures,
+                                prefix,
+                                tool_name,
+                                store_results,
+                                ...) {
       called <<- TRUE
       expect_identical(result_dir, "c2l")
       expect_identical(reference_signatures, signatures)

--- a/tests/testthat/test-cpp-backend-safety.R
+++ b/tests/testthat/test-cpp-backend-safety.R
@@ -131,7 +131,8 @@ test_that("PAGA C++ keeps embedded_with_PAGA native", {
   skip_if_not_installed("BiocNeighbors")
   srt <- make_cpp_backend_safety_object()
   out <- RunPAGA(
-    srt, group.by = "group", linear_reduction = "pca",
+    srt,
+    group.by = "group", linear_reduction = "pca",
     nonlinear_reduction = "umap", n_neighbors = 5L,
     embedded_with_PAGA = TRUE, backend = "cpp",
     show_plot = FALSE, verbose = FALSE
@@ -146,7 +147,8 @@ test_that("PHATE C++ handles gamma, native distance, MDS, and clustering", {
   data <- matrix(stats::rnorm(180), nrow = 30L)
   rownames(data) <- paste0("cell", seq_len(nrow(data)))
   out <- RunPHATE(
-    data, assay = "RNA", backend = "cpp", n_pca = NULL, n_landmark = 30L,
+    data,
+    assay = "RNA", backend = "cpp", n_pca = NULL, n_landmark = 30L,
     knn = 5L, t = 3L, gamma = 0, knn_dist = "cosine",
     mds = "metric", do_cluster = TRUE, n_clusters = 3L
   )
@@ -158,7 +160,8 @@ test_that("PHATE C++ handles gamma, native distance, MDS, and clustering", {
 test_that("scVelo C++ handles native postprocessing parameters", {
   srt <- make_cpp_backend_safety_object()
   out <- RunSCVELO(
-    srt, assay_y = c("spliced", "unspliced"), group.by = "group",
+    srt,
+    assay_y = c("spliced", "unspliced"), group.by = "group",
     linear_reduction = "pca", nonlinear_reduction = "umap",
     n_neighbors = 5L, backend = "cpp", filter_genes = FALSE,
     magic_impute = TRUE, knn = 3L, t = 2L,
@@ -176,7 +179,8 @@ test_that("CellRank C++ accepts Schur, terminal, lineage, and graph controls", {
   srt <- make_cpp_backend_safety_object()
   srt$custom_time <- seq(0, 1, length.out = ncol(srt))
   out <- RunCellRank(
-    srt, group.by = "group", linear_reduction = "pca",
+    srt,
+    group.by = "group", linear_reduction = "pca",
     nonlinear_reduction = "umap", kernel_type = "pseudotime",
     time_key = "custom_time", n_neighbors = 5L, n_macrostates = 3L,
     schur_method = "krylov", schur_n_components = 6L,

--- a/tests/testthat/test-cside-truthfulness.R
+++ b/tests/testthat/test-cside-truthfulness.R
@@ -1,6 +1,7 @@
 test_that("C-SIDE summaries count records rather than unique genes", {
   srt <- Seurat::CreateSeuratObject(matrix(1:6, 2,
-    dimnames = list(c("g1", "g2"), c("s1", "s2", "s3"))))
+    dimnames = list(c("g1", "g2"), c("s1", "s2", "s3"))
+  ))
   tab <- data.frame(feature = c("g1", "g1", "g2"), significant = c(TRUE, TRUE, FALSE))
   meta <- cside_summary_metadata(srt, "custom", "single", tab)
   expect_identical(meta$custom_n_sig, rep(2L, 3))

--- a/tests/testthat/test-gradient-truthfulness.R
+++ b/tests/testthat/test-gradient-truthfulness.R
@@ -8,24 +8,39 @@ test_that("gradient flags independently control storage and variable features", 
   srt$y <- c(1, 1, 2, 2)
   srt <- spatial_set_active_variable_features(srt, "other", "g3")
   srt@tools$SpatialGradientFeatures <- list(new = "unchanged")
-  payload <- list(screening = data.frame(), significance = data.frame(),
-    model_fits = data.frame(), top_variables = data.frame(variable = "g1"), parameters = data.frame())
+  payload <- list(
+    screening = data.frame(), significance = data.frame(),
+    model_fits = data.frame(), top_variables = data.frame(variable = "g1"), parameters = data.frame()
+  )
   local_mocked_bindings(sgf_run_cpp_gradient = function(...) payload, .package = "scop")
-  run <- function(...) RunSpatialGradientFeatures(srt, assay = "other", layer = "counts",
-    variables = "g1", result_name = "new", verbose = FALSE, ...)
+  run <- function(...) {
+    RunSpatialGradientFeatures(srt,
+      assay = "other", layer = "counts",
+      variables = "g1", result_name = "new", verbose = FALSE, ...
+    )
+  }
   for (empty in c(FALSE, TRUE)) {
     payload$top_variables <- data.frame(variable = if (empty) character() else "g1")
-    for (save in c(FALSE, TRUE)) for (update in c(FALSE, TRUE)) {
-      out <- run(store_results = save, set_variable_features = update)
-      selected <- SeuratObject::VariableFeatures(out, assay = "other")
-      selected <- as.character(selected[!is.na(selected)])
-      expect_identical(selected,
-        if (update) payload$top_variables$variable else "g3")
-      expect_identical(out[["RNA"]], srt[["RNA"]])
-      if (update && empty) expect_true(spatial_has_explicit_empty_variable_features(out, "other"))
-      if (save) expect_identical(out@tools$SpatialGradientFeatures$new$top_variables,
-        payload$top_variables)
-      else expect_identical(out@tools, srt@tools)
+    for (save in c(FALSE, TRUE)) {
+      for (update in c(FALSE, TRUE)) {
+        out <- run(store_results = save, set_variable_features = update)
+        selected <- SeuratObject::VariableFeatures(out, assay = "other")
+        selected <- as.character(selected[!is.na(selected)])
+        expect_identical(
+          selected,
+          if (update) payload$top_variables$variable else "g3"
+        )
+        expect_identical(out[["RNA"]], srt[["RNA"]])
+        if (update && empty) expect_true(spatial_has_explicit_empty_variable_features(out, "other"))
+        if (save) {
+          expect_identical(
+            out@tools$SpatialGradientFeatures$new$top_variables,
+            payload$top_variables
+          )
+        } else {
+          expect_identical(out@tools, srt@tools)
+        }
+      }
     }
   }
   for (bad in list(NA, 1, logical(), c(TRUE, FALSE))) {
@@ -41,9 +56,12 @@ test_that("gradient flags independently control storage and variable features", 
 
 test_that("active variable feature helper supports legacy assays and ranked Assay5 selections", {
   counts <- Matrix::Matrix(matrix(1:12, 3,
-    dimnames = list(paste0("g", 1:3), paste0("s", 1:4))), sparse = TRUE)
-  for (assay in list(SeuratObject::CreateAssayObject(counts = counts),
-                     SeuratObject::CreateAssay5Object(counts = counts))) {
+    dimnames = list(paste0("g", 1:3), paste0("s", 1:4))
+  ), sparse = TRUE)
+  for (assay in list(
+    SeuratObject::CreateAssayObject(counts = counts),
+    SeuratObject::CreateAssay5Object(counts = counts)
+  )) {
     srt <- Seurat::CreateSeuratObject(assay)
     expect_error(spatial_set_active_variable_features(srt, "RNA", "absent"), "None of the features")
     srt <- spatial_set_active_variable_features(srt, "RNA", c("g2", "g1", "g2"))

--- a/tests/testthat/test-neighborhood-truthfulness.R
+++ b/tests/testthat/test-neighborhood-truthfulness.R
@@ -8,8 +8,10 @@ test_that("neighborhood counts preserve saved scope, zero and unknown values", {
       expect_identical(weight, "binary")
       distances <- as.matrix(stats::dist(coords[, c("x", "y")]))
       hit <- which(distances <= radius & row(distances) != col(distances), arr.ind = TRUE)
-      list(edges = data.frame(from = hit[, 1L], to = hit[, 2L],
-        distance = distances[hit]))
+      list(edges = data.frame(
+        from = hit[, 1L], to = hit[, 2L],
+        distance = distances[hit]
+      ))
     },
     get_namespace_fun = function(pkg, fun, ...) {
       stop(paste("Unexpected optional namespace lookup:", pkg, fun))
@@ -17,15 +19,20 @@ test_that("neighborhood counts preserve saved scope, zero and unknown values", {
     .package = "scop"
   )
   srt <- Seurat::CreateSeuratObject(matrix(1:12, 2,
-    dimnames = list(c("g1", "g2"), paste0("s", 1:6))))
+    dimnames = list(c("g1", "g2"), paste0("s", 1:6))
+  ))
   srt$x <- c(0, 1, 20, 30, 31, 90)
   srt$y <- rep(0, 6)
   srt$label <- c("A", "B", "A", "A", "B", NA)
   srt$condition <- c("one", "one", "one", "two", "two", "one")
   srt$sample <- c("x", "x", "x", "y", "y", "x")
-  run <- function(radius = 2, ...) RunSpatialNeighborhood(srt, group.by = "label",
-    method = "observed", sample.by = "sample", split.by = "condition",
-    coord.cols = c("x", "y"), radius = radius, verbose = FALSE, ...)
+  run <- function(radius = 2, ...) {
+    RunSpatialNeighborhood(srt,
+      group.by = "label",
+      method = "observed", sample.by = "sample", split.by = "condition",
+      coord.cols = c("x", "y"), radius = radius, verbose = FALSE, ...
+    )
+  }
   out <- run(backend = "r")
   local_mocked_bindings(SpatialSpotPlot = function(srt, values, ...) values, .package = "scop")
   plot <- function(object = out, ...) SpatialNeighborhoodPlot(object, plot_type = "spatial", ...)
@@ -59,14 +66,19 @@ test_that("neighborhood counts preserve saved scope, zero and unknown values", {
 test_that("empty native neighborhoods render and aggregation backends agree", {
   testthat::skip_if_not_installed("BiocNeighbors")
   srt <- Seurat::CreateSeuratObject(Matrix::Matrix(matrix(1:8, 2,
-    dimnames = list(c("g1", "g2"), paste0("s", 1:4))), sparse = TRUE))
+    dimnames = list(c("g1", "g2"), paste0("s", 1:4))
+  ), sparse = TRUE))
   srt$x <- c(0, 1, 0, 1)
   srt$y <- rep(0, 4)
   srt$label <- c("A", "B", "A", "B")
   srt$sample <- c("x", "x", "y", "y")
-  run <- function(backend, radius) RunSpatialNeighborhood(srt, group.by = "label",
-    sample.by = "sample", coord.cols = c("x", "y"), radius = radius,
-    backend = backend, verbose = FALSE)
+  run <- function(backend, radius) {
+    RunSpatialNeighborhood(srt,
+      group.by = "label",
+      sample.by = "sample", coord.cols = c("x", "y"), radius = radius,
+      backend = backend, verbose = FALSE
+    )
+  }
   for (radius in c(0.01, 2)) {
     r <- run("r", radius)
     cpp <- run("cpp", radius)
@@ -80,7 +92,9 @@ test_that("empty native neighborhoods render and aggregation backends agree", {
     expect_equal(canonical(rb$pair_table), canonical(cb$pair_table))
     expect_equal(rb$edge_table, cb$edge_table)
     expect_equal(nrow(cb$edge_table), if (radius < 1) 0 else 4)
-    expect_s3_class(SpatialNeighborhoodPlot(cpp, plot_type = "spatial", pair = "A|B",
-      coord.cols = c("x", "y"), overlay_image = FALSE, theme_use = NULL), "ggplot")
+    expect_s3_class(SpatialNeighborhoodPlot(cpp,
+      plot_type = "spatial", pair = "A|B",
+      coord.cols = c("x", "y"), overlay_image = FALSE, theme_use = NULL
+    ), "ggplot")
   }
 })

--- a/tests/testthat/test-plot-theme-utils.R
+++ b/tests/testthat/test-plot-theme-utils.R
@@ -74,4 +74,3 @@ test_that("spatial_dim_continuous_scale respects upper_quantile and squish", {
   expect_equal(unname(sc100$limits), c(1, 100))
   expect_equal(sc99$oob(c(-10, 50, 150), range = c(0, 100)), c(0, 50, 100))
 })
-

--- a/tests/testthat/test-presto-backend.R
+++ b/tests/testthat/test-presto-backend.R
@@ -109,11 +109,9 @@ test_that("FindAllMarkers probes Presto only after support checks and before mar
       events <<- c(events, "supported")
       identical(test.use, "wilcox")
     },
-    presto_get_fun = function(
-      fun = "wilcoxauc",
-      install = FALSE,
-      error_on_missing = TRUE
-    ) {
+    presto_get_fun = function(fun = "wilcoxauc",
+                              install = FALSE,
+                              error_on_missing = TRUE) {
       events <<- c(events, "presto")
       expect_identical(fun, "wilcoxauc")
       expect_false(install)
@@ -234,11 +232,9 @@ test_that("automatic marker fast paths fall back without installing Presto", {
   all_fallback <- data.frame(path = "all")
   requests <- list()
   testthat::local_mocked_bindings(
-    presto_get_fun = function(
-      fun = "wilcoxauc",
-      install = FALSE,
-      error_on_missing = TRUE
-    ) {
+    presto_get_fun = function(fun = "wilcoxauc",
+                              install = FALSE,
+                              error_on_missing = TRUE) {
       requests[[length(requests) + 1L]] <<- list(
         fun = fun,
         install = install,

--- a/tests/testthat/test-projection-and-heatmap-borders.R
+++ b/tests/testthat/test-projection-and-heatmap-borders.R
@@ -111,7 +111,8 @@ test_that("ProjectionPlot rasterizes the final query overlay when requested", {
     }, .package = "ggrastr"
   )
   expect_no_error(ProjectionPlot(
-    query, reference, query_group = "group", ref_group = "group",
+    query, reference,
+    query_group = "group", ref_group = "group",
     query_reduction = "umap", ref_reduction = "umap",
     query_param = list(raster = TRUE, label = FALSE),
     ref_param = list(raster = TRUE, label = FALSE), verbose = FALSE

--- a/tests/testthat/test-run-cside.R
+++ b/tests/testthat/test-run-cside.R
@@ -38,8 +38,10 @@ test_cside_truthful_storage <- function() {
     if (isTRUE(verbose)) messages <<- c(messages, message)
   }, .package = "scop")
   with_mock_cside(list("run.CSIDE.single" = function(...) mock_cside_result()), {
-    out <- RunCSIDE(srt, condition.by = "condition", store_results = FALSE,
-      tool_name = "custom", prefix = "custom")
+    out <- RunCSIDE(srt,
+      condition.by = "condition", store_results = FALSE,
+      tool_name = "custom", prefix = "custom"
+    )
     expect_identical(out@tools$custom, srt@tools$custom)
     expect_equal(unique(out$custom_n_sig), 1)
     expect_true(any(grepl("not stored", messages)))

--- a/tests/testthat/test-run-spotlight.R
+++ b/tests/testthat/test-run-spotlight.R
@@ -262,17 +262,15 @@ test_that("standard spatial workflow dispatches to RunSPOTlight", {
   testthat::local_mocked_bindings(
     .package = "scop",
     RunSpotQC = function(srt, ...) srt,
-    RunSPOTlight = function(
-      srt,
-      reference,
-      reference_label,
-      assay,
-      reference_assay,
-      prefix,
-      tool_name,
-      store_results,
-      ...
-    ) {
+    RunSPOTlight = function(srt,
+                            reference,
+                            reference_label,
+                            assay,
+                            reference_assay,
+                            prefix,
+                            tool_name,
+                            store_results,
+                            ...) {
       expect_identical(reference, pair$reference)
       expect_identical(reference_label, "celltype")
       expect_identical(assay, "RNA")

--- a/tests/testthat/test-run-spotsweeper.R
+++ b/tests/testthat/test-run-spotsweeper.R
@@ -168,11 +168,9 @@ capture_spotsweeper_logs <- function(code) {
   events <- list()
   testthat::local_mocked_bindings(
     .package = "scop",
-    log_message = function(
-      ...,
-      verbose = NULL,
-      message_type = c("info", "success", "warning", "error", "running", "ask")
-    ) {
+    log_message = function(...,
+                           verbose = NULL,
+                           message_type = c("info", "success", "warning", "error", "running", "ask")) {
       message_type <- match.arg(message_type)
       text <- paste(vapply(
         list(...),
@@ -272,17 +270,20 @@ test_that("RunSpotSweeper skips artifact detection when mitochondrial signal is 
 test_that("RunSpotSweeper marks artifact backend failures as partial", {
   skip_if_no_spotsweeper_infra()
   srt <- make_spotsweeper_seurat()
-  out <- suppressWarnings(with_mock_spotsweeper({
-    RunSpotSweeper(
-      srt,
-      layer = "counts",
-      coord.cols = c("x", "y"),
-      sample.by = "sample",
-      n_neighbors = 2,
-      n_order = 2,
-      verbose = FALSE
-    )
-  }, artifact_mode = "error"))
+  out <- suppressWarnings(with_mock_spotsweeper(
+    {
+      RunSpotSweeper(
+        srt,
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        n_order = 2,
+        verbose = FALSE
+      )
+    },
+    artifact_mode = "error"
+  ))
 
   expect_identical(out@tools$SpotSweeper$status, "partial")
   expect_true(all(out@tools$SpotSweeper$artifact_status$status == "failed"))
@@ -301,17 +302,20 @@ test_that("RunSpotSweeper rejects missing or invalid artifact backend output tru
   )
   for (artifact_mode in names(expected_reason)) {
     srt <- make_spotsweeper_seurat()
-    out <- suppressWarnings(with_mock_spotsweeper({
-      RunSpotSweeper(
-        srt,
-        layer = "counts",
-        coord.cols = c("x", "y"),
-        sample.by = "sample",
-        n_neighbors = 2,
-        n_order = 2,
-        verbose = FALSE
-      )
-    }, artifact_mode = artifact_mode))
+    out <- suppressWarnings(with_mock_spotsweeper(
+      {
+        RunSpotSweeper(
+          srt,
+          layer = "counts",
+          coord.cols = c("x", "y"),
+          sample.by = "sample",
+          n_neighbors = 2,
+          n_order = 2,
+          verbose = FALSE
+        )
+      },
+      artifact_mode = artifact_mode
+    ))
 
     status <- out@tools$SpotSweeper$artifact_status
     expect_identical(out@tools$SpotSweeper$status, "partial")
@@ -326,17 +330,20 @@ test_that("RunSpotSweeper rejects missing or invalid artifact backend output tru
 test_that("RunSpotSweeper rejects artifact output with changed spot alignment", {
   skip_if_no_spotsweeper_infra()
   for (artifact_mode in c("drop", "rename", "reorder")) {
-    out <- suppressWarnings(with_mock_spotsweeper({
-      RunSpotSweeper(
-        make_spotsweeper_seurat(),
-        layer = "counts",
-        coord.cols = c("x", "y"),
-        sample.by = "sample",
-        n_neighbors = 2,
-        n_order = 2,
-        verbose = FALSE
-      )
-    }, artifact_mode = artifact_mode))
+    out <- suppressWarnings(with_mock_spotsweeper(
+      {
+        RunSpotSweeper(
+          make_spotsweeper_seurat(),
+          layer = "counts",
+          coord.cols = c("x", "y"),
+          sample.by = "sample",
+          n_neighbors = 2,
+          n_order = 2,
+          verbose = FALSE
+        )
+      },
+      artifact_mode = artifact_mode
+    ))
 
     status <- out@tools$SpotSweeper$artifact_status
     expect_identical(out@tools$SpotSweeper$status, "partial", info = artifact_mode)
@@ -357,17 +364,20 @@ test_that("RunSpotSweeper rejects artifact output with changed spot alignment", 
 test_that("RunSpotSweeper marks incomplete local-outlier output partial", {
   skip_if_no_spotsweeper_infra()
   for (local_mode in c("missing", "partial", "invalid")) {
-    out <- suppressMessages(with_mock_spotsweeper({
-      RunSpotSweeper(
-        make_spotsweeper_seurat(),
-        layer = "counts",
-        coord.cols = c("x", "y"),
-        sample.by = "sample",
-        n_neighbors = 2,
-        run_artifact = FALSE,
-        verbose = TRUE
-      )
-    }, local_mode = local_mode))
+    out <- suppressMessages(with_mock_spotsweeper(
+      {
+        RunSpotSweeper(
+          make_spotsweeper_seurat(),
+          layer = "counts",
+          coord.cols = c("x", "y"),
+          sample.by = "sample",
+          n_neighbors = 2,
+          run_artifact = FALSE,
+          verbose = TRUE
+        )
+      },
+      local_mode = local_mode
+    ))
 
     expect_identical(out@tools$SpotSweeper$status, "partial", info = local_mode)
     expect_true(any(
@@ -377,18 +387,21 @@ test_that("RunSpotSweeper marks incomplete local-outlier output partial", {
   }
 
   expect_error(
-    with_mock_spotsweeper({
-      RunSpotSweeper(
-        make_spotsweeper_seurat(),
-        layer = "counts",
-        coord.cols = c("x", "y"),
-        sample.by = "sample",
-        n_neighbors = 2,
-        run_artifact = FALSE,
-        return_filtered = TRUE,
-        verbose = FALSE
-      )
-    }, local_mode = "missing"),
+    with_mock_spotsweeper(
+      {
+        RunSpotSweeper(
+          make_spotsweeper_seurat(),
+          layer = "counts",
+          coord.cols = c("x", "y"),
+          sample.by = "sample",
+          n_neighbors = 2,
+          run_artifact = FALSE,
+          return_filtered = TRUE,
+          verbose = FALSE
+        )
+      },
+      local_mode = "missing"
+    ),
     "completed for every spot"
   )
 })
@@ -402,17 +415,20 @@ test_that("RunSpotSweeper does not reuse stale local-outlier metadata", {
     srt[[paste0(metric, "_z")]] <- 0
   }
 
-  out <- suppressMessages(with_mock_spotsweeper({
-    RunSpotSweeper(
-      srt,
-      layer = "counts",
-      coord.cols = c("x", "y"),
-      sample.by = "sample",
-      n_neighbors = 2,
-      run_artifact = FALSE,
-      verbose = TRUE
-    )
-  }, local_mode = "missing"))
+  out <- suppressMessages(with_mock_spotsweeper(
+    {
+      RunSpotSweeper(
+        srt,
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        run_artifact = FALSE,
+        verbose = TRUE
+      )
+    },
+    local_mode = "missing"
+  ))
 
   expect_identical(out@tools$SpotSweeper$status, "partial")
   expect_true(all(as.character(out$SpotSweeper_local_outlier_qc) == "NotEvaluated"))
@@ -457,16 +473,19 @@ test_that("RunSpotSweeper does not reuse a stale artifact metadata column", {
   srt$artifact <- rep(c(TRUE, FALSE), length.out = ncol(srt))
   artifact_before <- srt$artifact
 
-  out <- suppressMessages(with_mock_spotsweeper({
-    RunSpotSweeper(
-      srt,
-      layer = "counts",
-      coord.cols = c("x", "y"),
-      sample.by = "sample",
-      n_neighbors = 2,
-      verbose = TRUE
-    )
-  }, artifact_mode = "missing"))
+  out <- suppressMessages(with_mock_spotsweeper(
+    {
+      RunSpotSweeper(
+        srt,
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        verbose = TRUE
+      )
+    },
+    artifact_mode = "missing"
+  ))
 
   expect_identical(out@tools$SpotSweeper$status, "partial")
   expect_true(all(out@tools$SpotSweeper$artifact_status$status == "failed"))
@@ -729,18 +748,21 @@ test_that("RunSpotSweeper refuses filtered output when artifact detection is par
     tools = srt@tools
   )
   condition <- tryCatch(
-    suppressWarnings(with_mock_spotsweeper({
-      RunSpotSweeper(
-        srt,
-        layer = "counts",
-        coord.cols = c("x", "y"),
-        sample.by = "sample",
-        n_neighbors = 2,
-        n_order = 2,
-        return_filtered = TRUE,
-        verbose = FALSE
-      )
-    }, artifact_mode = "error")),
+    suppressWarnings(with_mock_spotsweeper(
+      {
+        RunSpotSweeper(
+          srt,
+          layer = "counts",
+          coord.cols = c("x", "y"),
+          sample.by = "sample",
+          n_neighbors = 2,
+          n_order = 2,
+          return_filtered = TRUE,
+          verbose = FALSE
+        )
+      },
+      artifact_mode = "error"
+    )),
     error = identity
   )
   expect_s3_class(condition, "error")
@@ -823,16 +845,19 @@ test_that("RunSpotSweeper console status is truthful and respects verbose", {
     logical(1)
   )))
 
-  silent_events <- capture_spotsweeper_logs(with_mock_spotsweeper({
-    RunSpotSweeper(
-      make_spotsweeper_seurat(),
-      layer = "counts",
-      coord.cols = c("x", "y"),
-      sample.by = "sample",
-      n_neighbors = 2,
-      verbose = FALSE
-    )
-  }, artifact_mode = "error"))
+  silent_events <- capture_spotsweeper_logs(with_mock_spotsweeper(
+    {
+      RunSpotSweeper(
+        make_spotsweeper_seurat(),
+        layer = "counts",
+        coord.cols = c("x", "y"),
+        sample.by = "sample",
+        n_neighbors = 2,
+        verbose = FALSE
+      )
+    },
+    artifact_mode = "error"
+  ))
   expect_length(silent_events, 0L)
 })
 
@@ -856,16 +881,19 @@ test_that("RunSpotSweeper partial completion survives warning escalation", {
     case <- cases[[case_name]]
     out <- NULL
     expect_no_error(
-      out <- suppressMessages(with_mock_spotsweeper({
-        RunSpotSweeper(
-          make_spotsweeper_seurat(include_mito = case$include_mito),
-          layer = "counts",
-          coord.cols = c("x", "y"),
-          sample.by = "sample",
-          n_neighbors = 2,
-          verbose = TRUE
-        )
-      }, artifact_mode = case$artifact_mode)),
+      out <- suppressMessages(with_mock_spotsweeper(
+        {
+          RunSpotSweeper(
+            make_spotsweeper_seurat(include_mito = case$include_mito),
+            layer = "counts",
+            coord.cols = c("x", "y"),
+            sample.by = "sample",
+            n_neighbors = 2,
+            verbose = TRUE
+          )
+        },
+        artifact_mode = case$artifact_mode
+      )),
       message = case_name
     )
     expect_s4_class(out, "Seurat")

--- a/tests/testthat/test-rundetest-findmarkers.R
+++ b/tests/testthat/test-rundetest-findmarkers.R
@@ -283,11 +283,9 @@ test_that("RunDEtest all-in-one fallback never installs missing Presto", {
       context_materialized <<- TRUE
       stop("marker context should not be materialized without Presto")
     },
-    presto_get_fun = function(
-      fun = "wilcoxauc",
-      install = FALSE,
-      error_on_missing = TRUE
-    ) {
+    presto_get_fun = function(fun = "wilcoxauc",
+                              install = FALSE,
+                              error_on_missing = TRUE) {
       install_requested <<- install
       NULL
     },

--- a/tests/testthat/test-rundetest-min-cells-sample.R
+++ b/tests/testthat/test-rundetest-min-cells-sample.R
@@ -131,24 +131,20 @@ test_that("min.cells.sample drops low-cell samples and restores DE direction", {
   tools_out <- sample_out@tools$DEtest_subcelltype
   sample_markers <- tools_out$AllMarkers_edgeR
   typea <- sample_markers[
-    sample_markers$gene == "marker" & as.character(sample_markers$group1) == "TypeA",
-    ,
+    sample_markers$gene == "marker" & as.character(sample_markers$group1) == "TypeA", ,
     drop = FALSE
   ]
   typeb <- sample_markers[
-    sample_markers$gene == "marker" & as.character(sample_markers$group1) == "TypeB",
-    ,
+    sample_markers$gene == "marker" & as.character(sample_markers$group1) == "TypeB", ,
     drop = FALSE
   ]
   inventory <- tools_out$sample_inventory
   typea_tiny <- inventory[
-    inventory$group == "TypeA" & inventory$sample == "Rp_tiny",
-    ,
+    inventory$group == "TypeA" & inventory$sample == "Rp_tiny", ,
     drop = FALSE
   ]
   typeb_tiny <- inventory[
-    inventory$group == "TypeB" & inventory$sample == "Rp_tiny",
-    ,
+    inventory$group == "TypeB" & inventory$sample == "Rp_tiny", ,
     drop = FALSE
   ]
 

--- a/tests/testthat/test-seurat-fast-paths.R
+++ b/tests/testthat/test-seurat-fast-paths.R
@@ -88,7 +88,8 @@ test_that("NormalizeData uses the fast path for Assay5 objects", {
   expect_equal(
     as.matrix(GetAssayData5(out, assay = "RNA", layer = "data")),
     as.matrix(seurat_reference_method(
-      "NormalizeData", "default", mat, verbose = FALSE
+      "NormalizeData", "default", mat,
+      verbose = FALSE
     )),
     tolerance = 1e-8
   )
@@ -160,7 +161,8 @@ test_that("NormalizeData supports legacy Assay objects", {
   expect_equal(
     as.matrix(out[["RNA"]]@data),
     as.matrix(seurat_reference_method(
-      "NormalizeData", "default", mat, verbose = FALSE
+      "NormalizeData", "default", mat,
+      verbose = FALSE
     )),
     tolerance = 1e-8
   )

--- a/tests/testthat/test-spatial-coordinate-contract-v3.R
+++ b/tests/testthat/test-spatial-coordinate-contract-v3.R
@@ -1,16 +1,21 @@
 coordinate_v3_fixture <- function(images = TRUE) {
-  counts <- matrix(seq_len(24), nrow = 3,
-    dimnames = list(paste0("g", 1:3), paste0("c", 1:8)))
+  counts <- matrix(seq_len(24),
+    nrow = 3,
+    dimnames = list(paste0("g", 1:3), paste0("c", 1:8))
+  )
   srt <- suppressWarnings(SeuratObject::CreateSeuratObject(counts))
   srt$sample <- rep(c("S1", "S2"), each = 4)
   srt$type <- rep(c("A", "B"), 4)
   srt$x <- seq_len(8)
   srt$y <- seq_len(8) * 2
-  if (images) for (i in 1:2) {
-    cells <- colnames(srt)[srt$sample == paste0("S", i)]
-    srt[[paste0("slice", i)]] <- SeuratObject::CreateFOV(
-      data.frame(x = c(10, 20, 30, 40), y = c(30, 40, 60, 50), row.names = cells),
-      type = "centroids", assay = "RNA", key = paste0("v", i, "_"))
+  if (images) {
+    for (i in 1:2) {
+      cells <- colnames(srt)[srt$sample == paste0("S", i)]
+      srt[[paste0("slice", i)]] <- SeuratObject::CreateFOV(
+        data.frame(x = c(10, 20, 30, 40), y = c(30, 40, 60, 50), row.names = cells),
+        type = "centroids", assay = "RNA", key = paste0("v", i, "_")
+      )
+    }
   }
   srt
 }
@@ -19,9 +24,11 @@ test_that("VisiumV2 image provenance survives metadata edits and cell operations
   data(visium_human_pancreas_sub, package = "scop")
   srt <- visium_human_pancreas_sub
   expected <- SpatialCoordinates(srt, image = "slice1")$data
-  srt$x <- NULL; srt$y <- NULL
+  srt$x <- NULL
+  srt$y <- NULL
   expect_equal(SpatialCoordinates(srt, image = "slice1")$data, expected)
-  srt$x <- rev(expected$y); srt$y <- rev(expected$x)
+  srt$x <- rev(expected$y)
+  srt$y <- rev(expected$x)
   expect_equal(SpatialCoordinates(srt, image = "slice1")$data, expected)
   cells <- expected$cell_id[c(5, 2, 1)]
   smaller <- suppressWarnings(srt[, cells])
@@ -72,8 +79,10 @@ test_that("FOV point pie and network final axes agree", {
   skip_if_not_installed("scatterpie")
   srt <- coordinate_v3_fixture()
   point <- SpatialSpotPlot(srt, image = "slice1", group.by = "type", crop = FALSE)
-  pie <- SpatialSpotPlot(srt, image = "slice1", plot_type = "pie",
-    values = matrix(1, nrow = 8, ncol = 2, dimnames = list(colnames(srt), c("A", "B"))))
+  pie <- SpatialSpotPlot(srt,
+    image = "slice1", plot_type = "pie",
+    values = matrix(1, nrow = 8, ncol = 2, dimnames = list(colnames(srt), c("A", "B")))
+  )
   graph <- RunSpatialNetwork(srt, image = "slice1", k = 1, verbose = FALSE)
   network <- SpatialNetworkPlot(graph)
   point_built <- ggplot2::ggplot_build(point)
@@ -126,8 +135,10 @@ test_that("integration covers all image-backed samples and records their sources
   expect_error(RunSpatialIntegration(srt, sample.by = "sample", image = "slice1", verbose = FALSE), "cover every cell")
   srt[["duplicate"]] <- srt[["slice1"]]
   expect_error(RunSpatialIntegration(srt, sample.by = "sample", verbose = FALSE), "one image covering")
-  expect_no_error(RunSpatialIntegration(srt, sample.by = "sample",
-    image = c(S1 = "slice1", S2 = "slice2"), verbose = FALSE))
+  expect_no_error(RunSpatialIntegration(srt,
+    sample.by = "sample",
+    image = c(S1 = "slice1", S2 = "slice2"), verbose = FALSE
+  ))
 })
 
 test_that("SpatialEcoTyper analysis uses the same selected raw image coordinates", {
@@ -136,18 +147,27 @@ test_that("SpatialEcoTyper analysis uses the same selected raw image coordinates
   testthat::local_mocked_bindings(
     check_r = function(...) invisible(TRUE),
     get_namespace_fun = function(package, name) {
-      if (package != "SpatialEcoTyper") return(get(name, asNamespace(package)))
-      if (name %in% c("mostFrequent", "GetSpatialMetacells", "GetPCList")) return(function(...) NULL)
-      if (name == "SpatialEcoTyper") return(function(normdata, metadata, ...) {
-        observed <<- metadata
-        list(metadata = data.frame(SE = rep("SE1", ncol(normdata)), row.names = colnames(normdata)))
-      })
+      if (package != "SpatialEcoTyper") {
+        return(get(name, asNamespace(package)))
+      }
+      if (name %in% c("mostFrequent", "GetSpatialMetacells", "GetPCList")) {
+        return(function(...) NULL)
+      }
+      if (name == "SpatialEcoTyper") {
+        return(function(normdata, metadata, ...) {
+          observed <<- metadata
+          list(metadata = data.frame(SE = rep("SE1", ncol(normdata)), row.names = colnames(normdata)))
+        })
+      }
       function(data_list, metadata_list, ...) {
         observed <<- metadata_list
-        data.frame(CID = unlist(lapply(data_list, colnames), use.names = FALSE),
-          Sample = rep(names(data_list), lengths(lapply(data_list, colnames))), InitSE = "I1", SE = "SE1")
+        data.frame(
+          CID = unlist(lapply(data_list, colnames), use.names = FALSE),
+          Sample = rep(names(data_list), lengths(lapply(data_list, colnames))), InitSE = "I1", SE = "SE1"
+        )
       }
-    })
+    }
+  )
   expect_error(RunSpatialEcoTyper(srt, layer = "counts", celltype.by = "type"), "Multiple spatial images")
   out <- RunSpatialEcoTyper(srt, layer = "counts", celltype.by = "type", image = "slice1", verbose = FALSE)
   expect_equal(observed$X, c(10, 20, 30, 40))
@@ -155,8 +175,10 @@ test_that("SpatialEcoTyper analysis uses the same selected raw image coordinates
   expect_true(all(is.na(out$SpatialEcoTyper_SE[5:8])))
   expect_equal(out@tools$SpatialEcoTyper$coordinates$x, observed$X)
   expect_identical(out@tools$SpatialEcoTyper$source$samples$single$image, "slice1")
-  out <- RunSpatialEcoTyper(srt, mode = "multi", sample.by = "sample", layer = "counts",
-    celltype.by = "type", outdir = tempfile(), verbose = FALSE)
+  out <- RunSpatialEcoTyper(srt,
+    mode = "multi", sample.by = "sample", layer = "counts",
+    celltype.by = "type", outdir = tempfile(), verbose = FALSE
+  )
   expect_named(observed, c("S1", "S2"))
   expect_equal(observed$S1$X, observed$S2$X)
   expect_false(anyNA(out$SpatialEcoTyper_SE))
@@ -209,7 +231,8 @@ test_that("the shared Visium input produces plottable raw-coordinate results", {
   expected <- SpatialCoordinates(spatial, image = "slice1")$data
   spatial <- RunSpatialNetwork(spatial, image = "slice1", k = 4, verbose = FALSE)
   spatial <- RunSpatialNeighborhood(
-    spatial, group.by = "coda_label", method = "observed",
+    spatial,
+    group.by = "coda_label", method = "observed",
     image = "slice1", k = 4, backend = "r", verbose = FALSE
   )
   expect_equal(SpatialCoordinates(spatial, image = "slice1")$data, expected)

--- a/tests/testthat/test-spatial-gradient.R
+++ b/tests/testthat/test-spatial-gradient.R
@@ -193,8 +193,10 @@ test_that("cpp backend stores annotation gradient result tables", {
   expect_false(any(vapply(stored, methods::is, logical(1), class2 = "SPATA2")))
   expect_true(nrow(stored$screening) > 0)
   expect_true(nrow(stored$top_variables) > 0)
-  expect_identical(SeuratObject::VariableFeatures(srt, assay = "RNA"),
-    unique(stored$top_variables$variable))
+  expect_identical(
+    SeuratObject::VariableFeatures(srt, assay = "RNA"),
+    unique(stored$top_variables$variable)
+  )
   expect_equal(stored$parameters$value[match("backend", stored$parameters$key)], "cpp")
   expect_false("spata2_version" %in% stored$parameters$key)
   expect_true(all(c("norm_var", "rel_var", "linear_r2") %in% colnames(stored$significance)))

--- a/tests/testthat/test-spatial-neighborhood-profile.R
+++ b/tests/testthat/test-spatial-neighborhood-profile.R
@@ -17,8 +17,8 @@ profile_oracle <- function(object, result, cumulative = FALSE) {
     q <- match(result$cell_id[i], rownames(meta))
     d <- sqrt((meta$col - meta$col[q])^2 + (meta$row - meta$row[q])^2)
     sum(seq_len(nrow(meta)) != q & meta$sample == result$sample[i] &
-          meta$label == result$group[i] & d <= result$radius[i] &
-          (cumulative | result$lower[i] == 0 | d > result$lower[i]))
+      meta$label == result$group[i] & d <= result$radius[i] &
+      (cumulative | result$lower[i] == 0 | d > result$lower[i]))
   }, integer(1))
 }
 
@@ -103,7 +103,8 @@ test_that("invalid input errors rather than returning a partial profile", {
   expect_identical(serialize(object, NULL), before)
   object$label[2] <- NA_character_
   expect_error(profile_quiet(object, "label", 1, "c1"), "nonmissing")
-  object$label[2] <- "M"; object$sample[2] <- ""
+  object$label[2] <- "M"
+  object$sample[2] <- ""
   expect_error(profile_quiet(object, "label", 1, "c1", "sample"), "nonempty")
   object$col[2] <- NA_real_
   expect_error(profile_quiet(object, "label", 1), "non-finite")

--- a/tests/testthat/test-spatial-original-consistency2.R
+++ b/tests/testthat/test-spatial-original-consistency2.R
@@ -334,8 +334,10 @@ test_that("RunSpotSweeper local outliers match the original SpotSweeper pipeline
     stopifnot(!anyDuplicated(colnames(spe)), all(expected_ids %in% colnames(spe)))
     spe <- spe[, match(expected_ids, colnames(spe))]
     colnames(spe) <- spots
-    expect_equal(unname(SpatialExperiment::spatialCoords(spe)),
-      unname(as.matrix(coords[, c("x", "y")])) )
+    expect_equal(
+      unname(SpatialExperiment::spatialCoords(spe)),
+      unname(as.matrix(coords[, c("x", "y")]))
+    )
   }
 
   wrapped_cd <- wrapped@tools$SpotSweeper$colData

--- a/tests/testthat/test-standard-spatial-atac.R
+++ b/tests/testthat/test-standard-spatial-atac.R
@@ -45,13 +45,11 @@ test_that("ATAC defaults are applied before spatial output planning", {
       captured$nested <- list(...)
       add_standard_spatial_atac_reduction(srt, "ATACsvd")
     },
-    RunBayesSpace = function(
-      srt,
-      cluster_colname,
-      init_colname,
-      use_reduction = NULL,
-      ...
-    ) {
+    RunBayesSpace = function(srt,
+                             cluster_colname,
+                             init_colname,
+                             use_reduction = NULL,
+                             ...) {
       captured$bayes <- list(
         cluster_colname = cluster_colname,
         init_colname = init_colname,
@@ -154,13 +152,11 @@ test_that("custom ATAC workflow values retain atac_defaults semantics", {
       captured$nested <- list(...)
       add_standard_spatial_atac_reduction(srt, "Customsvd")
     },
-    RunBayesSpace = function(
-      srt,
-      cluster_colname,
-      init_colname,
-      use_reduction = NULL,
-      ...
-    ) {
+    RunBayesSpace = function(srt,
+                             cluster_colname,
+                             init_colname,
+                             use_reduction = NULL,
+                             ...) {
       captured$bayes_use_reduction <- use_reduction
       srt[[cluster_colname]] <- rep("domain1", ncol(srt))
       srt@tools[["BayesSpace"]] <- list(result = "fresh")

--- a/tests/testthat/test-standard-spatial-stages.R
+++ b/tests/testthat/test-standard-spatial-stages.R
@@ -462,8 +462,7 @@ test_that("effective SVF storage controls require logical scalars", {
     )
     stages <- attr(condition, "standard_spatial_stages")
     svf <- stages[
-      stages$stage == "spatial_variable_features",
-      ,
+      stages$stage == "spatial_variable_features", ,
       drop = FALSE
     ]
 
@@ -615,8 +614,7 @@ test_that("BayesSpace planning failures carry clustering stage diagnostics", {
     )
     stages <- attr(condition, "standard_spatial_stages")
     clustering <- stages[
-      stages$stage == "spatial_clustering",
-      ,
+      stages$stage == "spatial_clustering", ,
       drop = FALSE
     ]
 
@@ -672,8 +670,7 @@ test_that("BayesSpace q inference failures retain clustering stage diagnostics",
   )
   stages <- attr(condition, "standard_spatial_stages")
   clustering <- stages[
-    stages$stage == "spatial_clustering",
-    ,
+    stages$stage == "spatial_clustering", ,
     drop = FALSE
   ]
 

--- a/tests/testthat/test-standard-spatial-storage.R
+++ b/tests/testthat/test-standard-spatial-storage.R
@@ -123,12 +123,10 @@ make_valid_empty_svf_tool <- function() {
 test_that("stored spatial variable feature results are reported", {
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunSpatialVariableFeatures = function(
-      srt,
-      set_variable_features,
-      store_results,
-      ...
-    ) {
+    RunSpatialVariableFeatures = function(srt,
+                                          set_variable_features,
+                                          store_results,
+                                          ...) {
       expect_false(set_variable_features)
       expect_true(store_results)
       expect_null(srt@tools[["SpatialVariableFeatures"]])
@@ -157,12 +155,10 @@ test_that("stored spatial variable feature results are reported", {
 test_that("storage-off SVF ignores and preserves an older tool result", {
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunSpatialVariableFeatures = function(
-      srt,
-      set_variable_features,
-      store_results,
-      ...
-    ) {
+    RunSpatialVariableFeatures = function(srt,
+                                          set_variable_features,
+                                          store_results,
+                                          ...) {
       expect_false(set_variable_features)
       expect_false(store_results)
       srt
@@ -195,13 +191,11 @@ test_that("storage-off SVF ignores and preserves an older tool result", {
 test_that("variable-feature-only output is certified without a tool", {
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunSpatialVariableFeatures = function(
-      srt,
-      assay,
-      set_variable_features,
-      store_results,
-      ...
-    ) {
+    RunSpatialVariableFeatures = function(srt,
+                                          assay,
+                                          set_variable_features,
+                                          store_results,
+                                          ...) {
       expect_true(set_variable_features)
       expect_false(store_results)
       top_features <- c("gene1", "gene2")
@@ -245,14 +239,12 @@ test_that("SVF bookkeeping follows the effective assay override", {
 
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunSpatialVariableFeatures = function(
-      srt,
-      assay,
-      features,
-      set_variable_features,
-      store_results,
-      ...
-    ) {
+    RunSpatialVariableFeatures = function(srt,
+                                          assay,
+                                          features,
+                                          set_variable_features,
+                                          store_results,
+                                          ...) {
       expect_identical(assay, "ALT")
       expect_identical(features, c("gene2", "gene3"))
       expect_length(
@@ -366,8 +358,7 @@ test_that("invalid effective SVF assays fail through the stage wrapper", {
     )
     stages <- attr(condition, "standard_spatial_stages")
     svf <- stages[
-      stages$stage == "spatial_variable_features",
-      ,
+      stages$stage == "spatial_variable_features", ,
       drop = FALSE
     ]
 
@@ -407,14 +398,12 @@ test_that("SVF output replaces stale selection and preserves HVF metadata", {
 
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunSpatialVariableFeatures = function(
-      srt,
-      assay,
-      features,
-      set_variable_features,
-      store_results,
-      ...
-    ) {
+    RunSpatialVariableFeatures = function(srt,
+                                          assay,
+                                          features,
+                                          set_variable_features,
+                                          store_results,
+                                          ...) {
       expect_identical(features, c("gene1", "gene2"))
       expect_true(set_variable_features)
       expect_false(store_results)
@@ -454,13 +443,11 @@ test_that("SVF output replaces stale selection and preserves HVF metadata", {
 test_that("stale variable features do not satisfy a quiet producer", {
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunSpatialVariableFeatures = function(
-      srt,
-      assay,
-      features,
-      store_results,
-      ...
-    ) {
+    RunSpatialVariableFeatures = function(srt,
+                                          assay,
+                                          features,
+                                          store_results,
+                                          ...) {
       expect_false(store_results)
       expect_null(srt@tools[["SpatialVariableFeatures"]])
       expect_identical(features, "gene1")
@@ -537,8 +524,7 @@ test_that("malformed explicit-empty sentinels do not satisfy the workflow", {
     )
     stages <- attr(condition, "standard_spatial_stages")
     svf <- stages[
-      stages$stage == "spatial_variable_features",
-      ,
+      stages$stage == "spatial_variable_features", ,
       drop = FALSE
     ]
 
@@ -789,13 +775,11 @@ test_that("classic Assay empty-selection handshake preserves misc state", {
 test_that("NULL SVF controls resolve to producer defaults", {
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunSpatialVariableFeatures = function(
-      srt,
-      assay,
-      set_variable_features = TRUE,
-      store_results = TRUE,
-      ...
-    ) {
+    RunSpatialVariableFeatures = function(srt,
+                                          assay,
+                                          set_variable_features = TRUE,
+                                          store_results = TRUE,
+                                          ...) {
       expect_true(set_variable_features)
       expect_true(store_results)
       SeuratObject::VariableFeatures(srt, assay = assay) <- "gene1"
@@ -828,13 +812,11 @@ test_that("NULL SVF controls resolve to producer defaults", {
 test_that("fresh non-finite SVF scores certify a valid empty selection", {
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunSpatialVariableFeatures = function(
-      srt,
-      assay,
-      set_variable_features,
-      store_results,
-      ...
-    ) {
+    RunSpatialVariableFeatures = function(srt,
+                                          assay,
+                                          set_variable_features,
+                                          store_results,
+                                          ...) {
       expect_true(set_variable_features)
       expect_true(store_results)
       expect_null(srt@tools[["SpatialVariableFeatures"]])
@@ -1764,8 +1746,7 @@ test_that("all preprocessing cluster outputs are protected before producers run"
   )
   tfidf_stages <- tfidf_out@tools$run_standard_spatial_workflow$stages
   tfidf_domain <- tfidf_stages[
-    tfidf_stages$stage == "spatial_clustering",
-    ,
+    tfidf_stages$stage == "spatial_clustering", ,
     drop = FALSE
   ]
 
@@ -1972,13 +1953,11 @@ test_that("SpotQC dispatch reuses the effective parameters used for planning", {
   called <- FALSE
   custom_rules <- c("custom score:upper:2", "nCount_RNA:lower:3")
   testthat::local_mocked_bindings(
-    RunSpotQC = function(
-      srt,
-      assay,
-      qc_metrics,
-      outlier_threshold,
-      ...
-    ) {
+    RunSpotQC = function(srt,
+                         assay,
+                         qc_metrics,
+                         outlier_threshold,
+                         ...) {
       called <<- TRUE
       expect_identical(assay, "ALT")
       expect_identical(qc_metrics, c("outlier", "gene"))
@@ -2185,12 +2164,10 @@ test_that("explicit NULL BayesSpace init is preserved through dispatch", {
   producer_calls <- 0L
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunBayesSpace = function(
-      srt,
-      cluster_colname,
-      init_colname = "unexpected default",
-      ...
-    ) {
+    RunBayesSpace = function(srt,
+                             cluster_colname,
+                             init_colname = "unexpected default",
+                             ...) {
       producer_calls <<- producer_calls + 1L
       expect_null(init_colname)
       if (identical(cluster_colname, "BayesSpace_init")) {
@@ -2239,13 +2216,11 @@ test_that("explicit NULL BayesSpace init is preserved through dispatch", {
   first_stage <- first_receipt$stages
   second_stage <- cluster_elsewhere@tools$run_standard_spatial_workflow$stages
   first_domain <- first_stage[
-    first_stage$stage == "spatial_clustering",
-    ,
+    first_stage$stage == "spatial_clustering", ,
     drop = FALSE
   ]
   second_domain <- second_stage[
-    second_stage$stage == "spatial_clustering",
-    ,
+    second_stage$stage == "spatial_clustering", ,
     drop = FALSE
   ]
 
@@ -2360,15 +2335,13 @@ test_that("unrequested stage names do not create metadata collisions", {
 test_that("SPOTlight dispatch satisfies the normalized storage contract", {
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunSPOTlight = function(
-      srt,
-      reference,
-      reference_label,
-      prefix,
-      tool_name,
-      store_results,
-      ...
-    ) {
+    RunSPOTlight = function(srt,
+                            reference,
+                            reference_label,
+                            prefix,
+                            tool_name,
+                            store_results,
+                            ...) {
       expect_s4_class(reference, "Seurat")
       expect_identical(reference_label, "label")
       expect_identical(prefix, "SPOTlight")
@@ -2451,13 +2424,11 @@ test_that("stale deconvolution metadata does not satisfy a quiet producer", {
 test_that("NULL deconvolution controls resolve to producer defaults", {
   testthat::local_mocked_bindings(
     RunStandardWorkflow = function(srt, ...) srt,
-    RunRCTD = function(
-      srt,
-      prefix = "RCTD",
-      tool_name = "RCTD",
-      store_results = TRUE,
-      ...
-    ) {
+    RunRCTD = function(srt,
+                       prefix = "RCTD",
+                       tool_name = "RCTD",
+                       store_results = TRUE,
+                       ...) {
       expect_identical(prefix, "RCTD")
       expect_identical(tool_name, "RCTD")
       expect_true(store_results)
@@ -2615,12 +2586,10 @@ test_that("quality control and BayesSpace probes replace stale outputs", {
       srt$SpotQC <- factor(rep("Pass", ncol(srt)), levels = c("Pass", "Fail"))
       srt
     },
-    RunBayesSpace = function(
-      srt,
-      cluster_colname = "BayesSpace_cluster",
-      init_colname = "BayesSpace_init",
-      ...
-    ) {
+    RunBayesSpace = function(srt,
+                             cluster_colname = "BayesSpace_cluster",
+                             init_colname = "BayesSpace_init",
+                             ...) {
       expect_false(cluster_colname %in% colnames(srt@meta.data))
       expect_false(init_colname %in% colnames(srt@meta.data))
       expect_null(srt@tools[["BayesSpace"]])

--- a/vignettes/spatial-benchmark-workflow.Rmd
+++ b/vignettes/spatial-benchmark-workflow.Rmd
@@ -36,11 +36,15 @@ n_spots <- 36L
 n_genes <- 60L
 grid <- expand.grid(x = 1:6, y = 1:6)
 spatial_domain <- factor(ifelse(grid$x <= 2, "left", ifelse(grid$x <= 4, "middle", "right")))
-counts <- matrix(rpois(n_genes * n_spots, 2), nrow = n_genes,
-  dimnames = list(paste0("Gene", seq_len(n_genes)), paste0("spot", seq_len(n_spots))))
+counts <- matrix(rpois(n_genes * n_spots, 2),
+  nrow = n_genes,
+  dimnames = list(paste0("Gene", seq_len(n_genes)), paste0("spot", seq_len(n_spots)))
+)
 signal <- split(seq_len(n_genes), rep(c("left", "middle", "right"), each = 20))
-for (label in names(signal)) counts[signal[[label]], spatial_domain == label] <-
-  counts[signal[[label]], spatial_domain == label] + rpois(sum(spatial_domain == label) * 20, 5)
+for (label in names(signal)) {
+  counts[signal[[label]], spatial_domain == label] <-
+    counts[signal[[label]], spatial_domain == label] + rpois(sum(spatial_domain == label) * 20, 5)
+}
 spatial <- SeuratObject::CreateSeuratObject(counts)
 spatial$x <- grid$x
 spatial$y <- grid$y

--- a/vignettes/spatial-main-workflow.Rmd
+++ b/vignettes/spatial-main-workflow.Rmd
@@ -254,7 +254,8 @@ remove their surrounding tissue from the calculation:
 
 ```{r spatial-neighborhood-profile}
 profile <- SpatialNeighborhoodProfile(
-  spatial, group.by = "coda_label", radii = c(100, 200, 400),
+  spatial,
+  group.by = "coda_label", radii = c(100, 200, 400),
   cells = head(colnames(spatial), 20), cumulative = TRUE, verbose = FALSE
 )
 head(profile)


### PR DESCRIPTION
## Summary

`styler::style_pkg()` (tidyverse style) applied locally across `R/`, `tests/`, and the vignette R chunks, with `man/` regenerated. Formatting only — no behaviour changes.

- 57 files reformatted (`R/` 35, `tests/` 20, `vignettes/` 2).
- `R/RunscOMM.R` had a duplicated `\dontrun{` wrapper that styler could not parse; the wrapper is removed in the first commit (`R CMD check --run-dontrun` would have failed on it too).
- Remaining files were already styler-conformant.

## Validation

- `styler::style_pkg()` reports 0 styling errors; `roxygen2::roxygenise()` is a no-op afterwards.
- `Rscript -e 'parse()'` over all `R/*.R` files: 0 errors.
- `testthat::test_local(filter = "spatial-object-alias|spatial-core|spatial-run-receipt|spatial-neighborhood-profile|rundetest-findmarkers|standard-spatial-stages|run-literature-methods")` passes.
- The same command was applied to thisplot / thisutils / inferCSN in their `style: apply styler` commits.

This is formatting-only, so it is worth merging quickly to avoid rebasing it over new work.