### PR TITLE
docs: sync the RunMonocle3 use_partition default with its source

### DIFF
--- a/R/RunMonocle.R
+++ b/R/RunMonocle.R
@@ -903,8 +903,7 @@ monocle2_cpp_resolve_root_state <- function(srt, root_state = NULL, group.by = N
 #' @param resolution The resolution parameter for clustering.
 #' Defaults to NULL.
 #' @param use_partition Whether to use partitions to learn disjoint graph in each partition.
-#' If not specified, user will be prompted for input.
-#' Defaults to NULL.
+#' Defaults to NULL, in which case TRUE is used.
 #' @param close_loop Whether to close loops in the graph.
 #' Defaults to TRUE.
 #' @param root_pr_nodes The root nodes to order cells.

--- a/man/RunMonocle3.Rd
+++ b/man/RunMonocle3.Rd
@@ -62,8 +62,7 @@ Defaults to 2.}
 Defaults to NULL.}
 
 \item{use_partition}{Whether to use partitions to learn disjoint graph in each partition.
-If not specified, user will be prompted for input.
-Defaults to NULL.}
+Defaults to NULL, in which case TRUE is used.}
 
 \item{close_loop}{Whether to close loops in the graph.
 Defaults to TRUE.}


### PR DESCRIPTION
`RunMonocle3(use_partition = NULL)` resolves to `TRUE` before calling `monocle3::learn_graph()`, which itself takes `use_partition = TRUE` and never prompts, so the parameter no longer says anything about a prompt. The regenerated `man/RunMonocle3.Rd` is included.

No behaviour change.