### PR TITLE
fix: build scTenifoldKnk network ensembles natively

### DIFF
--- a/R/scTenifold.R
+++ b/R/scTenifold.R
@@ -21,13 +21,13 @@
 #' `scTenifoldNet::manifoldAlignment()`.
 #' @param cores Number of cores used by native network-construction workers and
 #' forwarded to downstream linear algebra where applicable.
-#' @param backend `r` calls `scTenifoldKnk::scTenifoldKnk()` directly and is the
-#' default high-consistency path. `cpp` follows the upstream
-#' `scTenifoldNet`/`scTenifoldKnk` network construction, tensor decomposition,
-#' manifold alignment, and differential-regulation steps while keeping input
-#' handling and result storage inside `scop`.
+#' @param backend `r` runs the upstream `scTenifoldNet` pipeline with the
+#' `scTenifoldKnk` differential-regulation helpers and is the default
+#' high-consistency path. `cpp` runs all steps with scop's native kernels and is
+#' much faster on large gene sets.
 #' @param store_networks Whether to keep WT/KO tensor networks in
-#' `srt@tools`.
+#' `srt@tools`. This only controls what is stored; the network ensemble is
+#' always built the same way.
 #' @param store_manifold Whether to keep manifold-alignment coordinates in
 #' `srt@tools`.
 #' @param tool_name Name of the `srt@tools` entry.
