### PR TITLE
fix: keep scTenifoldKnk network scores when re-embedding subsamples

### DIFF
--- a/R/scTenifold.R
+++ b/R/scTenifold.R
@@ -541,6 +541,7 @@ sctenifold_make_networks_cpp <- function(
     out <- Matrix::sparseMatrix(
       i = integer(0),
       j = integer(0),
+      x = numeric(0),
       dims = c(n_genes, n_genes),
       dimnames = list(gene_names, gene_names)
     )

--- a/tests/testthat/test-sctenifold-knk.R
+++ b/tests/testthat/test-sctenifold-knk.R
@@ -10,6 +10,37 @@ make_sctenifold_knk_srt <- function(n_genes = 60L, n_cells = 80L, seed = 1L) {
   )
 }
 
+# A gene without counts in any cell is dropped by every subsample, so each
+# network has to be re-embedded into the full gene space.
+make_sctenifold_dropout_counts <- function(
+  n_genes = 40L,
+  n_cells = 60L,
+  seed = 1L
+) {
+  set.seed(seed)
+  counts <- matrix(
+    stats::rnbinom(n_genes * n_cells, mu = 5, size = 2),
+    nrow = n_genes,
+    dimnames = list(paste0("g", seq_len(n_genes)), paste0("c", seq_len(n_cells)))
+  )
+  counts["g2", ] <- 0
+  counts
+}
+
+build_sctenifold_networks <- function(counts, n_cells) {
+  set.seed(11)
+  sctenifold_make_networks_cpp(
+    counts,
+    nNet = 2L,
+    nCells = as.integer(n_cells),
+    nComp = 3L,
+    scaleScores = TRUE,
+    symmetric = FALSE,
+    q = 0.9,
+    nCores = 1L
+  )
+}
+
 run_sctenifold_knk <- function(srt, store_networks) {
   set.seed(11)
   RunscTenifoldKnk(
@@ -96,4 +127,58 @@ test_that("RunscTenifoldKnk store_networks only controls what is stored", {
     stored@tools$scTenifoldKnk$result$manifoldAlignment,
     dropped@tools$scTenifoldKnk$result$manifoldAlignment
   )
+})
+
+test_that("RunscTenifoldKnk re-embeds subsampled networks with their scores", {
+  counts <- make_sctenifold_dropout_counts()
+  # 30 sampled cells exercise the dual solver, 50 the primal one
+  for (n_cells in c(30L, 50L)) {
+    nets <- NULL
+    expect_no_warning(nets <- build_sctenifold_networks(counts, n_cells))
+
+    expect_length(nets, 2L)
+    for (net in nets) {
+      # a pattern (ngCMatrix) result silently drops the regression scores and
+      # collapses the network to unweighted logical entries
+      expect_s4_class(net, "dgCMatrix")
+      expect_identical(dim(net), c(nrow(counts), nrow(counts)))
+      expect_identical(rownames(net), rownames(counts))
+      expect_gt(Matrix::nnzero(net), nrow(counts))
+      expect_gt(length(unique(as.vector(net))), 2L)
+      expect_true(all(net["g2", ] == 0))
+      expect_true(all(net[, "g2"] == 0))
+    }
+  }
+})
+
+test_that("RunscTenifoldKnk cpp ensembles match the upstream construction", {
+  testthat::skip_if_not_installed("scTenifoldNet")
+  counts <- make_sctenifold_dropout_counts()
+  make_networks <- get_namespace_fun("scTenifoldNet", "makeNetworks")
+
+  for (n_cells in c(30L, 50L)) {
+    native <- build_sctenifold_networks(counts, n_cells)
+    set.seed(11)
+    upstream <- suppressMessages(make_networks(
+      X = counts,
+      nNet = 2L,
+      nCells = as.integer(n_cells),
+      nComp = 3L,
+      scaleScores = TRUE,
+      symmetric = FALSE,
+      q = 0.9,
+      nCores = 1L
+    ))
+
+    expect_length(native, length(upstream))
+    for (i in seq_along(native)) {
+      expect_identical(dim(native[[i]]), dim(upstream[[i]]))
+      expect_identical(rownames(native[[i]]), rownames(upstream[[i]]))
+      expect_equal(
+        as.matrix(native[[i]]),
+        as.matrix(upstream[[i]]),
+        tolerance = 1e-8
+      )
+    }
+  }
 })


### PR DESCRIPTION
Fixes #427.

`RunscTenifoldKnk(backend = "cpp")` re-embeds each subsampled network into the full gene space by assigning the coefficients into an empty matrix. That matrix was built with `Matrix::sparseMatrix(i = integer(0), j = integer(0), dims = ...)` and no `x =` argument, which returns a *pattern* (`ngCMatrix`) matrix. Assigning doubles into it coerced them to logical — the `val is coerced to logical for "ngCMatrix" x` warnings — and left the network without weights and with a single surviving entry.

The branch is entered whenever a subsample drops an all-zero gene, so it fires in essentially every network on real data with a detection tail. The tensor decomposition then received logical matrices, which `Rcpp` silently coerced back to 0/1, so the run completed with warnings only and the knocked-out gene lost its edges and its significance.

It became the default in 0.9.1, when the `cpp` backend stopped routing through `scTenifoldNet::makeNetworks()` (#422); before that only `store_networks = FALSE` reached this path.

The empty matrix now carries `x = numeric(0)`, matching the numeric matrix that `scTenifoldNet::makeNetworks()` builds before coercion to `dgCMatrix`. The ensemble then agrees with the upstream construction to floating-point round-off (~1e-14), and manifold alignment and differential regulation were already numerically identical between the two backends.

### Tests

`tests/testthat/test-sctenifold-knk.R` gains a fixture whose gene has no counts in any cell, so every subsample exercises the re-embedding branch:

- one test asserts the networks keep numeric weights (dgCMatrix, non-trivial nnzero and value spread, no warning) on both the dual and the primal solver;
- a second compares the ensemble element-wise against `scTenifoldNet::makeNetworks()` where that package is installed.

Both fail on the pre-fix code (14 and 4 failures) and pass with it. `test-sctenifold-knk.R` and `test-high-memory-sparse-paths.R` pass, run the way CI runs them (`test_local(filter =, load_package = "source")`).

Note the `optional-backends.yaml` matrix has no scTenifoldNet suite, so the parity test skips in CI; the invariant test runs everywhere.

### Real-data validation

`pancreas_sub`, 501 genes including 200 sitting at the detection boundary, `nc_nNet = 3`, `nc_nCells = 150`:

| | before | after | `backend = "r"` |
|---|---|---|---|
| `replCmat4` warnings | 3 | 0 | 0 |
| `Pdx1` rank | 148 | 1 | 1 |
| `Pdx1` p.adj | 0.957 | 0 | 0 |

`panc8_sub`, 3246 features (2821 genes after QC), `nc_nNet = 10`, `nc_nCells = 150`, `cores = 4`:

| | before | after |
|---|---|---|
| `replCmat4` warnings | 10 | 0 |
| `PDX1` rank | 2378 | 1 |
| `PDX1` Z / p.adj | -0.96 / 0.9993 | 19.08 / 0 |
| tensor network nnzero | 4 | 7,351,703 |

Both before-columns reproduce the numbers reported in #427.
