### PR TITLE
feat(nichenet): export merged ligand target table

### DIFF
--- a/R/RunNichenetr.R
+++ b/R/RunNichenetr.R
@@ -34,6 +34,25 @@
 #' `sender = "all"`.
 #' @param backend Backend used for post-processing aggregation. Upstream
 #'   NicheNet inference is unchanged.
+#' @param merged_table_file Optional path to a CSV file for exporting a temporary
+#'   ligand-receptor/activity/target merged table. The file is not stored in the
+#'   result bundle. Existing files and missing parent directories are rejected.
+#' @details In the exported table, a ligand's predicted targets are repeated for
+#'   each candidate receptor from the LR table. This is a ligand-level display
+#'   of the existing results; it does not establish receptor-mediated targets or
+#'   sender-specific target effects.
+#' @examples
+#' \dontrun{
+#' srt <- RunNichenetr(
+#'   object = srt,
+#'   group.by = "celltype",
+#'   receiver = "Receiver",
+#'   condition.by = "condition",
+#'   condition_oi = "case",
+#'   condition_reference = "control",
+#'   merged_table_file = "NicheNet_merged.csv"
+#' )
+#' }
 #' @return A Seurat object with standardized NicheNet results stored in
 #' `srt@tools[["Nichenetr"]]`.
 #' @export