@@ -307,37 +307,24 @@ RunscTenifoldKnk <- function(
 
   result <- switch(backend,
     cpp = {
-      for (pkg in c("scTenifoldNet", "RSpectra", "RhpcBLASctl", "MASS")) {
+      for (pkg in c("RSpectra", "RhpcBLASctl", "MASS")) {
         check_r(pkg, verbose = FALSE)
       }
 
       log_message(
-        "Construct scTenifoldNet network ensemble",
+        "Construct gene regulatory network ensemble",
         verbose = verbose
       )
-      wt <- if (isTRUE(store_networks)) {
-        get_namespace_fun("scTenifoldNet", "makeNetworks")(
-          X = count_matrix,
-          q = nc_q,
-          nNet = as.integer(nc_nNet),
-          nCells = as.integer(nc_nCells),
-          scaleScores = isTRUE(nc_scaleScores),
-          symmetric = isTRUE(nc_symmetric),
-          nComp = as.integer(nc_nComp),
-          nCores = as.integer(cores)
-        )
-      } else {
-        sctenifold_make_networks_cpp(
-          X = count_matrix,
-          q = nc_q,
-          nNet = as.integer(nc_nNet),
-          nCells = as.integer(nc_nCells),
-          scaleScores = isTRUE(nc_scaleScores),
-          symmetric = isTRUE(nc_symmetric),
-          nComp = as.integer(nc_nComp),
-          nCores = as.integer(cores)
-        )
-      }
+      wt <- sctenifold_make_networks_cpp(
+        X = count_matrix,
+        q = nc_q,
+        nNet = as.integer(nc_nNet),
+        nCells = as.integer(nc_nCells),
+        scaleScores = isTRUE(nc_scaleScores),
+        symmetric = isTRUE(nc_symmetric),
+        nComp = as.integer(nc_nComp),
+        nCores = as.integer(cores)
+      )
       wt <- sctenifold_tensor_cpp(
         wt,
         k = as.integer(td_K),

--- a/man/RunScTenifoldKnk.Rd
+++ b/man/RunScTenifoldKnk.Rd
@@ -68,14 +68,14 @@ parameters forwarded to \code{scTenifoldNet::tensorDecomposition()}.}
 \item{cores}{Number of cores used by native network-construction workers and
 forwarded to downstream linear algebra where applicable.}
 
-\item{backend}{\code{r} calls \code{scTenifoldKnk::scTenifoldKnk()} directly and is the
-default high-consistency path. \code{cpp} follows the upstream
-\code{scTenifoldNet}/\code{scTenifoldKnk} network construction, tensor decomposition,
-manifold alignment, and differential-regulation steps while keeping input
-handling and result storage inside \code{scop}.}
+\item{backend}{\code{r} runs the upstream \code{scTenifoldNet} pipeline with the
+\code{scTenifoldKnk} differential-regulation helpers and is the default
+high-consistency path. \code{cpp} runs all steps with scop's native kernels and is
+much faster on large gene sets.}
 
 \item{store_networks}{Whether to keep WT/KO tensor networks in
-\code{srt@tools}.}
+\code{srt@tools}. This only controls what is stored; the network ensemble is
+always built the same way.}
 
 \item{store_manifold}{Whether to keep manifold-alignment coordinates in
 \code{srt@tools}.}

--- a/tests/testthat/test-sctenifold-knk.R
+++ b/tests/testthat/test-sctenifold-knk.R
@@ -1,0 +1,99 @@
+make_sctenifold_knk_srt <- function(n_genes = 60L, n_cells = 80L, seed = 1L) {
+  set.seed(seed)
+  counts <- matrix(
+    stats::rnbinom(n_genes * n_cells, mu = 5, size = 2),
+    nrow = n_genes,
+    dimnames = list(paste0("g", seq_len(n_genes)), paste0("c", seq_len(n_cells)))
+  )
+  Seurat::CreateSeuratObject(
+    counts = Matrix::Matrix(counts, sparse = TRUE)
+  )
+}
+
+run_sctenifold_knk <- function(srt, store_networks) {
+  set.seed(11)
+  RunscTenifoldKnk(
+    srt,
+    gKO = "g1",
+    qc = FALSE,
+    nc_nNet = 2,
+    nc_nCells = 40,
+    td_maxIter = 50,
+    store_networks = store_networks,
+    store_manifold = TRUE,
+    backend = "cpp",
+    verbose = FALSE
+  )
+}
+
+test_that("RunscTenifoldKnk cpp backend builds the network ensemble natively", {
+  srt <- make_sctenifold_knk_srt()
+  manifold_calls <- 0L
+  # Manifold alignment and differential regulation need the optional
+  # RSpectra/RhpcBLASctl/MASS packages; stubbing them keeps this guard running
+  # where the check installs hard dependencies only.
+  testthat::local_mocked_bindings(
+    .package = "scop",
+    check_r = function(...) invisible(TRUE),
+    get_namespace_fun = function(pkg, fun, ...) {
+      stop(pkg, "::", fun, "() is not expected on the cpp backend")
+    },
+    sctenifold_manifold_cpp = function(x, y, d, cores) {
+      manifold_calls <<- manifold_calls + 1L
+      genes <- rownames(x)
+      matrix(
+        0,
+        nrow = 2L * length(genes),
+        ncol = d,
+        dimnames = list(
+          c(paste0("X_", genes), paste0("Y_", genes)),
+          paste0("NLMA ", seq_len(d))
+        )
+      )
+    },
+    sctenifold_dregulation = function(manifold_output, gko) {
+      genes <- sub("^X_", "", grep("^X_", rownames(manifold_output), value = TRUE))
+      data.frame(
+        gene = genes,
+        distance = rev(seq_along(genes)),
+        Z = 0,
+        FC = 1,
+        p.value = 1,
+        p.adj = 1
+      )
+    }
+  )
+
+  out <- run_sctenifold_knk(srt, store_networks = TRUE)
+  dr <- out@tools$scTenifoldKnk$diffRegulation
+
+  expect_identical(manifold_calls, 1L)
+  expect_identical(dim(out@tools$scTenifoldKnk$result$tensorNetworks$WT), c(60L, 60L))
+  expect_s3_class(dr, "data.frame")
+  expect_setequal(dr$gene, paste0("g", seq_len(60L)))
+})
+
+test_that("RunscTenifoldKnk store_networks only controls what is stored", {
+  testthat::skip_if_not_installed("RSpectra")
+  testthat::skip_if_not_installed("RhpcBLASctl")
+  testthat::skip_if_not_installed("MASS")
+  srt <- make_sctenifold_knk_srt()
+  testthat::local_mocked_bindings(
+    .package = "scop",
+    check_r = function(...) invisible(TRUE)
+  )
+
+  stored <- run_sctenifold_knk(srt, store_networks = TRUE)
+  dropped <- run_sctenifold_knk(srt, store_networks = FALSE)
+
+  expect_identical(
+    stored@tools$scTenifoldKnk$diffRegulation,
+    dropped@tools$scTenifoldKnk$diffRegulation
+  )
+  expect_false(is.null(stored@tools$scTenifoldKnk$result$tensorNetworks))
+  expect_null(dropped@tools$scTenifoldKnk$result$tensorNetworks)
+  expect_identical(
+    stored@tools$scTenifoldKnk$result$manifoldAlignment,
+    dropped@tools$scTenifoldKnk$result$manifoldAlignment
+  )
+})


### PR DESCRIPTION
## Problem

`RunscTenifoldKnk(backend = "cpp")` selected its network-construction implementation from `store_networks`: the default `TRUE` routed the ensemble to `scTenifoldNet::makeNetworks()`, whose per-gene full economy SVD is quadratic in the gene count, while `store_networks = FALSE` used scop's native kernel. Reported in #418 as hours instead of minutes on identical parameters.

`store_networks` only decides whether the WT/KO tensors are kept in `srt@tools`, so it no longer changes the computation. The `cpp` backend is fully native now and no longer requires `scTenifoldNet`; the stage message reflects that, and the documented `backend` text no longer claims `r` calls `scTenifoldKnk::scTenifoldKnk()`.

## Validation

- New `tests/testthat/test-sctenifold-knk.R`: the `cpp` backend must not call `scTenifoldNet::makeNetworks()` (fails on the previous code, pointing at the old branch), and `store_networks` only changes what is stored — same-seed `diffRegulation` is identical and `tensorNetworks` is `NULL` only when asked.
- The routing guard stubs the manifold-alignment and differential-regulation steps that need the optional `RSpectra`/`RhpcBLASctl`/`MASS` packages, so it also runs where the check installs hard dependencies only; the end-to-end storage test skips when those packages are absent.
- `test-high-memory-sparse-paths.R` and `test-cpp-backend-safety.R` pass.
- `pancreas_sub` (1001 features x 200 cells, 3 networks): 23.0 s with `store_networks = TRUE` vs 23.7 s with `FALSE`, identical `diffRegulation`, `Pdx1` ranks first.
- Same data and seed, native vs upstream ensemble: 6.2 s vs 12.4 s at 301 genes and 23.3 s vs 85.1 s at 1001 genes; the resulting networks agree to 3.4e-13.

Fixes #418