### PR TITLE
fix: keep SCENIC RSS rank labels readable and axis titles centred

### DIFF
--- a/R/SCENICPlot.R
+++ b/R/SCENICPlot.R
@@ -718,7 +718,8 @@ scenic_plot_rss_rank <- function(
   }
   rank_breaks <- 1L
   if (nrow(rss_matrix) >= 5L) {
-    rank_breaks <- unique(c(rank_breaks, seq.int(5L, nrow(rss_matrix), by = 5L)))
+    rank_step <- 5L * ((nrow(rss_matrix) + 49L) %/% 50L)
+    rank_breaks <- unique(c(rank_breaks, seq.int(rank_step, nrow(rss_matrix), by = rank_step)))
   }
   plots <- lapply(colnames(rss_matrix), function(one_group) {
     data_rank_plot <- rank_table[
@@ -854,6 +855,23 @@ scenic_plot_rss_rank <- function(
     }
     if (!is.null(title)) {
       plot <- plot + patchwork::plot_annotation(title = title)
+    }
+    if (length(plots) > 1L) {
+      assembled <- patchwork::patchworkGrob(plot)
+      area <- assembled$layout[assembled$layout$name == "panel-area", , drop = FALSE]
+      if (nrow(area) == 1L) {
+        xlab_cell <- assembled$layout$l == area$l &
+          assembled$layout$r == area$r &
+          assembled$layout$t > area$b
+        ylab_cell <- assembled$layout$t == area$t &
+          assembled$layout$b == area$b &
+          assembled$layout$l < area$l
+        assembled$layout$l[xlab_cell] <- 1L
+        assembled$layout$r[xlab_cell] <- ncol(assembled)
+        assembled$layout$t[ylab_cell] <- 1L
+        assembled$layout$b[ylab_cell] <- nrow(assembled)
+        plot <- patchwork::wrap_plots(patchwork::wrap_elements(panel = assembled))
+      }
     }
   }
   list(plot = plot, plots = plots, data = rank_table)

--- a/tests/testthat/test-scenic-plot.R
+++ b/tests/testthat/test-scenic-plot.R
@@ -301,6 +301,39 @@ test_that("SCENICPlot rss rank keeps requested labels by default", {
   )
 })
 
+test_that("SCENIC RSS rank thins x-axis labels for long regulon lists", {
+  n_regulon <- 300L
+  groups <- c("A", "B")
+  rss <- matrix(
+    seq_len(n_regulon * length(groups)),
+    nrow = n_regulon,
+    dimnames = list(paste0("TF", seq_len(n_regulon)), groups)
+  )
+  rank_table <- do.call(rbind, lapply(groups, function(one_group) {
+    scores <- sort(rss[, one_group], decreasing = TRUE)
+    data.frame(
+      group = one_group,
+      regulon = names(scores),
+      TF = names(scores),
+      specificity_score = as.numeric(scores),
+      rank = seq_along(scores),
+      is_top = seq_along(scores) <= 3,
+      is_highlight = FALSE,
+      display_label = names(scores),
+      stringsAsFactors = FALSE
+    )
+  }))
+
+  out <- scenic_plot_rss_rank(
+    rss_matrix = rss,
+    rank_table = rank_table,
+    top_table = rank_table[rank_table[["is_top"]], , drop = FALSE]
+  )
+  x_breaks <- ggplot2::ggplot_build(out$plots[[1]])$layout$panel_params[[1]]$x$breaks
+  expect_true(1 %in% x_breaks)
+  expect_lte(length(x_breaks), 11)
+})
+
 test_that("SCENIC regulon labels preserve signed duplicates in auto mode", {
   rank_table <- data.frame(
     group = c("A", "B", "A"),


### PR DESCRIPTION
Long regulon lists labelled every fifth rank, so the `rss_rank` x-axis collapsed into an unreadable row of numbers (61 labels at 300 regulons). The label step now widens with the number of regulons and stays a multiple of five.

The collected axis titles are also centred on the whole figure instead of the panel grid, and the assembled object stays a patchwork so `print()`, `ggsave()` and `patchworkGrob()` keep working.

Adds a regression test for the label step in `tests/testthat/test-scenic-plot.R`.