@@ -63,12 +82,41 @@ RunNichenetr <- function(
   use_sender_agnostic_background = TRUE,
   backend = c("cpp", "r"),
   verbose = TRUE,
-  srt = NULL
+  srt = NULL,
+  merged_table_file = NULL
 ) {
   srt <- resolve_deprecated_srt(object, srt, missing(object))
   backend <- match.arg(backend)
   mode <- match.arg(mode)
   species <- match.arg(species)
+
+  if (!is.null(merged_table_file)) {
+    if (
+      !is.character(merged_table_file) ||
+        length(merged_table_file) != 1L ||
+        is.na(merged_table_file) ||
+        !nzchar(trimws(merged_table_file))
+    ) {
+      log_message(
+        "{.arg merged_table_file} must be a single non-empty file path or {.val NULL}",
+        message_type = "error"
+      )
+    }
+    merged_table_file <- path.expand(merged_table_file)
+    if (file.exists(merged_table_file)) {
+      log_message(
+        "{.arg merged_table_file} already exists: {.file {merged_table_file}}. Choose a new path to avoid overwriting it.",
+        message_type = "error"
+      )
+    }
+    merged_table_parent <- dirname(merged_table_file)
+    if (!dir.exists(merged_table_parent)) {
+      log_message(
+        "The parent directory of {.arg merged_table_file} does not exist: {.file {merged_table_parent}}",
+        message_type = "error"
+      )
+    }
+  }
 
   if (!inherits(srt, "Seurat")) {
     log_message(
@@ -365,6 +413,132 @@ RunNichenetr <- function(
     species = species,
     backend = backend
   )
+
+  if (!is.null(merged_table_file)) {
+    merged_table <- bundle$long_table
+    if (!is.data.frame(merged_table)) {
+      merged_table <- data.frame(stringsAsFactors = FALSE)
+    } else {
+      merged_table <- as.data.frame(merged_table, stringsAsFactors = FALSE)
+    }
+
+    if ("weight" %in% colnames(merged_table)) {
+      if ("lr_weight" %in% colnames(merged_table)) {
+        merged_table$weight <- NULL
+      } else {
+        colnames(merged_table)[match("weight", colnames(merged_table))] <- "lr_weight"
+      }
+    }
+    if (!"lr_weight" %in% colnames(merged_table)) {
+      merged_table$lr_weight <- NA_real_
+    }
+
+    ligand_target_table <- bundle$ligand_target_df
+    if (!is.data.frame(ligand_target_table)) {
+      ligand_target_table <- data.frame(stringsAsFactors = FALSE)
+    }
+    target_ligand_col <- ccc_pick_col(
+      ligand_target_table,
+      c("ligand", "from", "test_ligand")
+    )
+    target_col <- ccc_pick_col(
+      ligand_target_table,
+      c("target", "to", "gene")
+    )
+    target_weight_col <- ccc_pick_col(
+      ligand_target_table,
+      c("weight", "lt_weight", "regulatory_potential", "score")
+    )
+
+    if (
+      nrow(merged_table) > 0L &&
+        "ligand" %in% colnames(merged_table) &&
+        !is.null(target_ligand_col) &&
+        !is.null(target_col)
+    ) {
+      target_ligands <- as.character(ligand_target_table[[target_ligand_col]])
+      target_values <- as.character(ligand_target_table[[target_col]])
+      target_weights <- if (!is.null(target_weight_col)) {
+        ligand_target_table[[target_weight_col]]
+      } else {
+        rep(NA_real_, nrow(ligand_target_table))
+      }
+      ligand_values <- as.character(merged_table$ligand)
+      expanded <- lapply(seq_len(nrow(merged_table)), function(i) {
+        target_idx <- which(
+          !is.na(target_ligands) &
+            !is.na(ligand_values[[i]]) &
+            target_ligands == ligand_values[[i]]
+        )
+        if (length(target_idx) == 0L) {
+          out <- merged_table[i, , drop = FALSE]
+          out$target <- NA_character_
+          out$lt_weight <- NA_real_
+          return(out)
+        }
+        out <- merged_table[rep(i, length(target_idx)), , drop = FALSE]
+        out$target <- target_values[target_idx]
+        out$lt_weight <- target_weights[target_idx]
+        out
+      })
+      merged_table <- do.call(rbind, expanded)
+      rownames(merged_table) <- NULL
+    } else {
+      merged_table$target <- if (nrow(merged_table) > 0L) {
+        NA_character_
+      } else {
+        character(0)
+      }
+      merged_table$lt_weight <- if (nrow(merged_table) > 0L) {
+        NA_real_
+      } else {
+        numeric(0)
+      }
+    }
+
+    condition_value <- if (
+      length(condition_oi) == 1L && !is.null(condition_oi)
+    ) {
+      as.character(condition_oi)
+    } else {
+      NA_character_
+    }
+    reference_value <- if (
+      length(condition_reference) == 1L && !is.null(condition_reference)
+    ) {
+      as.character(condition_reference)
+    } else {
+      NA_character_
+    }
+    contrast_value <- if (
+      !is.na(condition_value) && !is.na(reference_value)
+    ) {
+      paste(condition_value, reference_value, sep = "_vs_")
+    } else {
+      NA_character_
+    }
+    merged_table$condition <- rep(condition_value, nrow(merged_table))
+    merged_table$reference <- rep(reference_value, nrow(merged_table))
+    merged_table$contrast <- rep(contrast_value, nrow(merged_table))
+    if (identical(mode, "aggregate_cluster_de")) {
+      merged_table$receiver_affected <- rep(
+        paste(receiver_affected_use %||% character(0), collapse = ","),
+        nrow(merged_table)
+      )
+      merged_table$receiver_reference <- rep(
+        paste(receiver_reference_use %||% character(0), collapse = ","),
+        nrow(merged_table)
+      )
+    }
+
+    utils::write.csv(
+      merged_table,
+      file = merged_table_file,
+      row.names = FALSE,
+      na = "",
+      fileEncoding = "UTF-8"
+    )
+  }
 
   srt@tools[["Nichenetr"]] <- bundle
   srt <- ccc_update_unified_bundle(

--- a/man/RunNichenetr.Rd
+++ b/man/RunNichenetr.Rd
@@ -30,7 +30,8 @@ RunNichenetr(
   use_sender_agnostic_background = TRUE,
   backend = c("cpp", "r"),
   verbose = TRUE,
-  srt = NULL
+  srt = NULL,
+  merged_table_file = NULL
 )
 }
 \arguments{
@@ -90,6 +91,10 @@ RunNichenetr(
 \item{backend}{Backend used for post-processing aggregation. Upstream
 NicheNet inference is unchanged.}
 
+\item{merged_table_file}{Optional path to a CSV file for exporting a temporary
+ligand-receptor/activity/target merged table. The file is not stored in the
+result bundle. Existing files and missing parent directories are rejected.}
+
 \item{verbose}{Whether to print the message.
 Default is \code{TRUE}.}
 
@@ -99,6 +104,25 @@ will be removed in scop 1.0.0.}
 \value{
 A Seurat object with standardized NicheNet results stored in
 \code{srt@tools[["Nichenetr"]]}.
+}
+\details{
+In the exported table, a ligand's predicted targets are repeated for
+each candidate receptor from the LR table. This is a ligand-level display
+of the existing results; it does not establish receptor-mediated targets or
+sender-specific target effects.
+}
+\examples{
+\dontrun{
+srt <- RunNichenetr(
+  object = srt,
+  group.by = "celltype",
+  receiver = "Receiver",
+  condition.by = "condition",
+  condition_oi = "case",
+  condition_reference = "control",
+  merged_table_file = "NicheNet_merged.csv"
+)
+}
 }
 \description{
 Run NicheNet analysis

--- a/tests/testthat/test-ccc-backend-parity.R
+++ b/tests/testthat/test-ccc-backend-parity.R
@@ -658,6 +658,169 @@ test_that("RunNichenetr aggregate_cluster_de keeps distinct receiver fields", {
   expect_equal(out@tools$Nichenetr$parameters$receiver_reference, "ReceiverB")
 })
 
+test_that("RunNichenetr exports an LR activity target table without changing old tables", {
+  skip_if_not_installed("Seurat")
+  skip_if_not_installed("Matrix")
+
+  counts <- Matrix::sparseMatrix(
+    i = rep(1:5, 6),
+    j = rep(seq_len(6), each = 5),
+    x = seq_len(30),
+    dims = c(5, 6)
+  )
+  rownames(counts) <- c("L1", "R1", "R2", "G1", "G2")
+  colnames(counts) <- paste0("Cell", seq_len(ncol(counts)))
+  srt <- Seurat::CreateSeuratObject(counts = counts)
+  srt$celltype <- rep(c("Sender", "Receiver"), each = 3)
+  srt$condition <- rep(c("case", "control"), times = 3)
+  output_file <- tempfile(fileext = ".csv")
+  unlink(output_file)
+
+  testthat::local_mocked_bindings(
+    check_r = function(...) TRUE,
+    get_namespace_fun = function(package, name) {
+      if (identical(package, "nichenetr") && identical(name, "nichenet_seuratobj_aggregate_cluster_de")) {
+        return(function(...) {
+          list(
+            ligand_activities = data.frame(
+              test_ligand = "L1",
+              aupr_corrected = 0.9,
+              pearson = 0.8,
+              rank = 1
+            ),
+            ligand_receptor_df = data.frame(
+              from = c("L1", "L1"),
+              to = c("R1", "R2"),
+              weight = c(0.4, 0.6)
+            ),
+            ligand_target_df = data.frame(
+              ligand = rep("L1", 3),
+              target = c("G1", "G2", "G3"),
+              weight = c(0.3, 0.2, 0.1)
+            ),
+            geneset_oi = "G1"
+          )
+        })
+      }
+      stop("Unexpected mocked namespace lookup: ", package, "::", name)
+    },
+    load_nichenetr_models = function(...) {
+      list(
+        lr_network = data.frame(from = "L1", to = c("R1", "R2")),
+        ligand_target_matrix = matrix(
+          1,
+          nrow = 1,
+          ncol = 1,
+          dimnames = list("G1", "L1")
+        ),
+        weighted_networks = list()
+      )
+    },
+    .package = "scop"
+  )
+
+  out <- scop::RunNichenetr(
+    object = srt,
+    group.by = "celltype",
+    receiver = "Receiver",
+    sender = "Sender",
+    condition.by = "condition",
+    condition_oi = "case",
+    condition_reference = "control",
+    receiver_affected = "Receiver",
+    receiver_reference = "Receiver",
+    mode = "aggregate_cluster_de",
+    merged_table_file = output_file,
+    backend = "r",
+    verbose = FALSE
+  )
+
+  expect_true(file.exists(output_file))
+  exported <- utils::read.csv(output_file, check.names = FALSE, na.strings = "")
+  expect_equal(nrow(exported), 6L)
+  expect_true(all(c(
+    "ligand", "receptor", "target", "lr_weight", "lt_weight",
+    "aupr_corrected", "rank", "condition", "reference", "contrast",
+    "receiver_affected", "receiver_reference"
+  ) %in% colnames(exported)))
+  expect_equal(unique(exported$aupr_corrected), 0.9)
+  expect_equal(unique(exported$rank), 1)
+  expect_equal(sort(unique(exported$lr_weight)), c(0.4, 0.6))
+  expect_equal(sort(exported$lt_weight), c(0.1, 0.1, 0.2, 0.2, 0.3, 0.3))
+  expect_equal(unique(exported$condition), "case")
+  expect_equal(unique(exported$reference), "control")
+  expect_equal(unique(exported$contrast), "case_vs_control")
+  expect_equal(unique(exported$receiver_affected), "Receiver")
+  expect_equal(unique(exported$receiver_reference), "Receiver")
+  expect_equal(nrow(out@tools$Nichenetr$long_table), 2L)
+  expect_equal(nrow(out@tools$Nichenetr$ligand_target_df), 3L)
+  expect_equal(nrow(out@tools$Nichenetr$pair_table), 1L)
+})
+
+test_that("RunNichenetr validates merged table paths before backend execution", {
+  skip_if_not_installed("Seurat")
+  skip_if_not_installed("Matrix")
+
+  counts <- Matrix::sparseMatrix(
+    i = c(1, 2), j = c(1, 2), x = c(1, 1), dims = c(2, 2)
+  )
+  rownames(counts) <- c("L1", "R1")
+  colnames(counts) <- c("Cell1", "Cell2")
+  srt <- Seurat::CreateSeuratObject(counts = counts)
+  srt$celltype <- c("Sender", "Receiver")
+  srt$condition <- c("case", "control")
+  backend_called <- FALSE
+  existing_file <- tempfile(fileext = ".csv")
+  writeLines("sentinel", existing_file)
+
+  testthat::local_mocked_bindings(
+    check_r = function(...) {
+      backend_called <<- TRUE
+      TRUE
+    },
+    .package = "scop"
+  )
+
+  expect_error(
+    scop::RunNichenetr(
+      object = srt,
+      group.by = "celltype",
+      receiver = "Receiver",
+      sender = "Sender",
+      condition.by = "condition",
+      condition_oi = "case",
+      condition_reference = "control",
+      mode = "aggregate_cluster_de",
+      merged_table_file = existing_file,
+      verbose = FALSE
+    ),
+    "already exists"
+  )
+  expect_false(backend_called)
+  expect_equal(readLines(existing_file), "sentinel")
+
+  missing_parent <- file.path(
+    tempfile("nichenet_missing_parent_"),
+    "merged.csv"
+  )
+  expect_error(
+    scop::RunNichenetr(
+      object = srt,
+      group.by = "celltype",
+      receiver = "Receiver",
+      sender = "Sender",
+      condition.by = "condition",
+      condition_oi = "case",
+      condition_reference = "control",
+      mode = "aggregate_cluster_de",
+      merged_table_file = missing_parent,
+      verbose = FALSE
+    ),
+    "parent directory.*does not exist"
+  )
+  expect_false(backend_called)
+})
+
 test_that("NicheNet standardization preserves official ranks and sender support", {
   standardize <- getFromNamespace("standardize_nichenetr_result", "scop")
   out <- standardize(


### PR DESCRIPTION
## Summary

- add an optional merged_table_file argument to RunNichenetr()
- export a UTF-8 CSV that expands existing LR rows with ligand activity fields and ligand-target rows
- preserve all existing NicheNet result tables and CCC aggregation behavior
- reject existing output files and missing parent directories before backend execution
- document the ligand-level interpretation of repeated target rows

## Validation

- targeted test-ccc-backend-parity.R: 116 passed, 1 existing skip
- pkgload::load_all(".", quiet=TRUE, compile=FALSE): passed
- R CMD check --no-install --no-manual --as-cran --no-examples --no-tests: 0 errors, 0 warnings, 1 existing note
- full CCC test run: new tests passed; unrelated existing failures remain from the local presto lazy-load database, namespace preload state, and an Ensembl network timeout
- full rcmdcheck reached package installation but was blocked by the current worktree C++ build/embedded-NUL log issue
